### PR TITLE
Promise fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "grunt-cli": "~0.1.6",
     "grunt-mocha": "^0.4.11",
     "grunt-simple-mocha": "^0.4.0",
+    "promises-aplus-tests": "^2.1.0",
     "sauce-tunnel": "^2.1.0",
     "wd": "^0.3.8"
   }

--- a/polyfills/Promise/polyfill.js
+++ b/polyfills/Promise/polyfill.js
@@ -1,4 +1,6 @@
-(function (global, setImmediate, slice, empty, PENDING, FULFILLED, REJECTED) {
+(function (global, slice, empty, PENDING, FULFILLED, REJECTED) {
+	var setImmediate;
+
 	function resolvePromise(promise, state, value, defer) {
 		if (promise.PromiseState === PENDING) {
 			promise.PromiseState = state;
@@ -199,11 +201,11 @@
 		Promise: Promise
 	});
 
-	setImmediate = setImmediate || function (func) {
+	setImmediate = global.setImmediate || function (func) {
 		var args = slice.call(arguments, 1);
 
 		return setTimeout(function () {
 			func.apply(null, args);
 		});
 	};
-})(this, window.setImmediate, Array.prototype.slice, function () {}, 'pending', 'fulfilled', 'rejected');
+})(typeof global !== 'undefined' ? global : this, Array.prototype.slice, function () {}, 'pending', 'fulfilled', 'rejected');

--- a/polyfills/Promise/polyfill.js
+++ b/polyfills/Promise/polyfill.js
@@ -176,11 +176,13 @@
 
 	function defineValues(object, properties) {
 		for (var key in properties) {
-			Object.defineProperty(object, key, {
-				configurable: true,
-				value: properties[key],
-				writable: true
-			});
+			if (properties.hasOwnProperty(key)) {
+				Object.defineProperty(object, key, {
+					configurable: true,
+					value: properties[key],
+					writable: true
+				});
+			}
 		}
 
 		return object;

--- a/polyfills/Promise/polyfill.js
+++ b/polyfills/Promise/polyfill.js
@@ -145,7 +145,7 @@
 		}
 
 		while (++index < length) {
-			if (index in arraylike) {
+			if (index in iterable) {
 				resolve(array[index]).then(createOnFulfilled());
 			}	
 		}

--- a/polyfills/Promise/polyfill.js
+++ b/polyfills/Promise/polyfill.js
@@ -127,15 +127,16 @@
 		index = -1,
 		length = Math.min(Math.max(Number(array.length) || 0, 0), 9007199254740991);
 
-		function createOnFulfilled() {
-			return function (value) {
-				resolvePromise(promise, FULFILLED, value);
-			};
+		function onFulfilled(value) {
+			resolvePromise(promise, FULFILLED, value);
+		}
+		function onRejected(reason) {
+			resolvePromise(promise, REJECTED, reason);
 		}
 
 		while (++index < length) {
-			if (index in iterable) {
-				resolve(array[index]).then(createOnFulfilled());
+			if (index in array) {
+				resolve(array[index]).then(onFulfilled, onRejected);
 			}	
 		}
 
@@ -200,4 +201,4 @@
 			func.apply(null, args);
 		});
 	};
-})(typeof global !== 'undefined' ? global : this, Array.prototype.slice, function () {}, 'pending', 'fulfilled', 'rejected');
+})(this, Array.prototype.slice, function () {}, 'pending', 'fulfilled', 'rejected');

--- a/polyfills/Promise/polyfill.js
+++ b/polyfills/Promise/polyfill.js
@@ -77,27 +77,16 @@
 			return value;
 		}
 
-		var
-		promise = new Promise(empty);
+		return new Promise(function (res) {
+			res(value);
+		});
+	}
 
-		if (value && value.then instanceof Function) {
-			var
-			promiseFulfill = createResolver(promise, FULFILLED),
-			promiseReject = createResolver(promise, REJECTED);
-
-			setImmediate(function () {
-				try {
-					value.then(promiseFulfill, promiseReject);
-				} catch (error) {
-					resolvePromise(promise, REJECTED, error);
-				}
-			});
-		} else {
-			promise.PromiseState = FULFILLED;
-			promise.PromiseValue = value;
-		}
-
-		return promise;
+	// Promise.reject
+	function reject(reason) {
+		return new Promise(function (resolve, reject) {
+			reject(reason);
+		});
 	}
 
 	// Promise.all
@@ -191,7 +180,8 @@
 	defineValues(Promise, {
 		all: all,
 		race: race,
-		resolve: resolve
+		resolve: resolve,
+		reject: reject
 	});
 
 	defineValues(Promise.prototype, {

--- a/polyfills/Promise/tests.js
+++ b/polyfills/Promise/tests.js
@@ -541,7 +541,7 @@ describe('Promise combinators', function () {
         });
 
         it('should turn into a rejected promise with a non array argument', function (done) {
-            isRejected(Promise.all('foo'), done, function (error) {
+            isRejected(Promise.all(5), done, function (error) {
                 expect(error).to.be.a(TypeError);
                 done();
             });

--- a/polyfills/Promise/tests.js
+++ b/polyfills/Promise/tests.js
@@ -1,3 +1,4 @@
+/*global describe, specify, it, expect, assert*/
 it('has correct instance', function () {
 	expect(Promise).to.be.a(Function);
 });
@@ -6,197 +7,632 @@ it('has correct argument length', function () {
 	expect(Promise.length).to.be(1);
 });
 
-describe('Section 2.1.2.1: When fulfilled, a promise: must not transition to any other state.', function () {
-	var promise, deferred;
+/*
+Copyright 2013 Yahoo! Inc. All rights reserved.
+Licensed under the BSD License.
+http://yuilibrary.com/license/
+*/
+var dummy = {dummy: 'dummy'};
 
-	beforeEach(function () {
-		deferred = {};
+function isFulfilled(promise, done, callback) {
+    promise.then(function (value) {
+        setTimeout(function () {
+            callback(value);
+        }, 0);
+    }, function () {
+        setTimeout(function () {
+            done(new Error('Promise rejected instead of fulfilled'));
+        }, 0);
+    });
+}
 
-		promise = new Promise(function () {
-			deferred.resolve = arguments[0];
-			deferred.reject = arguments[1];
-		});
-	});
+function isRejected(promise, done, callback) {
+    promise.then(function () {
+        setTimeout(function () {
+            done(new Error('Promise fulfilled instead of rejected'));
+        }, 0);
+    }, function (reason) {
+        setTimeout(function () {
+            callback(reason);
+        }, 0);
+    });
+}
 
-	it('trying to fulfill immediately then reject immediately', function (done) {
-		promise.then(function onFulfilled() {
-			deferred.value = true;
-		}, function onRejected() {
-			deferred.value = false;
-		});
+function fulfilledAfter(ms) {
+    return new Promise(function (resolve) {
+        setTimeout(function () {
+            resolve(ms);
+        }, ms);
+    });
+}
 
-		deferred.resolve();
-		deferred.reject();
+function rejectedAfter(ms) {
+    return new Promise(function (resolve, reject) {
+        setTimeout(function () {
+            reject(ms);
+        }, ms);
+    });
+}
 
-		setTimeout(function () {
-			expect(deferred.value).to.be(true);
+function extend(subclass, superclass, proto, attrs) {
+	var prop;
 
-			done();
-		}, 50);
-	});
+    extend.f.prototype = superclass.prototype;
+    subclass.prototype = new extend.f();
+    subclass.prototype.constructor = subclass;
+    subclass.superclass = superclass.prototype;
 
-	it('trying to fulfill immediately then reject delayed', function (done) {
-		promise.then(function onFulfilled() {
-			deferred.value = true;
-		}, function onRejected() {
-			deferred.value = false;
-		});
+    if (proto) {
+        for (prop in proto) {
+            if (proto.hasOwnProperty(prop)) {
+                subclass.prototype[prop] = proto[prop];
+            }
+        }
+    }
 
-		deferred.resolve();
+    if (attrs) {
+        for (prop in attrs) {
+            if (attrs.hasOwnProperty(prop)) {
+                subclass[prop] = attrs[prop];
+            }
+        }
+    }
 
-		setTimeout(function () {
-			deferred.reject();
+    return subclass;
+}
+extend.f = function () {};
 
-			setTimeout(function () {
-				expect(deferred.value).to.be(true);
-
-				done();
-			}, 50);
-		}, 50);
-	});
-
-	it('trying to fulfill delayed then reject delayed', function (done) {
-		promise.then(function () {
-			deferred.value = true;
-		}, function () {
-			deferred.value = false;
-		});
-
-		setTimeout(function () {
-			deferred.resolve();
-
-			setTimeout(function () {
-				deferred.reject();
-
-				setTimeout(function () {
-					expect(deferred.value).to.be(true);
-
-					done();
-				}, 50);
-			});
-		}, 50);
-	});
+describe('global.Promise', function () {
+    it('is correctly defined', function () {
+        assert.equal(typeof global.Promise, 'function');
+        assert.equal(typeof Promise.resolve, 'function', 'Missing Promise.resolve');
+        assert.equal(typeof Promise.reject, 'function', 'Missing Promise.rejected');
+        assert.equal(typeof Promise.all, 'function', 'Missing Promise.all');
+        assert.equal(typeof Promise.race, 'function', 'Missing Promise.race');
+    });
 });
 
-describe('Section 2.1.3.1: When rejected, a promise: must not transition to any other state.', function () {
-	var promise, deferred;
+describe('infinite recursion', function () {
+    it('should not happen!', function (done) {
+        var p = Promise.resolve(42).then(function () {
+            return p;
+        });
 
-	beforeEach(function () {
-		deferred = {};
-
-		promise = new Promise(function () {
-			deferred.resolve = arguments[0];
-			deferred.reject = arguments[1];
-		});
-	});
-
-	it('trying to reject immediately then resolve immediately', function (done) {
-		promise.then(function onFulfilled() {
-			deferred.value = true;
-		}, function onRejected() {
-			deferred.value = false;
-		});
-
-		deferred.reject();
-		deferred.resolve();
-
-		setTimeout(function () {
-			expect(deferred.value).to.be(false);
-
-			done();
-		}, 50);
-	});
-
-	it('trying to reject immediately then resolve delayed', function (done) {
-		promise.then(function onFulfilled() {
-			deferred.value = true;
-		}, function onRejected() {
-			deferred.value = false;
-		});
-
-		deferred.reject();
-
-		setTimeout(function () {
-			deferred.resolve();
-
-			setTimeout(function () {
-				expect(deferred.value).to.be(false);
-
-				done();
-			}, 50);
-		}, 50);
-	});
-
-	it('trying to reject delayed then resolve delayed', function (done) {
-		promise.then(function () {
-			deferred.value = true;
-		}, function () {
-			deferred.value = false;
-		});
-
-		setTimeout(function () {
-			deferred.reject();
-
-			setTimeout(function () {
-				deferred.resolve();
-
-				setTimeout(function () {
-					expect(deferred.value).to.be(false);
-
-					done();
-				}, 50);
-			});
-		}, 50);
-	});
+        p.then(function (v) {
+            done(new Error('promise should have been rejected: ' + (v instanceof Promise)));
+        }, function () {
+            done();
+        });
+    });
 });
 
-describe('2.2.1: Both `onFulfilled` and `onRejected` are optional arguments.', function () {
-	var promise;
+describe('Basic promise behavior', function () {
+    describe('Promise constructor', function () {
+        it('should return a promise when used as a function', function () {
+            expect(Promise(function () {})).to.be.a(Promise);
+        });
 
-	describe('2.2.1.1: If `onFulfilled` is not a function, it must be ignored.', function () {
-		describe('applied to a directly-rejected promise', function () {
-			function testNonFunction(nonFunction, stringRepresentation) {
-				specify('`onFulfilled` is ' + stringRepresentation, function (done) {
-					promise.then(nonFunction, function () {
-						done();
-					});
-				});
-			}
+        specify('fulfilling more than once should not change the promise value', function (done) {
+            var promise = new Promise(function (resolve) {
+                resolve(true);
+                resolve(5);
+            });
 
-			var resolve, reject;
+            isFulfilled(promise, done, function (value) {
+                expect(value).to.be(true);
+                done();
+            });
+        });
 
-			promise = new Promise(function (oresolve, oreject) {
-				resolve = oresolve;
-				reject = oreject;
-			});
+        specify('rejecting more than once should not change the rejection reason', function (done) {
+            var promise = new Promise(function (resolve, reject) {
+                reject(new Error('foo'));
+                reject(new Error('bar'));
+            });
 
-			reject();
+            isRejected(promise, done, function (reason) {
+                expect(reason.message).to.be('foo');
+                done();
+            });
+        });
 
-			testNonFunction(undefined, '`undefined`');
-			testNonFunction(null, '`null`');
-			testNonFunction(false, '`false`');
-			testNonFunction(5, '`5`');
-			testNonFunction({}, 'an object');
-		});
+        specify('correct value for `this` inside the promise init function', function () {
+            var promise = new Promise(function () {
+                expect(this).to.be(undefined);
+            });
+        });
+    });
 
-		describe('applied to a promise rejected and then chained off of', function () {
-			function testNonFunction(nonFunction, stringRepresentation) {
-				specify('`onFulfilled` is ' + stringRepresentation, function (done) {
-					promise.then(function () {}, undefined).then(nonFunction, function () {
-						done();
-					});
-				});
-			}
+    describe('promise.then()', function () {
+        it('returns a promise', function () {
+            var promise = new Promise(function (resolve) {
+                resolve(5)
+            });
+            expect(promise).to.be.a(Promise);
+        });
 
-			promise = new Promise(function (resolve, reject) {
-				reject();
-			});
+        it('calls its callbacks asynchronously', function () {
+            var foo = false;
+            var promise = new Promise(function (resolve) {
+                resolve();
+            }).then(function () {
+                foo = true;
+            });
+            expect(foo).to.be(false);
+        });
 
-			testNonFunction(undefined, '`undefined`');
-			testNonFunction(null, '`null`');
-			testNonFunction(false, '`false`');
-			testNonFunction(5, '`5`');
-			testNonFunction({}, 'an object');
-		});
-	});
+        /*it('returns a subclass of Promise when subclassing', function () {
+            function PromiseSubclass() {
+                PromiseSubclass.superclass.constructor.apply(this, arguments);
+            }
+            extend(PromiseSubclass, Promise);
+            PromiseSubclass._defer = Promise._defer;
+
+            var promise = new PromiseSubclass(function () {}).then();
+
+            expect(promise).to.be.a(Promise);
+            expect(promise).to.be.a(PromiseSubclass);
+        });*/
+    });
+
+    describe('Behavior of the then() callbacks', function () {
+        var global = Function('return this')();
+
+        specify('throwing inside a callback should turn into a rejection', function (done) {
+            var error = new Error('Arbitrary error');
+
+            var promise = new Promise(function (resolve) {
+                resolve(5);
+            }).then(function (value) {
+                throw error;
+            });
+
+            isRejected(promise, done, function (reason) {
+                expect(reason).to.be(error);
+                done();
+            });
+        });
+
+        specify('returning a promise from a callback should link both promises', function (done) {
+            var promise = new Promise(function (resolve) {
+                resolve('placeholder');
+            }).then(function () {
+                return new Promise(function (resolve) {
+                    resolve(5);
+                });
+            });
+
+            isFulfilled(promise, done, function (value) {
+                expect(value).to.be(5);
+                done();
+            });
+        });
+
+        specify('`this` inside a callback must be the global object in sloppy mode', function (done) {
+            // this test is run only in sloppy mode
+            if ((function () { return this; }()) === undefined) {
+                return done();
+            }
+
+            var resolvedThis, rejectedThis,
+                fulfilled = new Promise(function (resolve) {
+                    resolve('value');
+                }),
+                rejected = new Promise(function (resolve, reject) {
+                    reject('reason');
+                });
+
+            fulfilled.then(function () {
+                resolvedThis = this;
+                rejected.then(null, function () {
+                    rejectedThis = this;
+                    setTimeout(function () {
+                        expect(resolvedThis).to.be(global);
+                        expect(rejectedThis).to.be(global);
+                        done();
+                    });
+                });
+            });
+        });
+
+        specify('`this` inside a callback must be undefined in strict mode', function (done) {
+            // This test is run only in strict mode
+            'use strict';
+
+            if ((function () { return this; }()) !== undefined) {
+                return done();
+            }
+
+            var resolvedThis, rejectedThis,
+                fulfilled = new Promise(function (resolve) {
+                    resolve('value');
+                }),
+                rejected = new Promise(function (resolve, reject) {
+                    reject('reason');
+                });
+
+            fulfilled.then(function () {
+                resolvedThis = this;
+                rejected.then(null, function () {
+                    rejectedThis = this;
+                    setTimeout(function () {
+                        expect(resolvedThis).to.be(undefined);
+                        expect(rejectedThis).to.be(undefined);
+                        done();
+                    }, 0);
+                });
+            });
+        });
+
+        specify('resolution of a thenable for a thenable that fulfills twice', function (done) {
+            var dummy = { dummy: "dummy" };
+            var value = {foo: 'bar'},
+                other = {};
+
+            var promise = Promise.resolve(dummy).then(function () {
+                return {
+                    then: function (resolvePromise) {
+                        resolvePromise({
+                            then: function (onFulfilled) {
+                                onFulfilled({
+                                    then: function (onFulfilled) {
+                                        setTimeout(function () {
+                                            onFulfilled(value);
+                                        }, 0);
+                                    }
+                                });
+                                onFulfilled(other);
+                            }
+                        });
+                    }
+                };
+            });
+
+            isFulfilled(promise, done, function (result) {
+                expect(result).to.equal(value);
+                done();
+            });
+        });
+
+        specify('resolution of a thenable for a thenable that fulfills and then throws', function (done) {
+            var value = {foo: 'bar'};
+
+            var promise = Promise.resolve(dummy).then(function () {
+                return {
+                    then: function (resolvePromise) {
+                        resolvePromise({
+                            then: function (onFulfilled) {
+                                onFulfilled({
+                                    then: function (onFulfilled) {
+                                        setTimeout(function () {
+                                            onFulfilled(value);
+                                        }, 0);
+                                    }
+                                });
+                                throw new Error('foo');
+                            }
+                        });
+                    }
+                };
+            });
+
+            isFulfilled(promise, done, function (result) {
+                expect(result).to.equal(value);
+                done();
+            });
+        });
+
+        specify('resolution of a thenable that both fulfills and rejects', function (done) {
+            var value = {foo:'bar'};
+
+            var p1 = new Promise(function (resolve) {
+                setTimeout(function () {
+                    resolve(value);
+                }, 0);
+            });
+
+            var p2 = Promise.resolve(dummy).then(function () {
+                return {
+                    then: function (onFulfilled, onRejected) {
+                        onFulfilled(p1);
+                        onRejected(new Error('foo'));
+                    }
+                };
+            });
+
+            isFulfilled(p2, done, function (result) {
+                expect(result).to.equal(value);
+                done();
+            });
+        });
+    });
+
+    describe('promise.catch()', function () {
+        it('is a method of Promise', function () {
+            var promise = new Promise(function () {});
+            expect(promise['catch']).to.be.a('function');
+        });
+
+        it('does nothing to resolved promises', function (done) {
+            var value = {foo:'bar'},
+                resolved = new Promise(function (resolve) {
+                    resolve(value);
+                }),
+                next;
+
+            next = resolved['catch'](function (err) {
+                return err;
+            });
+
+            expect(next).to.be.an('object');
+            expect(next).to.be.a(Promise);
+
+            isFulfilled(next, done, function (val) {
+                expect(val).to.equal(value);
+                done();
+            });
+        });
+
+        it('is equivalent to then(undefined, fn)', function (done) {
+            var reason = new Error('some error'),
+                rejected = new Promise(function (resolve, reject) {
+                    reject(reason);
+                }),
+                next;
+
+            next = rejected['catch'](function (err) {
+                return err;
+            });
+
+            isFulfilled(next, done, function (value) {
+                expect(value).to.equal(reason);
+                done();
+            });
+        });
+    });
+});
+
+describe('Promise factory functions tests', function () {
+    describe('Promise.resolve', function () {
+        it('is a static method', function () {
+            expect(Promise.resolve).to.be.a('function');
+        });
+
+        it('is fulfilled when passed a regular value', function (done) {
+            var value = {},
+                promise = Promise.resolve(value);
+
+            isFulfilled(promise, done, function (result) {
+                expect(result).to.equal(value);
+                done();
+            });
+        });
+
+        it('adopts the state of a rejected promise', function (done) {
+            var value = {},
+                fulfilled = Promise.reject(value),
+                promise = Promise.resolve(fulfilled);
+
+            isRejected(promise, done, function (result) {
+                expect(result).to.equal(value);
+                done();
+            });
+        });
+
+        /*it('should preserve the constructor when using inheritance', function (done) {
+            function Subpromise() {
+                Subpromise.superclass.constructor.apply(this, arguments);
+            }
+            extend(Subpromise, Promise, null, {
+                _defer: Promise._defer,
+                resolve: Promise.resolve
+            });
+
+            var promise = Subpromise.resolve('foo');
+
+            expect(promise).to.be.a(Subpromise);
+
+            isFulfilled(promise, done, function (value) {
+                expect(value).to.equal('foo');
+                done();
+            });
+        });*/
+
+        it('should not modify promises', function () {
+            var promise = Promise.resolve(),
+                wrapped = Promise.resolve(promise);
+
+            expect(promise).to.be.a(Promise);
+            expect(promise).to.be(wrapped);
+        });
+
+        it('should wrap regular values in a promise', function () {
+            // truthy values
+            expect(Promise.resolve(5)).to.be.a(Promise);
+            expect(Promise.resolve('foo')).to.be.a(Promise);
+            expect(Promise.resolve(true)).to.be.a(Promise);
+            expect(Promise.resolve(function () {})).to.be.a(Promise);
+            expect(Promise.resolve({})).to.be.a(Promise);
+
+            // falsy values
+            expect(Promise.resolve(0)).to.be.a(Promise);
+            expect(Promise.resolve('')).to.be.a(Promise);
+            expect(Promise.resolve(false)).to.be.a(Promise);
+            expect(Promise.resolve(null)).to.be.a(Promise);
+            expect(Promise.resolve(undefined)).to.be.a(Promise);
+            expect(Promise.resolve()).to.be.a(Promise);
+
+            // almost promises
+            expect(Promise.resolve({then: 5})).to.be.a(Promise);
+        });
+    });
+
+    describe('Promise.reject', function () {
+        it('is a static method', function () {
+            expect(Promise.reject).to.be.a('function');
+        });
+
+        it('returns a rejected promise', function (done) {
+            var value = new Error('foo'),
+                promise = Promise.reject(value);
+
+            expect(promise).to.be.a(Promise);
+
+            isRejected(promise, done, function (result) {
+                expect(result).to.equal(value);
+                done();
+            });
+        });
+
+        it('should wrap fulfilled promises', function (done) {
+            var value = new Promise(function (resolve) {
+                    resolve('foo');
+                }),
+                promise = Promise.reject(value);
+
+            isRejected(promise, done, function (result) {
+                expect(result).to.equal(value);
+                done();
+            });
+        });
+
+        it('should wrap rejected promises', function (done) {
+            var value = new Promise(function (resolve, reject) {
+                    reject('foo');
+                }),
+                promise = Promise.reject(value);
+
+            isRejected(promise, done, function (result) {
+                expect(result).to.equal(value);
+                done();
+            });
+        });
+
+        /*it('should preserve the constructor when using inheritance', function (done) {
+            function Subpromise() {
+                Subpromise.superclass.constructor.apply(this, arguments);
+            }
+            extend(Subpromise, Promise, null, {
+                _defer: Promise._defer,
+                reject: Promise.reject
+            });
+
+            var promise = Subpromise.reject('foo');
+
+            expect(promise).to.be.a(Subpromise);
+
+            isRejected(promise, done, function (reason) {
+                expect(reason).to.equal('foo');
+                done();
+            });
+        });*/
+    });
+});
+
+describe('Promise combinators', function () {
+    describe('Promise.all', function () {
+        it('should return a promise', function () {
+            var somePromise = new Promise(function () {});
+
+            expect(Promise.all([5])).to.be.a(Promise);
+            expect(Promise.all([new Promise(function () {})])).to.be.a(Promise);
+            expect(Promise.all([])).to.be.a(Promise);
+            expect(Promise.all([somePromise])).not.to.equal(somePromise);
+        });
+
+        it('should turn into a rejected promise with a non array argument', function (done) {
+            isRejected(Promise.all('foo'), done, function (error) {
+                expect(error).to.be.a(TypeError);
+                done();
+            });
+        });
+
+        it('should preserve the order of promises', function (done) {
+            var promise = Promise.all([fulfilledAfter(20), fulfilledAfter(10), fulfilledAfter(15)]);
+
+            isFulfilled(promise, done, function (result) {
+                expect(result).to.eql([20, 10, 15]);
+                done();
+            });
+        });
+
+        it('should wrap values in a promise', function (done) {
+            var obj = {
+                    hello: 'world'
+                },
+                promise = Promise.all(['foo', 5, obj]);
+
+            isFulfilled(promise, done, function (result) {
+                expect(result).to.eql(['foo', 5, obj]);
+                done();
+            });
+        });
+
+        it('correctly handles functions in arguments', function (done) {
+            function testFn() {}
+
+            isFulfilled(Promise.all([testFn]), done, function (values) {
+                expect(values[0]).to.be.a('function');
+                expect(values[0]).to.equal(testFn);
+                done();
+            });
+        });
+
+        it('should fail as fast as possible', function (done) {
+            var promise = Promise.all([rejectedAfter(20), rejectedAfter(10), rejectedAfter(15)]);
+
+            isRejected(promise, done, function (reason) {
+                expect(reason).to.equal(10);
+                done();
+            });
+        });
+    });
+
+    describe('Promise.race', function () {
+        it('should turn into a rejected promise with a non array argument', function (done) {
+            isRejected(Promise.race('foo'), done, function (error) {
+                expect(error).to.be.a(TypeError);
+                done();
+            });
+        });
+
+        it('should fulfill when passed a fulfilled promise', function (done) {
+            isFulfilled(Promise.race([fulfilledAfter(1)]), done, function (result) {
+                expect(result).to.equal(1);
+                done();
+            });
+        });
+
+        it('should fulfill when passed a fulfilled promise', function (done) {
+            isFulfilled(Promise.race([fulfilledAfter(1)]), done, function (result) {
+                expect(result).to.equal(1);
+                done();
+            });
+        });
+
+        it('should reject when passed a rejected promise', function (done) {
+            isRejected(Promise.race([rejectedAfter(1)]), done, function (result) {
+                expect(result).to.equal(1);
+                done();
+            });
+        });
+
+        it('should fulfill to the value of the first promise to be fulfilled', function (done) {
+            var promise = Promise.race([fulfilledAfter(10), fulfilledAfter(100)]);
+
+            isFulfilled(promise, done, function (result) {
+                expect(result).to.equal(10);
+                done();
+            });
+        });
+
+        it('should reject with the reason of the first promise to be rejected', function (done) {
+            var promise = Promise.race([rejectedAfter(10), rejectedAfter(100)]);
+
+            isRejected(promise, done, function (result) {
+                expect(result).to.equal(10);
+                done();
+            });
+        });
+    });
 });

--- a/test/node/polyfills/promise.js
+++ b/test/node/polyfills/promise.js
@@ -7,32 +7,6 @@ eval(
     '}).call(global);'
 );
 
-describe('global.Promise', function () {
-    it('is correctly defined', function () {
-        assert.equal(typeof global.Promise, 'function');
-        assert.equal(typeof Promise.resolve, 'function', 'Missing Promise.resolve');
-        //assert.equal(typeof Promise.reject, 'function', 'Missing Promise.rejected');
-        assert.equal(typeof Promise.all, 'function', 'Missing Promise.all');
-        assert.equal(typeof Promise.race, 'function', 'Missing Promise.race');
-    });
-});
-
-describe('infinite recursion', function () {
-    it('should not happen!', function (done) {
-        var p = Promise.resolve(42);
-
-        var p2 = p.then(function () {
-            return p;
-        });
-
-        p2.then(function (v) {
-            done(new Error('promise should have been rejected: ' + (v instanceof Promise)));
-        }, function () {
-            done();
-        });
-    });
-});
-
 describe('Promises A+ Tests', function () {
     var adapter = {
         resolved: function (value) {

--- a/test/node/polyfills/promise.js
+++ b/test/node/polyfills/promise.js
@@ -1,0 +1,61 @@
+var fs     = require('fs');
+var assert = require('assert');
+
+eval(
+    '(function () {\n' +
+    fs.readFileSync('./polyfills/Promise/polyfill.js', 'utf8') +
+    '}).call(global);'
+);
+
+describe('global.Promise', function () {
+    it('is correctly defined', function () {
+        assert.equal(typeof global.Promise, 'function');
+        assert.equal(typeof Promise.resolve, 'function', 'Missing Promise.resolve');
+        //assert.equal(typeof Promise.reject, 'function', 'Missing Promise.rejected');
+        assert.equal(typeof Promise.all, 'function', 'Missing Promise.all');
+        assert.equal(typeof Promise.race, 'function', 'Missing Promise.race');
+    });
+});
+
+describe('infinite recursion', function () {
+    it('should not happen!', function (done) {
+        var p = Promise.resolve(42);
+
+        var p2 = p.then(function () {
+            return p;
+        });
+
+        p2.then(function (v) {
+            done(new Error('promise should have been rejected: ' + (v instanceof Promise)));
+        }, function () {
+            done();
+        });
+    });
+});
+
+describe('Promises A+ Tests', function () {
+    var adapter = {
+        resolved: function (value) {
+            return new Promise(function (resolve) {
+                resolve(value);
+            });
+        },
+        rejected: function (reason) {
+            return new Promise(function (resolve, reject) {
+                reject(reason);
+            });
+        },
+        deferred: function () {
+            var deferred = {};
+
+            deferred.promise = new Promise(function (resolve, reject) {
+                deferred.resolve = resolve;
+                deferred.reject = reject;
+            });
+
+            return deferred;
+        }
+    };
+
+    require('promises-aplus-tests').mocha(adapter);
+});


### PR DESCRIPTION
There are still a few issues with the current Promise implementation:
1. It's lacking `Promise.reject`
2. It's not passing two A+ tests:

Resolving a promise with another one is not working correctly:

``` js
var p1 = new Promise(function (resolve, reject) {
  reject(new Error('hello'));
});
var p2 = new Promise(function (resolve) {
  resolve(p1);
});
// p2 should be rejected with an error
```

An infinite loop is caused when resolving a promise with itself:

``` js
var p = Promise.resolve(42).then(function () {
  return p;
});
// p should be rejected
```

I'm trying to fix the resolution of promises, but I'm having a hard time understanding the "promiseChain" logic. @jonathantneal can you explain a bit how it works?

PS: this is obviously failing and should not be merged yet.
