### PR TITLE
Support ES6 polyfill sources with 6to5, closes #179

### DIFF
--- a/lib/sources.js
+++ b/lib/sources.js
@@ -37,7 +37,7 @@ fs.readdirSync(polyfillSourceFolder).forEach(function (featureName) {
 				browsers: config.browsers,
 				dependencies: config.dependencies || [],
 				licence: config.licence || "",
-				ESVersion: config.ESVersion || undefined
+				esversion: config.esversion || undefined
 			}
 			delete config.browsers;
 			delete config.dependencies;
@@ -70,15 +70,15 @@ fs.readdirSync(polyfillSourceFolder).forEach(function (featureName) {
 					v.rawSource = fs.readFileSync(polyfillSourcePath, 'utf8');
 				}
 
-				// At time of writing no current browsers support the full ES6 language syntax, so for simplicity, polyfills written in ES6 will be transpiled to ES5 in all cases (also note that uglify currently cannot minify ES6 syntax).  When browsers start shipping with complete ES6 support, the ES6 source versions should be served where appropriate, which will require another set of variations on the source properties of the polyfill.  At this point it might be better to create a collection of sources with different properties, eg v.sources = [{code:'...', esVersion:6, minified:true, gated:true},{...}] etc.
-				if (v.ESVersion && v.ESVersion > 5) {
-					if (v.ESVersion === 6) {
+				// At time of writing no current browsers support the full ES6 language syntax, so for simplicity, polyfills written in ES6 will be transpiled to ES5 in all cases (also note that uglify currently cannot minify ES6 syntax).  When browsers start shipping with complete ES6 support, the ES6 source versions should be served where appropriate, which will require another set of variations on the source properties of the polyfill.  At this point it might be better to create a collection of sources with different properties, eg v.sources = [{code:'...', esversion:6, minified:true, gated:true},{...}] etc.
+				if (v.esversion && v.esversion > 5) {
+					if (v.esversion === 6) {
 
 						// Don't add a "use strict"
 						var result = to5.transform(v.rawSource, { blacklist: ["useStrict"] });
 						v.rawSource = result.code;
 					} else {
-						throw {name:"Unsupported ES version", message:"Feature "+featureName+' ('+polyfillVariant+') uses ES'+v.ESVersion+' but no transpiler is available for that version'};
+						throw {name:"Unsupported ES version", message:"Feature "+featureName+' ('+polyfillVariant+') uses ES'+v.esversion+' but no transpiler is available for that version'};
 					}
 				}
 

--- a/lib/sources.js
+++ b/lib/sources.js
@@ -1,99 +1,151 @@
 var fs            = require('fs'),
 	path          = require('path'),
-	uglify        = require('uglify-js');
+	uglify        = require('uglify-js'),
+	to5           = require("6to5");
 
 var polyfillSourceFolder = path.join(__dirname, '../polyfills');
 var configuredAliases = {};
 var sources = {};
+var errors = [];
 
 "use strict";
 
+console.log('Loading sources...');
 
 fs.readdirSync(polyfillSourceFolder).forEach(function (featureName) {
+	try {
 
-	// Load the polyfill's configuration
-	var polyfillPath = path.join(polyfillSourceFolder, featureName);
-	var configPath = path.join(polyfillPath, 'config.json');
-	if (!fs.existsSync(polyfillPath) || !fs.existsSync(configPath)) {
-		return;
-	}
-	var config = require(configPath);
-
-	config.hasTests = fs.existsSync(path.join(polyfillPath, 'tests.js'));
-
-	// Move any default variant (outside of 'variants' object, into the variant object against the 'default' key)
-	// Allows for simple configuration in cases where there is only one variant
-	config.variants = config.variants || {};
-	if (config.browsers) {
-		config.variants['default'] = {
-			browsers: config.browsers,
-			dependencies: config.dependencies || [],
-			licence: config.licence || ""
-		}
-		delete config.browsers;
-		delete config.dependencies;
-		delete config.licence;
-	}
-
-	// Read each variant's source into memory, and minify
-	Object.keys(config.variants).forEach(function(polyfillVariant) {
-		var detectPath = path.join(polyfillPath, 'detect.js');
-		var v = config.variants[polyfillVariant];
-		var polyfillFile = 'polyfill.js';
-
-		if (polyfillVariant !== 'default') {
-			polyfillFile = 'polyfill-' + polyfillVariant + '.js';
-		}
-
-		var polyfillSourcePath = path.join(polyfillPath, polyfillFile);
-
-		if (!fs.existsSync(polyfillSourcePath)) {
-			console.log("Invalid config for: " + featureName);
+		// Load the polyfill's configuration
+		var polyfillPath = path.join(polyfillSourceFolder, featureName);
+		var configPath = path.join(polyfillPath, 'config.json');
+		if (!fs.existsSync(polyfillPath) || !fs.existsSync(configPath)) {
 			return;
 		}
+		try {
+			var config = require(configPath);
+		} catch (e) {
+			throw {name:"Missing or invalid config", message:"Unable to read config from "+configPath};
+		}
 
-		v.rawSource = fs.readFileSync(polyfillSourcePath, 'utf8');
-		v.minSource = uglify.minify(v.rawSource, {fromString: true}).code;
+		config.hasTests = fs.existsSync(path.join(polyfillPath, 'tests.js'));
 
-		if (fs.existsSync(detectPath)) {
-			v.detectSource = fs.readFileSync(detectPath, 'utf8').replace(/\s*$/, '') || null;
-			v.rawGatedSource = "if (!(" + v.detectSource + ")) {\n" + v.rawSource + "}\n";
-
-			// Verify the generated feature gate is valid javascript
-			try {
-				new Function(v.rawSourceGated);
-			} catch(e) {
-				console.error("Error generating feature gate for polyfill: " + featureName+'-'+polyfillVariant);
-				console.error("Invalid Syntax in feature gate: '" + e.message + "'");
-				console.error("The detect.js file must be a valid expression that can be inserted as the condition of an if statement");
-				process.exit(1);
+		// Move any default variant (outside of 'variants' object, into the variant object against the 'default' key)
+		// Allows for simple configuration in cases where there is only one variant
+		config.variants = config.variants || {};
+		if (config.browsers) {
+			config.variants['default'] = {
+				browsers: config.browsers,
+				dependencies: config.dependencies || [],
+				licence: config.licence || "",
+				ESVersion: config.ESVersion || undefined
 			}
-
-			v.minGatedSource = uglify.minify(v.rawGatedSource, {fromString: true}).code;
-		} else {
-			v.detectSource = '';
-			v.rawGatedSource = v.rawSource;
-			v.minGatedSource = v.minSource;
+			delete config.browsers;
+			delete config.dependencies;
+			delete config.licence;
 		}
-		v.rawSource = '\n// '+featureName + '\n' + v.rawSource;
-		v.rawGatedSource = '\n// '+featureName + '\n' + v.rawGatedSource;
-	});
 
-	sources[featureName] = config;
-
-	// Store alias names in a map for efficient lookup, mapping aliases to
-	// featureNames.  An alias can map to many polyfill names. So a group
-	// of polyfills can be aliased under the same name.  This is why an
-	// array is created and used for the value in the map.
-	config.aliases = config.aliases || [];
-	config.aliases.forEach(function(aliasName) {
-		if (configuredAliases[aliasName]) {
-			configuredAliases[aliasName].push(featureName);
-		} else {
-			configuredAliases[aliasName] = [ featureName ];
+		// If there is still no default variant, create one
+		if (!('default' in config.variants)) {
+			config.variants.default = {
+				browsers: {},
+				dependencies: [],
+				licence: "",
+				rawSource: "/* This polyfill has no generic form, and no browser specific variant applies to the current user agent. */"
+			}
 		}
-	});
+
+		// Read each variant's source into memory, and minify
+		Object.keys(config.variants).forEach(function(polyfillVariant) {
+			try {
+				var detectPath = path.join(polyfillPath, 'detect.js');
+				var v = config.variants[polyfillVariant];
+
+				if (!v.rawSource) {
+					var polyfillFile = 'polyfill' + ((polyfillVariant !== 'default') ? '-'+polyfillVariant : '') + '.js';
+					var polyfillSourcePath = path.join(polyfillPath, polyfillFile);
+
+					if (!fs.existsSync(polyfillSourcePath)) {
+						throw {name:"Missing polyfill source file", message:"Path "+polyfillSourcePath+" not found"};
+					}
+					v.rawSource = fs.readFileSync(polyfillSourcePath, 'utf8');
+				}
+
+				// At time of writing no current browsers support the full ES6 language syntax, so for simplicity, polyfills written in ES6 will be transpiled to ES5 in all cases (also note that uglify currently cannot minify ES6 syntax).  When browsers start shipping with complete ES6 support, the ES6 source versions should be served where appropriate, which will require another set of variations on the source properties of the polyfill.  At this point it might be better to create a collection of sources with different properties, eg v.sources = [{code:'...', esVersion:6, minified:true, gated:true},{...}] etc.
+				if (v.ESVersion && v.ESVersion > 5) {
+					if (v.ESVersion === 6) {
+
+						// Don't add a "use strict"
+						var result = to5.transform(v.rawSource, { blacklist: ["useStrict"] });
+						v.rawSource = result.code;
+					} else {
+						throw {name:"Unsupported ES version", message:"Feature "+featureName+' ('+polyfillVariant+') uses ES'+v.ESVersion+' but no transpiler is available for that version'};
+					}
+				}
+
+				validateSource(v.rawSource, featureName+' from '+polyfillSourcePath);
+
+				v.minSource = uglify.minify(v.rawSource, {fromString: true}).code;
+
+				if (fs.existsSync(detectPath)) {
+					v.detectSource = fs.readFileSync(detectPath, 'utf8').replace(/\s*$/, '') || null;
+					validateSource("if ("+v.detectSource+") true;", featureName+' feature detect from '+detectPath);
+
+					v.rawGatedSource = "if (!(" + v.detectSource + ")) {\n" + v.rawSource + "}\n";
+					v.minGatedSource = uglify.minify(v.rawGatedSource, {fromString: true}).code;
+				} else {
+					v.detectSource = '';
+					v.rawGatedSource = v.rawSource;
+					v.minGatedSource = v.minSource;
+				}
+
+				// Add start-of-module marker comments to unminifed variants
+				v.rawSource = '\n// '+featureName + '\n' + v.rawSource;
+				v.rawGatedSource = '\n// '+featureName + '\n' + v.rawGatedSource;
+			} catch (ex) {
+				errors.push(ex);
+			}
+		});
+
+		sources[featureName] = config;
+
+		// Store alias names in a map for efficient lookup, mapping aliases to
+		// featureNames.  An alias can map to many polyfill names. So a group
+		// of polyfills can be aliased under the same name.  This is why an
+		// array is created and used for the value in the map.
+		config.aliases = config.aliases || [];
+		config.aliases.forEach(function(aliasName) {
+			if (configuredAliases[aliasName]) {
+				configuredAliases[aliasName].push(featureName);
+			} else {
+				configuredAliases[aliasName] = [ featureName ];
+			}
+		});
+	} catch (ex) {
+		errors.push(ex);
+	}
 });
+
+if (errors.length) {
+	console.error('Errors encountered processing polyfill sources:');
+	errors.forEach(function(e) {
+		console.error('  - '+e.name);
+		console.error('    '+e.message);
+		if (e.error) console.error('    '+e.error.toString());
+		console.log('');
+	});
+	process.exit(1);
+} else {
+	console.log('Sources loaded successfully');
+}
+
+
+function validateSource(code, label) {
+	try {
+		new Function(code);
+	} catch(e) {
+		throw {name:"Parse error", message:"Error parsing source code for "+label, error:e};
+	}
+}
 
 exports.polyfillExists = function(featureName) {
 	return (featureName in sources);

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,253 @@
 {
   "name": "polyfill-service",
+  "version": "1.0.2",
   "dependencies": {
+    "6to5": {
+      "version": "1.15.0",
+      "from": "6to5@>=1.15.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/6to5/-/6to5-1.15.0.tgz",
+      "dependencies": {
+        "acorn-6to5": {
+          "version": "0.9.1-12",
+          "from": "acorn-6to5@0.9.1-12",
+          "resolved": "https://registry.npmjs.org/acorn-6to5/-/acorn-6to5-0.9.1-12.tgz"
+        },
+        "ast-types": {
+          "version": "0.6.5",
+          "from": "ast-types@0.6.5",
+          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.6.5.tgz"
+        },
+        "chokidar": {
+          "version": "0.11.1",
+          "from": "chokidar@0.11.1",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-0.11.1.tgz",
+          "dependencies": {
+            "readdirp": {
+              "version": "1.1.0",
+              "from": "readdirp@>=1.1.0 <1.2.0",
+              "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-1.1.0.tgz",
+              "dependencies": {
+                "graceful-fs": {
+                  "version": "2.0.3",
+                  "from": "graceful-fs@>=2.0.0 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+                },
+                "minimatch": {
+                  "version": "0.2.14",
+                  "from": "minimatch@>=0.2.12 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.5.0",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.0",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                    }
+                  }
+                },
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@>=1.0.26-2 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0"
+                    }
+                  }
+                }
+              }
+            },
+            "async-each": {
+              "version": "0.1.6",
+              "from": "async-each@>=0.1.5 <0.2.0",
+              "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
+            },
+            "fsevents": {
+              "version": "0.3.1",
+              "from": "fsevents@>=0.3.1 <0.4.0",
+              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.1.tgz",
+              "dependencies": {
+                "nan": {
+                  "version": "1.3.0",
+                  "from": "nan@>=1.3.0 <1.4.0"
+                }
+              }
+            }
+          }
+        },
+        "commander": {
+          "version": "2.5.0",
+          "from": "commander@2.5.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.5.0.tgz"
+        },
+        "es6-shim": {
+          "version": "0.21.0",
+          "from": "es6-shim@0.21.0",
+          "resolved": "https://registry.npmjs.org/es6-shim/-/es6-shim-0.21.0.tgz"
+        },
+        "es6-symbol": {
+          "version": "0.1.1",
+          "from": "es6-symbol@0.1.1",
+          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz",
+          "dependencies": {
+            "d": {
+              "version": "0.1.1",
+              "from": "d@>=0.1.1 <0.2.0",
+              "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+            },
+            "es5-ext": {
+              "version": "0.10.4",
+              "from": "es5-ext@>=0.10.4 <0.11.0",
+              "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.4.tgz",
+              "dependencies": {
+                "es6-iterator": {
+                  "version": "0.1.2",
+                  "from": "es6-iterator@>=0.1.1 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "estraverse": {
+          "version": "1.8.0",
+          "from": "estraverse@1.8.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.8.0.tgz"
+        },
+        "esutils": {
+          "version": "1.1.6",
+          "from": "esutils@1.1.6",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
+        },
+        "fs-readdir-recursive": {
+          "version": "0.1.0",
+          "from": "fs-readdir-recursive@0.1.0",
+          "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.0.tgz"
+        },
+        "private": {
+          "version": "0.1.6",
+          "from": "private@0.1.6",
+          "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
+        },
+        "regexpu": {
+          "version": "0.3.0",
+          "from": "regexpu@0.3.0",
+          "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-0.3.0.tgz",
+          "dependencies": {
+            "recast": {
+              "version": "0.8.8",
+              "from": "recast@>=0.8.0 <0.9.0",
+              "resolved": "https://registry.npmjs.org/recast/-/recast-0.8.8.tgz",
+              "dependencies": {
+                "esprima-fb": {
+                  "version": "7001.1.0-dev-harmony-fb",
+                  "from": "esprima-fb@>=7001.1.0-dev-harmony-fb <7001.2.0",
+                  "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-7001.1.0-dev-harmony-fb.tgz"
+                },
+                "source-map": {
+                  "version": "0.1.32",
+                  "from": "source-map@0.1.32",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "0.1.0",
+                      "from": "amdefine@>=0.0.4",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                    }
+                  }
+                },
+                "cls": {
+                  "version": "0.1.5",
+                  "from": "cls@>=0.1.3 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/cls/-/cls-0.1.5.tgz"
+                },
+                "depd": {
+                  "version": "1.0.0",
+                  "from": "depd@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.0.tgz"
+                },
+                "ast-types": {
+                  "version": "0.5.7",
+                  "from": "ast-types@>=0.5.7 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.5.7.tgz"
+                }
+              }
+            },
+            "regenerate": {
+              "version": "1.0.1",
+              "from": "regenerate@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.0.1.tgz"
+            },
+            "regjsgen": {
+              "version": "0.2.0",
+              "from": "regjsgen@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
+            },
+            "regjsparser": {
+              "version": "0.1.3",
+              "from": "regjsparser@>=0.1.2 <0.2.0",
+              "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.3.tgz",
+              "dependencies": {
+                "jsesc": {
+                  "version": "0.5.0",
+                  "from": "jsesc@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "source-map": {
+          "version": "0.1.40",
+          "from": "source-map@0.1.40",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.40.tgz",
+          "dependencies": {
+            "amdefine": {
+              "version": "0.1.0",
+              "from": "amdefine@>=0.0.4",
+              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+            }
+          }
+        },
+        "source-map-support": {
+          "version": "0.2.8",
+          "from": "source-map-support@0.2.8",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.8.tgz",
+          "dependencies": {
+            "source-map": {
+              "version": "0.1.32",
+              "from": "source-map@0.1.32",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.0",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "caniuse-db": {
       "version": "1.0.20140710",
       "from": "caniuse-db@1.0.20140710",
@@ -22,9 +269,9 @@
           "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.4.tgz"
         },
         "es6-iterator": {
-          "version": "0.1.1",
+          "version": "0.1.2",
           "from": "es6-iterator@>=0.1.1 <0.2.0",
-          "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.1.tgz"
+          "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.2.tgz"
         },
         "es6-symbol": {
           "version": "0.1.1",
@@ -44,24 +291,24 @@
       "resolved": "https://registry.npmjs.org/expect.js/-/expect.js-0.3.1.tgz"
     },
     "express": {
-      "version": "4.10.1",
+      "version": "4.10.7",
       "from": "express@>=4.4.4 <5.0.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.10.1.tgz",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.10.7.tgz",
       "dependencies": {
         "accepts": {
-          "version": "1.1.2",
-          "from": "accepts@>=1.1.2 <1.2.0",
-          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.2.tgz",
+          "version": "1.1.4",
+          "from": "accepts@>=1.1.4 <1.2.0",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
           "dependencies": {
             "mime-types": {
-              "version": "2.0.2",
-              "from": "mime-types@>=2.0.2 <2.1.0",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.2.tgz",
+              "version": "2.0.7",
+              "from": "mime-types@>=2.0.7 <2.1.0",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.7.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.1.2",
-                  "from": "mime-db@>=1.1.0 <1.2.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.1.2.tgz"
+                  "version": "1.5.0",
+                  "from": "mime-db@>=1.5.0 <1.6.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.5.0.tgz"
                 }
               }
             },
@@ -83,9 +330,9 @@
           "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.5.tgz"
         },
         "debug": {
-          "version": "2.1.0",
-          "from": "debug@>=2.1.0 <2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.0.tgz",
+          "version": "2.1.1",
+          "from": "debug@>=2.1.1 <2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.1.tgz",
           "dependencies": {
             "ms": {
               "version": "0.6.2",
@@ -105,21 +352,21 @@
           "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
         },
         "etag": {
-          "version": "1.5.0",
-          "from": "etag@>=1.5.0 <1.6.0",
-          "resolved": "https://registry.npmjs.org/etag/-/etag-1.5.0.tgz",
+          "version": "1.5.1",
+          "from": "etag@>=1.5.1 <1.6.0",
+          "resolved": "https://registry.npmjs.org/etag/-/etag-1.5.1.tgz",
           "dependencies": {
             "crc": {
-              "version": "3.0.0",
-              "from": "crc@3.0.0",
-              "resolved": "https://registry.npmjs.org/crc/-/crc-3.0.0.tgz"
+              "version": "3.2.1",
+              "from": "crc@3.2.1",
+              "resolved": "https://registry.npmjs.org/crc/-/crc-3.2.1.tgz"
             }
           }
         },
         "finalhandler": {
-          "version": "0.3.2",
-          "from": "finalhandler@0.3.2",
-          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.3.2.tgz"
+          "version": "0.3.3",
+          "from": "finalhandler@0.3.3",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.3.3.tgz"
         },
         "fresh": {
           "version": "0.2.4",
@@ -132,14 +379,14 @@
           "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
         },
         "methods": {
-          "version": "1.1.0",
-          "from": "methods@1.1.0",
-          "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.0.tgz"
+          "version": "1.1.1",
+          "from": "methods@1.1.1",
+          "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.1.tgz"
         },
         "on-finished": {
-          "version": "2.1.1",
-          "from": "on-finished@>=2.1.1 <2.2.0",
-          "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.1.tgz",
+          "version": "2.2.0",
+          "from": "on-finished@>=2.2.0 <2.3.0",
+          "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.0.tgz",
           "dependencies": {
             "ee-first": {
               "version": "1.1.0",
@@ -159,9 +406,9 @@
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.3.tgz"
         },
         "proxy-addr": {
-          "version": "1.0.3",
-          "from": "proxy-addr@>=1.0.3 <1.1.0",
-          "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.3.tgz",
+          "version": "1.0.5",
+          "from": "proxy-addr@>=1.0.4 <1.1.0",
+          "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.5.tgz",
           "dependencies": {
             "forwarded": {
               "version": "0.1.0",
@@ -169,16 +416,16 @@
               "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
             },
             "ipaddr.js": {
-              "version": "0.1.3",
-              "from": "ipaddr.js@0.1.3",
-              "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.3.tgz"
+              "version": "0.1.6",
+              "from": "ipaddr.js@0.1.6",
+              "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.6.tgz"
             }
           }
         },
         "qs": {
-          "version": "2.3.2",
-          "from": "qs@2.3.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.2.tgz"
+          "version": "2.3.3",
+          "from": "qs@>=2.3.1 <2.4.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
         },
         "range-parser": {
           "version": "1.0.2",
@@ -204,28 +451,40 @@
               "version": "0.6.2",
               "from": "ms@0.6.2",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+            },
+            "on-finished": {
+              "version": "2.1.1",
+              "from": "on-finished@>=2.1.1 <2.2.0",
+              "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.1.tgz",
+              "dependencies": {
+                "ee-first": {
+                  "version": "1.1.0",
+                  "from": "ee-first@1.1.0",
+                  "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz"
+                }
+              }
             }
           }
         },
         "serve-static": {
-          "version": "1.7.1",
-          "from": "serve-static@>=1.7.1 <1.8.0",
-          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.7.1.tgz"
+          "version": "1.7.2",
+          "from": "serve-static@>=1.7.2 <1.8.0",
+          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.7.2.tgz"
         },
         "type-is": {
-          "version": "1.5.2",
-          "from": "type-is@>=1.5.2 <1.6.0",
-          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.5.2.tgz",
+          "version": "1.5.5",
+          "from": "type-is@>=1.5.5 <1.6.0",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.5.5.tgz",
           "dependencies": {
             "mime-types": {
-              "version": "2.0.2",
-              "from": "mime-types@>=2.0.2 <2.1.0",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.2.tgz",
+              "version": "2.0.7",
+              "from": "mime-types@>=2.0.7 <2.1.0",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.7.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.1.2",
-                  "from": "mime-db@>=1.1.0 <1.2.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.1.2.tgz"
+                  "version": "1.5.0",
+                  "from": "mime-db@>=1.5.0 <1.6.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.5.0.tgz"
                 }
               }
             }
@@ -353,9 +612,9 @@
                           "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.0.10.tgz",
                           "dependencies": {
                             "combined-stream": {
-                              "version": "0.0.5",
+                              "version": "0.0.7",
                               "from": "combined-stream@>=0.0.4 <0.1.0",
-                              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.5.tgz",
+                              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                               "dependencies": {
                                 "delayed-stream": {
                                   "version": "0.0.5",
@@ -399,9 +658,9 @@
                           }
                         },
                         "node-uuid": {
-                          "version": "1.4.1",
+                          "version": "1.4.2",
                           "from": "node-uuid@>=1.4.0 <1.5.0",
-                          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
+                          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
                         },
                         "cookie-jar": {
                           "version": "0.2.0",
@@ -580,9 +839,9 @@
                           "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.0.10.tgz",
                           "dependencies": {
                             "combined-stream": {
-                              "version": "0.0.5",
+                              "version": "0.0.7",
                               "from": "combined-stream@>=0.0.4 <0.1.0",
-                              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.5.tgz",
+                              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                               "dependencies": {
                                 "delayed-stream": {
                                   "version": "0.0.5",
@@ -626,9 +885,9 @@
                           }
                         },
                         "node-uuid": {
-                          "version": "1.4.1",
+                          "version": "1.4.2",
                           "from": "node-uuid@>=1.4.0 <1.5.0",
-                          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
+                          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
                         },
                         "cookie-jar": {
                           "version": "0.2.0",
@@ -710,7 +969,7 @@
             },
             "minimatch": {
               "version": "0.2.14",
-              "from": "minimatch@>=0.2.11 <0.3.0",
+              "from": "minimatch@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
               "dependencies": {
                 "lru-cache": {
@@ -801,9 +1060,9 @@
               "resolved": "https://registry.npmjs.org/async/-/async-0.2.9.tgz"
             },
             "ini": {
-              "version": "1.3.0",
+              "version": "1.3.2",
               "from": "ini@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.0.tgz"
+              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.2.tgz"
             },
             "optimist": {
               "version": "0.6.0",
@@ -825,13 +1084,13 @@
           }
         },
         "nssocket": {
-          "version": "0.5.1",
+          "version": "0.5.3",
           "from": "nssocket@>=0.5.1 <0.6.0",
-          "resolved": "https://registry.npmjs.org/nssocket/-/nssocket-0.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/nssocket/-/nssocket-0.5.3.tgz",
           "dependencies": {
             "eventemitter2": {
               "version": "0.4.14",
-              "from": "eventemitter2@>=0.4.11 <0.5.0",
+              "from": "eventemitter2@>=0.4.14 <0.5.0",
               "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
             },
             "lazy": {
@@ -936,9 +1195,9 @@
                   "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.0.10.tgz",
                   "dependencies": {
                     "combined-stream": {
-                      "version": "0.0.5",
+                      "version": "0.0.7",
                       "from": "combined-stream@>=0.0.4 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.5.tgz",
+                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                       "dependencies": {
                         "delayed-stream": {
                           "version": "0.0.5",
@@ -982,9 +1241,9 @@
                   }
                 },
                 "node-uuid": {
-                  "version": "1.4.1",
+                  "version": "1.4.2",
                   "from": "node-uuid@>=1.4.0 <1.5.0",
-                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
                 },
                 "cookie-jar": {
                   "version": "0.2.0",
@@ -1060,9 +1319,9 @@
               "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             },
             "source-map": {
-              "version": "0.1.40",
+              "version": "0.1.43",
               "from": "source-map@>=0.1.7 <0.2.0",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.40.tgz",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "0.1.0",
@@ -1158,7 +1417,7 @@
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <3.0.0"
+              "from": "inherits@>=2.0.1 <2.1.0"
             }
           }
         },
@@ -1187,14 +1446,19 @@
       }
     },
     "moment": {
-      "version": "2.8.3",
+      "version": "2.9.0",
       "from": "moment@>=2.8.3 <3.0.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.8.3.tgz"
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.9.0.tgz"
+    },
+    "q": {
+      "version": "1.1.2",
+      "from": "q@>=1.1.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.1.2.tgz"
     },
     "request": {
-      "version": "2.47.0",
+      "version": "2.51.0",
       "from": "request@>=2.44.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.47.0.tgz",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
       "dependencies": {
         "bl": {
           "version": "0.9.3",
@@ -1221,33 +1485,41 @@
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0"
+                  "from": "inherits@>=2.0.1 <2.1.0"
                 }
               }
             }
           }
         },
         "caseless": {
-          "version": "0.6.0",
-          "from": "caseless@>=0.6.0 <0.7.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.6.0.tgz"
+          "version": "0.8.0",
+          "from": "caseless@>=0.8.0 <0.9.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
         },
         "forever-agent": {
           "version": "0.5.2",
           "from": "forever-agent@>=0.5.0 <0.6.0"
         },
         "form-data": {
-          "version": "0.1.4",
-          "from": "form-data@>=0.1.0 <0.2.0",
+          "version": "0.2.0",
+          "from": "form-data@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
           "dependencies": {
-            "mime": {
-              "version": "1.2.11",
-              "from": "mime@>=1.2.11 <1.3.0",
-              "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
-            },
             "async": {
               "version": "0.9.0",
               "from": "async@>=0.9.0 <0.10.0"
+            },
+            "mime-types": {
+              "version": "2.0.7",
+              "from": "mime-types@>=2.0.3 <2.1.0",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.7.tgz",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.5.0",
+                  "from": "mime-db@>=1.5.0 <1.6.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.5.0.tgz"
+                }
+              }
             }
           }
         },
@@ -1260,14 +1532,14 @@
           "from": "mime-types@>=1.0.1 <1.1.0"
         },
         "node-uuid": {
-          "version": "1.4.1",
+          "version": "1.4.2",
           "from": "node-uuid@>=1.4.0 <1.5.0",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
         },
         "qs": {
-          "version": "2.3.2",
+          "version": "2.3.3",
           "from": "qs@>=2.3.1 <2.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.2.tgz"
+          "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
         },
         "tunnel-agent": {
           "version": "0.4.0",
@@ -1285,13 +1557,14 @@
           }
         },
         "http-signature": {
-          "version": "0.10.0",
+          "version": "0.10.1",
           "from": "http-signature@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
           "dependencies": {
             "assert-plus": {
-              "version": "0.1.2",
-              "from": "assert-plus@0.1.2",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
+              "version": "0.1.5",
+              "from": "assert-plus@>=0.1.5 <0.2.0",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
             },
             "asn1": {
               "version": "0.1.11",
@@ -1299,16 +1572,16 @@
               "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
             },
             "ctype": {
-              "version": "0.5.2",
-              "from": "ctype@0.5.2",
-              "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
+              "version": "0.5.3",
+              "from": "ctype@0.5.3",
+              "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
             }
           }
         },
         "oauth-sign": {
-          "version": "0.4.0",
-          "from": "oauth-sign@>=0.4.0 <0.5.0",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.4.0.tgz"
+          "version": "0.5.0",
+          "from": "oauth-sign@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
         },
         "hawk": {
           "version": "1.1.1",
@@ -1342,14 +1615,65 @@
           "from": "stringstream@>=0.0.4 <0.1.0"
         },
         "combined-stream": {
-          "version": "0.0.5",
+          "version": "0.0.7",
           "from": "combined-stream@>=0.0.5 <0.1.0",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.5.tgz",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
           "dependencies": {
             "delayed-stream": {
               "version": "0.0.5",
               "from": "delayed-stream@0.0.5",
               "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+            }
+          }
+        }
+      }
+    },
+    "request-promise": {
+      "version": "0.3.2",
+      "from": "request-promise@>=0.3.2 <0.4.0",
+      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-0.3.2.tgz",
+      "dependencies": {
+        "bluebird": {
+          "version": "2.6.4",
+          "from": "bluebird@>=2.3.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.6.4.tgz"
+        },
+        "chalk": {
+          "version": "0.5.1",
+          "from": "chalk@>=0.5.1 <0.6.0",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "1.1.0",
+              "from": "ansi-styles@>=1.1.0 <2.0.0"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.2",
+              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
+            },
+            "has-ansi": {
+              "version": "0.1.0",
+              "from": "has-ansi@>=0.1.0 <0.2.0",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "0.2.1",
+                  "from": "ansi-regex@>=0.2.0 <0.3.0"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "0.3.0",
+              "from": "strip-ansi@>=0.3.0 <0.4.0",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "0.2.1",
+                  "from": "ansi-regex@>=0.2.0 <0.3.0"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "0.2.0",
+              "from": "supports-color@>=0.2.0 <0.3.0"
             }
           }
         }
@@ -1366,9 +1690,9 @@
       "resolved": "https://registry.npmjs.org/tsort/-/tsort-0.0.1.tgz"
     },
     "uglify-js": {
-      "version": "2.4.15",
+      "version": "2.4.16",
       "from": "uglify-js@>=2.4.14 <3.0.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.15.tgz",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.16.tgz",
       "dependencies": {
         "async": {
           "version": "0.2.10",
@@ -1407,9 +1731,9 @@
       }
     },
     "useragent": {
-      "version": "2.1.1",
+      "version": "2.1.3",
       "from": "useragent@>=2.0.8 <3.0.0",
-      "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.1.3.tgz",
       "dependencies": {
         "lru-cache": {
           "version": "2.2.4",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "license": "CC0 1.0 Universal License",
   "dependencies": {
+    "6to5": "^1.15.0",
     "caniuse-db": "1.0.20140710",
     "es6-set": "^0.1.0",
     "expect.js": "^0.3.1",

--- a/polyfills/Math.acosh/config.json
+++ b/polyfills/Math.acosh/config.json
@@ -14,5 +14,6 @@
 		"op_mob": "*",
 		"op_mini": "*",
 		"safari": "4 - 7"
-	}
+	},
+	"ESVersion": 6
 }

--- a/polyfills/Math.acosh/config.json
+++ b/polyfills/Math.acosh/config.json
@@ -15,5 +15,5 @@
 		"op_mini": "*",
 		"safari": "4 - 7"
 	},
-	"ESVersion": 6
+	"esversion": 6
 }

--- a/polyfills/Math.acosh/polyfill.js
+++ b/polyfills/Math.acosh/polyfill.js
@@ -1,3 +1,1 @@
-Math.acosh = function acosh(x) {
-	return Math.log(x + Math.sqrt(x * x - 1));
-};
+Math.acosh = x => Math.log(x + Math.sqrt(x * x - 1));


### PR DESCRIPTION
This was actually surprisingly easy, though I cheated by assuming we don't want to serve untranspiled ES6 to any browser.  There's an argument that Firefox 36 might already qualify, having ES6 support that's already better than the 6to5 transpiler.  However, while we can guarantee the consistent logic of the transpiler and cope with language features it doesn't support, browsers with varying degrees of ES6 support are harder to cope with so we should probably have a higher bar.  At this point I don't think there are any browsers that we should serve raw ES6 to.

I've jotted down a few thoughts in a comment about how we could model the more complex set of sources that would result from having ES version as a dimension along with whether to minify and whether to gate (resulting in a minimum of eight versions of every polyfill variant!).  But for now, I think we have a licence to assume we want to level down everything to ES5 before splitting into minified and gated variations.

I also added some better error handling on startup, so that it's easier to spot misconfigured or syntactically invalid polyfills.
