### PR TITLE
Faking high precisiong timing in requestAnimationFrame

### DIFF
--- a/polyfills/performance.now/config.json
+++ b/polyfills/performance.now/config.json
@@ -1,0 +1,15 @@
+{
+	"browsers": {
+		"bb": "<10",
+		"chrome": "<24",
+		"ie": "<10",
+		"ios_saf": "<8 || 8.1",
+		"firefox": "<15",
+		"opera": "<15",
+		"op_mob": "<24",
+		"safari": "<8"
+	},
+	"dependencies": [
+		"Date.now"
+	]
+}

--- a/polyfills/performance.now/detect.js
+++ b/polyfills/performance.now/detect.js
@@ -1,0 +1,1 @@
+window.performance && window.performance.now

--- a/polyfills/performance.now/polyfill.js
+++ b/polyfills/performance.now/polyfill.js
@@ -1,0 +1,14 @@
+(function (global) {
+
+var
+startTime = Date.now();
+
+if (!global.performance) {
+    global.performance = {};
+}
+
+global.performance.now = function () {
+    return Date.now() - startTime;
+};
+
+}(this));

--- a/polyfills/requestAnimationFrame/config.json
+++ b/polyfills/requestAnimationFrame/config.json
@@ -28,5 +28,9 @@
 			}
 		}
 	},
+	"dependencies": [
+		"Date.now",
+		"performance.now"
+	],
 	"license": "requestAnimationFrame polyfill by Erik Möller, fixes from Paul Irish, Tino Zijdel, and Jonathan Neal"
 }

--- a/polyfills/requestAnimationFrame/polyfill-moz.js
+++ b/polyfills/requestAnimationFrame/polyfill-moz.js
@@ -1,5 +1,21 @@
+(function (global) {
+var
+now = Date.now || function () {
+    return new Date().getTime();
+},
+startTime = now(),
+perfNow = (window.performance && window.performance.now) || function () {
+    return now() - startTime;
+};
+
 // window.requestAnimationFrame
-window.requestAnimationFrame = mozRequestAnimationFrame;
+global.requestAnimationFrame = function (callback) {
+    return mozRequestAnimationFrame(function () {
+        callback(perfNow());
+    });
+};
 
 // window.cancelAnimationFrame
-window.cancelAnimationFrame = mozCancelAnimationFrame;
+global.cancelAnimationFrame = mozCancelAnimationFrame;
+
+}(this));

--- a/polyfills/requestAnimationFrame/polyfill-moz.js
+++ b/polyfills/requestAnimationFrame/polyfill-moz.js
@@ -1,17 +1,9 @@
 (function (global) {
-var
-now = Date.now || function () {
-    return new Date().getTime();
-},
-startTime = now(),
-perfNow = (window.performance && window.performance.now) || function () {
-    return now() - startTime;
-};
 
 // window.requestAnimationFrame
 global.requestAnimationFrame = function (callback) {
     return mozRequestAnimationFrame(function () {
-        callback(perfNow());
+        callback(performance.now());
     });
 };
 

--- a/polyfills/requestAnimationFrame/polyfill-webkit.js
+++ b/polyfills/requestAnimationFrame/polyfill-webkit.js
@@ -1,17 +1,9 @@
 (function (global) {
-var
-now = Date.now || function () {
-    return new Date().getTime();
-},
-startTime = now(),
-perfNow = (window.performance && window.performance.now) || function () {
-    return now() - startTime;
-};
 
 // window.requestAnimationFrame
 global.requestAnimationFrame = function (callback) {
     return webkitRequestAnimationFrame(function () {
-        callback(perfNow());
+        callback(performance.now());
     });
 };
 

--- a/polyfills/requestAnimationFrame/polyfill-webkit.js
+++ b/polyfills/requestAnimationFrame/polyfill-webkit.js
@@ -1,5 +1,21 @@
+(function (global) {
+var
+now = Date.now || function () {
+    return new Date().getTime();
+},
+startTime = now(),
+perfNow = (window.performance && window.performance.now) || function () {
+    return now() - startTime;
+};
+
 // window.requestAnimationFrame
-window.requestAnimationFrame = webkitRequestAnimationFrame;
+global.requestAnimationFrame = function (callback) {
+    return webkitRequestAnimationFrame(function () {
+        callback(perfNow());
+    });
+};
 
 // window.cancelAnimationFrame
-window.cancelAnimationFrame = webkitCancelAnimationFrame;
+global.cancelAnimationFrame = webkitCancelAnimationFrame;
+
+}(this));

--- a/polyfills/requestAnimationFrame/polyfill.js
+++ b/polyfills/requestAnimationFrame/polyfill.js
@@ -2,14 +2,21 @@
 	'use strict';
 
 	var
-	startTime = (new Date()).getTime(),
+	now = Date.now || function () {
+		return new Date().getTime();
+	},
+	startTime = now(),
 	lastTime = startTime;
 
 	// <Global>.requestAnimationFrame
 	global.requestAnimationFrame = function (callback) {
 		var
-		currentTime = (new Date()).getTime(),
-		delay = Math.max(0, 16 - (currentTime - lastTime));
+		currentTime = now(),
+		delay = 16 + lastTime - currentTime;
+
+		if (delay < 0) {
+			delay = 0;
+		}
 
 		lastTime = currentTime;
 

--- a/polyfills/requestAnimationFrame/polyfill.js
+++ b/polyfills/requestAnimationFrame/polyfill.js
@@ -2,14 +2,7 @@
 	'use strict';
 
 	var
-	now = Date.now || function () {
-		return new Date().getTime();
-	},
-	startTime = now(),
-	lastTime = startTime,
-	getElapsed = (window.performance && window.performance.now) || function () {
-		return lastTime - startTime;
-	};
+	lastTime = Date.now();
 
 	// <Global>.requestAnimationFrame
 	global.requestAnimationFrame = function (callback) {
@@ -18,7 +11,7 @@
 		}
 		
 		var
-		currentTime = now(),
+		currentTime = Date.now(),
 		delay = 16 + lastTime - currentTime;
 
 		if (delay < 0) {
@@ -28,9 +21,9 @@
 		lastTime = currentTime;
 
 		return setTimeout(function () {
-			lastTime = now();
+			lastTime = Date.now();
 
-			callback(getElapsed());
+			callback(performance.now());
 		}, delay);
 	};
 

--- a/polyfills/requestAnimationFrame/polyfill.js
+++ b/polyfills/requestAnimationFrame/polyfill.js
@@ -6,7 +6,10 @@
 		return new Date().getTime();
 	},
 	startTime = now(),
-	lastTime = startTime;
+	lastTime = startTime,
+	getElapsed = (window.performance && window.performance.now) || function () {
+		return lastTime - startTime;
+	};
 
 	// <Global>.requestAnimationFrame
 	global.requestAnimationFrame = function (callback) {
@@ -21,9 +24,9 @@
 		lastTime = currentTime;
 
 		return setTimeout(function () {
-			lastTime = (new Date()).getTime();
+			lastTime = now();
 
-			callback(lastTime - startTime);
+			callback(getElapsed());
 		}, delay);
 	};
 

--- a/polyfills/requestAnimationFrame/polyfill.js
+++ b/polyfills/requestAnimationFrame/polyfill.js
@@ -13,6 +13,10 @@
 
 	// <Global>.requestAnimationFrame
 	global.requestAnimationFrame = function (callback) {
+		if (typeof callback !== 'function') {
+			throw new TypeError(callback + 'is not a function');
+		}
+		
 		var
 		currentTime = now(),
 		delay = 16 + lastTime - currentTime;

--- a/polyfills/requestAnimationFrame/tests.js
+++ b/polyfills/requestAnimationFrame/tests.js
@@ -1,0 +1,28 @@
+it('should be defined', function () {
+    expect(window.requestAnimationFrame).to.be.a('function');
+    expect(window.cancelAnimationFrame).to.be.a('function');
+});
+
+it('should return a number id', function () {
+    expect(requestAnimationFrame(function () {})).to.be.a('number');
+});
+
+it('should be cancelable', function (done) {
+    var called = false;
+    var id = requestAnimationFrame(function () {
+        called = true;
+    });
+    cancelAnimationFrame(id);
+    setTimeout(function () {
+        expect(called).to.be(false);
+        done();
+    }, 50);
+});
+
+it('should use a high precision timer', function (done) {
+    requestAnimationFrame(function (time) {
+        // See http://updates.html5rocks.com/2012/05/requestAnimationFrame-API-now-with-sub-millisecond-precision#feature-detection
+        expect(time).to.be.below(1e12);
+        done();
+    });
+});


### PR DESCRIPTION
Hi! I just got back from some pretty long vacations, so I'm starting to slowly get my feet wet.

The `requestAnimationFrame` polyfill wasn't passing the right argument to the callback function. Vendor versions also send the current timestamp in milliseconds instead of using high precision time. For example, see:

![image](https://cloud.githubusercontent.com/assets/347002/5635046/4d18a708-95c4-11e4-8985-da16657b15aa.png)

This PR fixes this, adds a couple of minor perf improvements (`Date.now` is much faster than `new Date().getTime()`) and adds some basic tests.
