### PR TITLE
Error handling for Object.defineProperty

### DIFF
--- a/polyfills/Object.defineProperty/polyfill-ie7.js
+++ b/polyfills/Object.defineProperty/polyfill-ie7.js
@@ -10,20 +10,37 @@ Object.defineProperty = function defineProperty(object, property, descriptor) {
 	}
 
 	var
+	ERR_ACCESSORS_NOT_SUPPORTED = 'getters & setters can not be defined on this javascript',
+	ERR_VALUE_ACCESSORS = 'A property cannot both have accessors and be writable or have a value',
+	hasValueOrWritable = 'value' in descriptor || 'writable' in descriptor,
 	propertyString = String(property),
 	Element = window.Element || {};
 
 	// handle descriptor.get
 	if ('get' in descriptor) {
-		object[propertyString] = object === Element.prototype ? new Element.__getter__(descriptor.get) : descriptor.get.call(object);
-	}
-	// handle descriptor.value
-	else {
-		object[propertyString] = descriptor.value;
+		if (typeof descriptor.get !== 'function') {
+			throw new TypeError('Getter expected a function');
+		}
+		if (hasValueOrWritable) {
+			throw new TypeError(ERR_VALUE_ACCESSORS);
+		}
+		if (object !== Element.prototype) {
+			throw new TypeError(ERR_ACCESSORS_NOT_SUPPORTED);
+		}
+		object[propertyString] = new Element.__getter__(descriptor.get);
 	}
 
 	// handle descriptor.set
-	if ('set' in descriptor && object.constructor === Element) {
+	if ('set' in descriptor) {
+		if (typeof descriptor.get !== 'function') {
+			throw new TypeError('Getter expected a function');
+		}
+		if (hasValueOrWritable) {
+			throw new TypeError(ERR_VALUE_ACCESSORS);
+		}
+		if (object.constructor !== Element) {
+			throw new TypeError(ERR_ACCESSORS_NOT_SUPPORTED);
+		}
 		object.attachEvent('onpropertychange', function callee(event) {
 			object.detachEvent('onpropertychange', callee);
 
@@ -33,6 +50,10 @@ Object.defineProperty = function defineProperty(object, property, descriptor) {
 
 			object.attachEvent('onpropertychange', callee);
 		});
+	}
+
+	if ('value' in descriptor) {
+		object[propertyString] = descriptor.value;
 	}
 
 	// return object

--- a/polyfills/Object.defineProperty/polyfill-ie8.js
+++ b/polyfills/Object.defineProperty/polyfill-ie8.js
@@ -1,4 +1,7 @@
 (function (nativeDefineProperty) {
+	var ERR_ACCESSORS_NOT_SUPPORTED = 'getters & setters can not be defined on this javascript engine';
+	var ERR_VALUE_ACCESSORS = 'A property cannot both have accessors and be writable or have a value';
+
 	Object.defineProperty = function defineProperty(object, property, descriptor) {
 		// handle object
 		if (object === null || !(object instanceof Object || typeof object === 'object')) {
@@ -11,21 +14,35 @@
 		}
 
 		var
-		propertyString = String(property);
+		propertyString = String(property),
+		hasValueOrWritable = 'value' in descriptor || 'writable' in descriptor;
 
 		// handle native support
 		if (object === window || object === document || object === Element.prototype || object instanceof Element) {
 			return nativeDefineProperty(object, propertyString, descriptor);
 		}
 
-		// handle descriptor.get
 		if ('get' in descriptor) {
-			object[propertyString] = descriptor.get.call(object);
+			if (typeof descriptor.get !== 'function') {
+				throw new TypeError('Getter expected a function');
+			}
+			if (hasValueOrWritable) {
+				throw new TypeError(ERR_VALUE_ACCESSORS);
+			}
+			throw new TypeError(ERR_ACCESSORS_NOT_SUPPORTED);
 		}
-		// handle descriptor.value
-		else {
-			object[propertyString] = descriptor.value;
+		
+		if ('set' in descriptor) {
+			if (typeof descriptor.set !== 'function') {
+				throw new TypeError('Setter expected a function');
+			}
+			if (hasValueOrWritable) {
+				throw new TypeError(ERR_VALUE_ACCESSORS);
+			}
+			throw new TypeError(ERR_ACCESSORS_NOT_SUPPORTED);
 		}
+
+		object[propertyString] = descriptor.value;
 
 		// return object
 		return object;

--- a/polyfills/Object.defineProperty/polyfill.js
+++ b/polyfills/Object.defineProperty/polyfill.js
@@ -1,43 +1,60 @@
-Object.defineProperty = Object.defineProperty || function defineProperty(object, property, descriptor) {
-	// handle object
-	if (object === null || !(object instanceof Object || typeof object === 'object')) {
-		throw new TypeError('Object must be an object');
+(function () {
+	if (Object.defineProperty) {
+		return;
 	}
+	
+	var supportsAccessors = Object.prototype.hasOwnProperty('__defineGetter__');
+	var ERR_ACCESSORS_NOT_SUPPORTED = 'getters & setters can not be defined on this javascript engine';
+	var ERR_VALUE_ACCESSORS = 'A property cannot both have accessors and be writable or have a value';
 
-	// handle descriptor
-	if (!(descriptor instanceof Object)) {
-		throw new TypeError('Descriptor must be an object');
-	}
+	Object.defineProperty = function defineProperty(object, property, descriptor) {
+		// handle object
+		if (object === null || !(object instanceof Object || typeof object === 'object')) {
+			throw new TypeError('Object must be an object');
+		}
 
-	var
-	propertyString = String(property),
-	getterType = 'get' in descriptor && typeof descriptor.get,
-	setterType = 'set' in descriptor && typeof descriptor.set;
+		// handle descriptor
+		if (!(descriptor instanceof Object)) {
+			throw new TypeError('Descriptor must be an object');
+		}
 
-	// handle descriptor.get
-	if (getterType && getterType !== 'function') {
-		throw new TypeError('Getter expected a function');
-	}
+		var
+		propertyString = String(property),
+		getterType = 'get' in descriptor && typeof descriptor.get,
+		setterType = 'set' in descriptor && typeof descriptor.set,
+		hasValueOrWritable = 'value' in descriptor || 'writable' in descriptor;
 
-	// handle descriptor.set
-	if (setterType && setterType !== 'function') {
-		throw new TypeError('Setter expected a function');
-	}
+		// handle descriptor.get
+		if (getterType) {
+			if (getterType !== 'function') {
+				throw new TypeError('Getter expected a function');
+			}
+			if (!supportsAccessors) {
+				throw new TypeError(ERR_ACCESSORS_NOT_SUPPORTED);
+			}
+			if (hasValueOrWritable) {
+				throw new TypeError(ERR_VALUE_ACCESSORS);
+			}
+			object.__defineGetter__(propertyString, descriptor.get);
+		}
 
-	// handle descriptor.get
-	if (getterType) {
-		object.__defineGetter__(propertyString, descriptor.get);
-	}
-	// handle descriptor.value
-	else {
+		// handle descriptor.set
+		if (setterType) {
+			if (setterType !== 'function') {
+				throw new TypeError('Setter expected a function');
+			}
+			if (!supportsAccessors) {
+				throw new TypeError(ERR_ACCESSORS_NOT_SUPPORTED);
+			}
+			if (hasValueOrWritable) {
+				throw new TypeError(ERR_VALUE_ACCESSORS);
+			}
+			object.__defineSetter__(propertyString, descriptor.set);
+		}
+
 		object[propertyString] = descriptor.value;
-	}
 
-	// handle descriptor.set
-	if (setterType) {
-		object.__defineSetter__(propertyString, descriptor.set);
-	}
-
-	// return object
-	return object;
-};
+		// return object
+		return object;
+	};
+}());

--- a/polyfills/Object.defineProperty/tests.js
+++ b/polyfills/Object.defineProperty/tests.js
@@ -1,3 +1,4 @@
+/*global describe, it, expect*/
 describe('Basic functionality', function () {
 	var
 	object = {},
@@ -80,5 +81,57 @@ describe('Error handling', function () {
 		expect(function () {
 			Object.defineProperty(object, property, '');
 		});
+	});
+
+	it('Throws an error when both an accessor and a value are specified', function () {
+		expect(function () {
+			Object.defineProperty(object, property, {
+				value: value,
+				writable: true,
+				enumerable: true,
+				configurable: true,
+				get: function () {}
+			});
+		}).to.throwException();
+
+		expect(function () {
+			Object.defineProperty(object, property, {
+				value: value,
+				writable: true,
+				enumerable: true,
+				configurable: true,
+				set: function () {}
+			});
+		}).to.throwException();
+	});
+
+	it('Throws an error when an accessor is specified and writable is set', function () {
+		expect(function () {
+			Object.defineProperty(object, property, {
+				get: function () {},
+				writable: false
+			});
+		}).to.throwException();
+
+		expect(function () {
+			Object.defineProperty(object, property, {
+				get: function () {},
+				writable: true
+			});
+		}).to.throwException();
+
+		expect(function () {
+			Object.defineProperty(object, property, {
+				set: function () {},
+				writable: false
+			});
+		}).to.throwException();
+
+		expect(function () {
+			Object.defineProperty(object, property, {
+				set: function () {},
+				writable: true
+			});
+		}).to.throwException();
 	});
 });


### PR DESCRIPTION
`Object.defineProperty` was not checking if accessors were available in the object. It also was not throwing when both an accessor and a value were specified in the descriptor.
