### PR TITLE
Fix matchMedia queries with multiple dimensions

### DIFF
--- a/polyfills/matchMedia/polyfill.js
+++ b/polyfills/matchMedia/polyfill.js
@@ -13,7 +13,7 @@
 			.replace(/,/g, '||')
 			.replace(/and/g, '&&')
 			.replace(/dpi/g, '')
-			.replace(/(\d+)(cm|em|in|mm|pc|pt|px|rem)/, function ($0, $1, $2) {
+			.replace(/(\d+)(cm|em|in|mm|pc|pt|px|rem)/g, function ($0, $1, $2) {
 				return $1 * (
 					$2 === 'cm' ? 0.3937 * 96 : (
 						$2 === 'em' || $2 === 'rem' ? 16 : (

--- a/polyfills/matchMedia/tests.js
+++ b/polyfills/matchMedia/tests.js
@@ -7,3 +7,9 @@ it("should return a MediaQueryList that has a media property representing the me
 	var mql = window.matchMedia('screen');
 	expect(mql.media).to.be('screen');
 });
+
+it("should generate valid Javascript for multiple dimensions", function() {
+	expect(function() {
+		window.matchMedia('(min-width: 1px) and (max-width: 1000px)');
+	}).not.to.throwException();
+});


### PR DESCRIPTION
Regex global flag was missing, so only the first dimension in a media query was being converted.
