### PR TITLE
Fixes #299: typo on line Event/polyfill-ie8.js:99

### DIFF
--- a/polyfills/Event/polyfill-ie8.js
+++ b/polyfills/Event/polyfill-ie8.js
@@ -96,7 +96,7 @@
 		var
 		element = this,
 		type = arguments[0],
-		listener = arguments[1].
+		listener = arguments[1],
 		index;
 
 		if (element._events && element._events[type] && element._events[type].list) {


### PR DESCRIPTION
Pretty straightforward change. There was a typo causing listener to be set to the `arguments[1].index` instead of `arugments[1]` and then creating an index variable.
