### PR TITLE
delete element._events[type] when last listener is removed. Fixes #302

### DIFF
--- a/polyfills/Event/polyfill-ie8.js
+++ b/polyfills/Event/polyfill-ie8.js
@@ -109,6 +109,7 @@
 					if (element.detachEvent) {
 						element.detachEvent('on' + type, element._events[type]);
 					}
+					delete element._events[type];
 				}
 			}
 		}

--- a/polyfills/Event/tests.js
+++ b/polyfills/Event/tests.js
@@ -74,3 +74,22 @@ it('should should not trigger an event handler once removed', function() {
 	testEl.removeEventListener('test', listener);
 	testEl.dispatchEvent(testEvent);
 });
+
+it('should trigger an event handler once added, removed, and added again', function () {
+	// NOTE: The event must be a real DOM event or the
+	// dispatchEvent polyfill will catch the fireEvent
+	// error, simulate firing the event by running the
+	// event listeners.
+	var fired = false;
+	var listener = function() {
+		fired = true;
+		document.removeEventListener('click', listener);
+	};
+
+	document.addEventListener('click', listener);
+	document.removeEventListener('click', listener);
+	document.addEventListener('click', listener);
+	// click the document
+	document.dispatchEvent(new Event('click'));
+	expect(fired).to.be.(true);
+});


### PR DESCRIPTION
Currently when Calling removeEventListener on the last listener on an element detaches the event handler and addEventListener no longer re-adds it because the `_events[type]` object still exists.

The problem is the event is detached when the list is empty, but `element._events[type]` is not removed.

This change fixes the problem by deleting `element._events[type]` when the last listener is removed in `removeEventListener`, and also adds a test to catch this case.
