### PR TITLE
Fix typo in polyfills/Events/tests.js

### DIFF
--- a/polyfills/Event/tests.js
+++ b/polyfills/Event/tests.js
@@ -60,7 +60,7 @@ it('should bubble the event', function(done) {
 	testEl.dispatchEvent(testEvent);
 });
 
-it('should should not trigger an event handler once removed', function() {
+it('should not trigger an event handler once removed', function() {
 	var testEvent = new Event('test', {
 		bubbles: true,
 		cancelable: true


### PR DESCRIPTION
This is is just a simple typo fix 'should should' -> 'should'. Fixes #309.
