### PR TITLE
Fix installing collections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /node_modules
 /npm-debug.log
+/polyfills/__repo
 /polyfills/__versions
 /polyfills/aliases.json
 /polyfills/sources.json

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,9 +1,14 @@
+'use strict';
+
 require('es6-promise').polyfill();
 
 module.exports = function(grunt) {
 
 	grunt.initConfig({
-
+		"clean": {
+			repo: ['polyfills/__repo'],
+			versions: ['polyfills/__versions']
+		},
 		"simplemocha": {
 			options: {
 				globals: ['should'],
@@ -48,6 +53,7 @@ module.exports = function(grunt) {
 	});
 
 	grunt.loadTasks('tasks');
+	grunt.loadNpmTasks('grunt-contrib-clean');
 	grunt.loadNpmTasks('grunt-simple-mocha');
 
 	grunt.registerTask("test", [
@@ -72,8 +78,11 @@ module.exports = function(grunt) {
 	]);
 
 	grunt.registerTask("build", [
+		"clean:repo",
+		"clean:versions",
 		"installcollections",
-		"buildsources"
+		"buildsources",
+		"clean:repo"
 	]);
 };
 

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "batch": "^0.5.1",
     "grunt": "~0.4.0",
     "grunt-cli": "~0.1.6",
+    "grunt-contrib-clean": "^0.6.0",
     "grunt-mocha": "^0.4.11",
     "grunt-simple-mocha": "^0.4.0",
     "sauce-tunnel": "^2.1.0",


### PR DESCRIPTION
When I tried building I ran into a couple of issues with the `installcollections` task:
- It was using Linux commands (and I'm on Windows :ghost:)
- It was using a symlink (which doesn't work in Windows without admin privileges) and symlinks aren't packaged by npm, which could lead to issues for people using the package as a library
- There was a regexp which wasn't working

So I replaced the `rm -rf` with grunt-contrib-clean, removed the symlink and fixed the tag list.
