### PR TITLE
Promise upstream update, fixes #316

### DIFF
--- a/polyfills/Promise/config.json
+++ b/polyfills/Promise/config.json
@@ -16,7 +16,8 @@
 		"safari": "* - 7"
 	},
 	"dependencies": [
-		"_enqueueMicrotask"
+		"_enqueueMicrotask",
+		"Array.isArray"
 	],
 	"license": "MIT",
 	"author": "Dmitry Korobkin (https://github.com/Octane/Promise)"

--- a/polyfills/Promise/polyfill.js
+++ b/polyfills/Promise/polyfill.js
@@ -1,336 +1,310 @@
-(function (global) {
-	var
-	STATUS = '[[PromiseStatus]]',
-	VALUE = '[[PromiseValue]]',
-	ON_FUlFILLED = '[[OnFulfilled]]',
-	ON_REJECTED = '[[OnRejected]]',
-	ORIGINAL_ERROR = '[[OriginalError]]',
-	PENDING = 'pending',
-	INTERNAL_PENDING = 'internal pending',
-	FULFILLED = 'fulfilled',
-	REJECTED = 'rejected',
-	NOT_ARRAY = 'not an array.',
-	REQUIRES_NEW = 'constructor Promise requires "new".',
-	CHAINING_CYCLE = 'then() cannot return same Promise that it resolves.',
-	TO_STRING = Object.prototype.toString;
+/**
+ * Promise polyfill v1.0.10
+ * requires setImmediate
+ *
+ * © 2014–2015 Dmitry Korobkin
+ * Released under the MIT license
+ * github.com/Octane/Promise
+ */
+(function (global) {'use strict';
 
-	function InternalError(originalError) {
-		this[ORIGINAL_ERROR] = originalError;
-	}
+    var STATUS = '[[PromiseStatus]]';
+    var VALUE = '[[PromiseValue]]';
+    var ON_FUlFILLED = '[[OnFulfilled]]';
+    var ON_REJECTED = '[[OnRejected]]';
+    var ORIGINAL_ERROR = '[[OriginalError]]';
+    var PENDING = 'pending';
+    var INTERNAL_PENDING = 'internal pending';
+    var FULFILLED = 'fulfilled';
+    var REJECTED = 'rejected';
+    var NOT_ARRAY = 'not an array.';
+    var REQUIRES_NEW = 'constructor Promise requires "new".';
+    var CHAINING_CYCLE = 'then() cannot return same Promise that it resolves.';
 
-	function isInternalError(anything) {
-		return anything instanceof InternalError;
-	}
+    var setImmediate = _enqueueMicrotask;
+    var isArray = Array.isArray || function (anything) {
+        return Object.prototype.toString.call(anything) == '[object Array]';
+    };
 
-	function isObject(anything) {
-		//Object.create(null) instanceof Object → false
-		return Object(anything) === anything;
-	}
+    function InternalError(originalError) {
+        this[ORIGINAL_ERROR] = originalError;
+    }
 
-	function isCallable(anything) {
-		return typeof anything === 'function';
-	}
+    function isInternalError(anything) {
+        return anything instanceof InternalError;
+    }
 
-	function isPromise(anything) {
-		return anything instanceof Promise;
-	}
+    function isObject(anything) {
+        //Object.create(null) instanceof Object → false
+        return Object(anything) === anything;
+    }
 
-	function identity(value) {
-		return value;
-	}
+    function isCallable(anything) {
+        return typeof anything == 'function';
+    }
 
-	function thrower(reason) {
-		throw reason;
-	}
+    function isPromise(anything) {
+        return anything instanceof Promise;
+    }
 
-	function enqueue(promise, onFulfilled, onRejected) {
-		if (!promise[ON_FUlFILLED]) {
-			promise[ON_FUlFILLED] = [];
-			promise[ON_REJECTED] = [];
-		}
+    function identity(value) {
+        return value;
+    }
 
-		promise[ON_FUlFILLED].push(onFulfilled);
-		promise[ON_REJECTED].push(onRejected);
-	}
+    function thrower(reason) {
+        throw reason;
+    }
 
-	function clearAllQueues(promise) {
-		delete promise[ON_FUlFILLED];
-		delete promise[ON_REJECTED];
-	}
+    function enqueue(promise, onFulfilled, onRejected) {
+        if (!promise[ON_FUlFILLED]) {
+            promise[ON_FUlFILLED] = [];
+            promise[ON_REJECTED] = [];
+        }
+        promise[ON_FUlFILLED].push(onFulfilled);
+        promise[ON_REJECTED].push(onRejected);
+    }
 
-	function callEach(queue) {
-		var
-		length = queue.length,
-		index = -1;
+    function clearAllQueues(promise) {
+        delete promise[ON_FUlFILLED];
+        delete promise[ON_REJECTED];
+    }
 
-		while (++index < length) {
-			queue[index]();
-		}
-	}
+    function callEach(queue) {
+        var i;
+        var length = queue.length;
+        for (i = 0; i < length; i++) {
+            queue[i]();
+        }
+    }
 
-	function call(resolve, reject, value) {
-		var anything = toPromise(value);
+    function call(resolve, reject, value) {
+        var anything = toPromise(value);
+        if (isPromise(anything)) {
+            anything.then(resolve, reject);
+        } else if (isInternalError(anything)) {
+            reject(anything[ORIGINAL_ERROR]);
+        } else {
+            resolve(value);
+        }
+    }
 
-		if (isPromise(anything)) {
-			anything.then(resolve, reject);
-		} else if (isInternalError(anything)) {
-			reject(anything[ORIGINAL_ERROR]);
-		} else {
-			resolve(value);
-		}
-	}
+    function toPromise(anything) {
+        var then;
+        if (isPromise(anything)) {
+            return anything;
+        }
+        if(isObject(anything)) {
+            try {
+                then = anything.then;
+            } catch (error) {
+                return new InternalError(error);
+            }
+            if (isCallable(then)) {
+                return new Promise(function (resolve, reject) {
+                    setImmediate(function () {
+                        try {
+                            then.call(anything, resolve, reject);
+                        } catch (error) {
+                            reject(error);
+                        }
+                    });
+                });
+            }
+        }
+        return null;
+    }
 
-	function toPromise(anything) {
-		var then;
+    function resolvePromise(promise, resolver) {
+        function resolve(value) {
+            if (promise[STATUS] == PENDING) {
+                fulfillPromise(promise, value);
+            }
+        }
+        function reject(reason) {
+            if (promise[STATUS] == PENDING) {
+                rejectPromise(promise, reason);
+            }
+        }
+        try {
+            resolver(resolve, reject);
+        } catch(error) {
+            reject(error);
+        }
+    }
 
-		if (isPromise(anything)) {
-			return anything;
-		}
+    function fulfillPromise(promise, value) {
+        var queue;
+        var anything = toPromise(value);
+        if (isPromise(anything)) {
+            promise[STATUS] = INTERNAL_PENDING;
+            anything.then(
+                function (value) {
+                    fulfillPromise(promise, value);
+                },
+                function (reason) {
+                    rejectPromise(promise, reason);
+                }
+            );
+        } else if (isInternalError(anything)) {
+            rejectPromise(promise, anything[ORIGINAL_ERROR]);
+        } else {
+            promise[STATUS] = FULFILLED;
+            promise[VALUE] = value;
+            queue = promise[ON_FUlFILLED];
+            if (queue && queue.length) {
+                clearAllQueues(promise);
+                callEach(queue);
+            }
+        }
+    }
 
-		if(isObject(anything)) {
-			try {
-				then = anything.then;
-			} catch (error) {
-				return new InternalError(error);
-			}
+    function rejectPromise(promise, reason) {
+        var queue = promise[ON_REJECTED];
+        promise[STATUS] = REJECTED;
+        promise[VALUE] = reason;
+        if (queue && queue.length) {
+            clearAllQueues(promise);
+            callEach(queue);
+        }
+    }
 
-			if (isCallable(then)) {
-				return new Promise(function (resolve, reject) {
-					_enqueueMicrotask(function () {
-						try {
-							then.call(anything, resolve, reject);
-						} catch (error) {
-							reject(error);
-						}
-					});
-				});
-			}
-		}
-		return null;
-	}
+    function Promise(resolver) {
+        var promise = this;
+        if (!isPromise(promise)) {
+            throw new TypeError(REQUIRES_NEW);
+        }
+        promise[STATUS] = PENDING;
+        promise[VALUE] = undefined;
+        resolvePromise(promise, resolver);
+    }
 
-	function resolvePromise(promise, resolver) {
-		function resolve(value) {
-			if (promise[STATUS] === PENDING) {
-				fulfillPromise(promise, value);
-			}
-		}
+    Promise.prototype.then = function (onFulfilled, onRejected) {
+        var promise = this;
+        var nextPromise;
+        onFulfilled = isCallable(onFulfilled) ? onFulfilled : identity;
+        onRejected = isCallable(onRejected) ? onRejected : thrower;
+        nextPromise = new Promise(function (resolve, reject) {
+            function tryCall(func) {
+                var value;
+                try {
+                    value = func(promise[VALUE]);
+                } catch (error) {
+                    reject(error);
+                    return;
+                }
+                if (value === nextPromise) {
+                    reject(new TypeError(CHAINING_CYCLE));
+                } else {
+                    call(resolve, reject, value);
+                }
+            }
+            function asyncOnFulfilled() {
+                setImmediate(tryCall, onFulfilled);
+            }
+            function asyncOnRejected() {
+                setImmediate(tryCall, onRejected);
+            }
+            switch (promise[STATUS]) {
+                case FULFILLED:
+                    asyncOnFulfilled();
+                    break;
+                case REJECTED:
+                    asyncOnRejected();
+                    break;
+                default:
+                    enqueue(promise, asyncOnFulfilled, asyncOnRejected);
+            }
+        });
+        return nextPromise;
+    };
 
-		function reject(reason) {
-			if (promise[STATUS] === PENDING) {
-				rejectPromise(promise, reason);
-			}
-		}
+    Promise.prototype['catch'] = function (onRejected) {
+        return this.then(identity, onRejected);
+    };
 
-		try {
-			resolver(resolve, reject);
-		} catch (error) {
-			reject(error);
-		}
-	}
+    Promise.resolve = function (value) {
+        var anything = toPromise(value);
+        if (isPromise(anything)) {
+            return anything;
+        }
+        return new Promise(function (resolve, reject) {
+            if (isInternalError(anything)) {
+                reject(anything[ORIGINAL_ERROR]);
+            } else {
+                resolve(value);
+            }
+        });
+    };
 
-	function fulfillPromise(promise, value) {
-		var
-		anything = toPromise(value),
-		queue;
+    Promise.reject = function (reason) {
+        return new Promise(function (resolve, reject) {
+            reject(reason);
+        });
+    };
 
-		if (isPromise(anything)) {
-			promise[STATUS] = INTERNAL_PENDING;
+    Promise.race = function (values) {
+        return new Promise(function (resolve, reject) {
+            var i;
+            var length;
+            if (isArray(values)) {
+                length = values.length;
+                for (i = 0; i < length; i++) {
+                    call(resolve, reject, values[i]);
+                }
+            } else {
+                reject(new TypeError(NOT_ARRAY));
+            }
+        });
+    };
 
-			anything.then(
-				function (value) {
-					fulfillPromise(promise, value);
-				},
-				function (reason) {
-					rejectPromise(promise, reason);
-				}
-			);
-		} else if (isInternalError(anything)) {
-			rejectPromise(promise, anything[ORIGINAL_ERROR]);
-		} else {
-			promise[STATUS] = FULFILLED;
-			promise[VALUE] = value;
+    Promise.all = function (values) {
+        return new Promise(function (resolve, reject) {
+            var fulfilledCount = 0;
+            var promiseCount = 0;
+            var anything;
+            var length;
+            var value;
+            var i;
+            if (isArray(values)) {
+                values = values.slice(0);
+                length = values.length;
+                for (i = 0; i < length; i++) {
+                    value = values[i];
+                    anything = toPromise(value);
+                    if (isPromise(anything)) {
+                        promiseCount++;
+                        anything.then(
+                            function (index) {
+                                return function (value) {
+                                    values[index] = value;
+                                    fulfilledCount++;
+                                    if (fulfilledCount == promiseCount) {
+                                        resolve(values);
+                                    }
+                                };
+                            }(i),
+                            reject
+                        );
+                    } else if (isInternalError(anything)) {
+                        reject(anything[ORIGINAL_ERROR]);
+                    } else {
+                        //[1, , 3] → [1, undefined, 3]
+                        values[i] = value;
+                    }
+                }
+                if (!promiseCount) {
+                    resolve(values);
+                }
+            } else {
+                reject(new TypeError(NOT_ARRAY));
+            }
+        });
+    };
 
-			queue = promise[ON_FUlFILLED];
+    if (typeof module != 'undefined' && module.exports) {
+        module.exports = global.Promise || Promise;
+    } else if (!global.Promise) {
+        global.Promise = Promise;
+    }
 
-			if (queue && queue.length) {
-				clearAllQueues(promise);
-
-				callEach(queue);
-			}
-		}
-	}
-
-	function rejectPromise(promise, reason) {
-		var queue = promise[ON_REJECTED];
-
-		promise[STATUS] = REJECTED;
-		promise[VALUE] = reason;
-
-		if (queue && queue.length) {
-			clearAllQueues(promise);
-
-			callEach(queue);
-		}
-	}
-
-	function Promise(resolver) {
-		var promise = this;
-
-		if (!isPromise(promise)) {
-			throw new TypeError(REQUIRES_NEW);
-		}
-
-		promise[STATUS] = PENDING;
-		promise[VALUE] = undefined;
-
-		resolvePromise(promise, resolver);
-	}
-
-	Promise.prototype.then = function (onFulfilled, onRejected) {
-		var
-		promise = this,
-		nextPromise;
-
-		onFulfilled = isCallable(onFulfilled) ? onFulfilled : identity;
-		onRejected = isCallable(onRejected) ? onRejected : thrower;
-
-		nextPromise = new Promise(function (resolve, reject) {
-			function tryCall(func) {
-				var value;
-
-				try {
-					value = func(promise[VALUE]);
-				} catch (error) {
-					reject(error);
-					return;
-				}
-				if (value === nextPromise) {
-					reject(new TypeError(CHAINING_CYCLE));
-				} else {
-					call(resolve, reject, value);
-				}
-			}
-
-			function asyncOnFulfilled() {
-				_enqueueMicrotask(function () {
-					tryCall(onFulfilled);
-				});
-			}
-
-			function asyncOnRejected() {
-				_enqueueMicrotask(function () {
-					tryCall(onRejected);
-				});
-			}
-
-			switch (promise[STATUS]) {
-				case FULFILLED:
-					asyncOnFulfilled();
-					break;
-
-				case REJECTED:
-					asyncOnRejected();
-					break;
-
-				default:
-					enqueue(promise, asyncOnFulfilled, asyncOnRejected);
-			}
-		});
-
-		return nextPromise;
-	};
-
-	Promise.prototype['catch'] = function (onRejected) {
-		return this.then(identity, onRejected);
-	};
-
-	Promise.resolve = function (value) {
-		var anything = toPromise(value);
-
-		if (isPromise(anything)) {
-			return anything;
-		}
-
-		return new Promise(function (resolve, reject) {
-			if (isInternalError(anything)) {
-				reject(anything[ORIGINAL_ERROR]);
-			} else {
-				resolve(value);
-			}
-		});
-	};
-
-	Promise.reject = function (reason) {
-		return new Promise(function (resolve, reject) {
-			reject(reason);
-		});
-	};
-
-	Promise.race = function (values) {
-		return new Promise(function (resolve, reject) {
-			var
-			index = -1,
-			length;
-
-			if (TO_STRING.call(values) === '[object Array]') {
-				length = values.length;
-
-				while (++index < length) {
-					call(resolve, reject, values[index]);
-				}
-			} else {
-				reject(new TypeError(NOT_ARRAY));
-			}
-		});
-	};
-
-	Promise.all = function (values) {
-		return new Promise(function (resolve, reject) {
-			var
-			fulfilledCount = 0,
-			promiseCount = 0,
-			index = -1,
-			anything, length, value;
-
-			if (TO_STRING.call(values) === '[object Array]') {
-				values = values.slice(0);
-				length = values.length;
-
-				while (++index < length) {
-					value = values[index];
-					anything = toPromise(value);
-
-					if (isPromise(anything)) {
-						++promiseCount;
-
-						anything.then(function (index) {
-							return function (value) {
-								values[index] = value;
-
-								++fulfilledCount;
-
-								if (fulfilledCount === promiseCount) {
-									resolve(values);
-								}
-							};
-						}(index), reject);
-					} else if (isInternalError(anything)) {
-						reject(anything[ORIGINAL_ERROR]);
-					} else {
-						//[1, , 3] → [1, undefined, 3]
-						values[index] = value;
-					}
-				}
-
-				if (!promiseCount) {
-					resolve(values);
-				}
-			} else {
-				reject(new TypeError(NOT_ARRAY));
-			}
-		});
-	};
-
-	global.Promise = Promise;
-})(this);
+}(this));

--- a/polyfills/Promise/polyfill.js
+++ b/polyfills/Promise/polyfill.js
@@ -21,7 +21,9 @@
     var REQUIRES_NEW = 'constructor Promise requires "new".';
     var CHAINING_CYCLE = 'then() cannot return same Promise that it resolves.';
 
+    // Polyfill service change: The following line is modified from the upstream source
     var setImmediate = _enqueueMicrotask;
+
     var isArray = Array.isArray || function (anything) {
         return Object.prototype.toString.call(anything) == '[object Array]';
     };

--- a/polyfills/_enqueueMicrotask/config.json
+++ b/polyfills/_enqueueMicrotask/config.json
@@ -8,20 +8,20 @@
 		"chrome": "* - 17",
 		"firefox": "* - 13",
 		"ie": "* - 10",
-		"ios": "* - 5.1",
-		"opera": "* - 12.1",
-		"safari": "* - 5.1"
+		"ios": "* - 5",
+		"opera": "* - 12",
+		"safari": "* - 5"
 	},
 	"variants": {
 		"MutationObserver": {
 			"browsers": {
-				"android": "4.4",
-				"chrome": "18",
-				"firefox": "14",
-				"ie": "11",
-				"ios": "6.1",
-				"opera": "15",
-				"safari": "6"
+				"android": "4.4 - *",
+				"chrome": "18 - *",
+				"firefox": "14 - *",
+				"ie": "11 - *",
+				"ios": "6 - *",
+				"opera": "15 - *",
+				"safari": "6 - *"
 			},
 			"dependencies": [
 				"MutationObserver"

--- a/polyfills/_enqueueMicrotask/polyfill-MutationObserver.js
+++ b/polyfills/_enqueueMicrotask/polyfill-MutationObserver.js
@@ -22,6 +22,8 @@ var _enqueueMicrotask = function () {
 	});
 
 	return function (callback) {
+		var args = [].slice.call(arguments, 1);
+		if (args) callback = callback.bind.apply(callback, [this].concat(args));
 		callbacks[callbacks.length] = callback;
 
 		if (!flushing) {

--- a/polyfills/_enqueueMicrotask/polyfill.js
+++ b/polyfills/_enqueueMicrotask/polyfill.js
@@ -19,6 +19,8 @@ var _enqueueMicrotask = function () {
 	setInterval(flush, 1);
 
 	return function (callback) {
+		var args = [].slice.call(arguments, 1);
+		if (args) callback = callback.bind.apply(callback, [this].concat(args));
 		callbacks[callbacks.length] = callback;
 
 		if (!flushing) {

--- a/polyfills/_mutation/config.json
+++ b/polyfills/_mutation/config.json
@@ -6,7 +6,7 @@
 		"firefox": "*",
 		"ios_chr": "*",
 		"ios_saf": "*",
-		"ie": "6 - *",
+		"ie": "*",
 		"opera": "*",
 		"op_mini": "*",
 		"safari": "*"


### PR DESCRIPTION
Proposed update to Promise to bring it into line with the upstream source.  See #316 for rationale.

Additional changes beyond pasting in the current source from the upstream repo:
- Edited the imported polyfill to assign `_enqueueMicrotask` to the private `setImmediate`.  Signposted this change with a comment
- Added support to `_enqueueMicrotask` for multiple arguments (required by the promise polyfill)
- Made all private features target all browsers (by definition, no browser will have them natively, and the service will ensure they are only served when required)
- Update Promise config to require `Array.isArray` since it is used by the Promise polyfill

@jonathantneal @Octane @juandopazo are you OK with this approach?
