### PR TITLE
fix polyfill String.prototype.endsWith

### DIFF
--- a/polyfills/String.prototype.endsWith/polyfill.js
+++ b/polyfills/String.prototype.endsWith/polyfill.js
@@ -1,5 +1,5 @@
 String.prototype.endsWith = function (string) {
 	var index = arguments.length < 2 ? this.length : arguments[1];
-
-	return this.indexOf(string) === index - string.length;
+	var foundIndex = this.indexOf(string);
+	return foundIndex !== -1 && foundIndex === index - string.length;
 };


### PR DESCRIPTION
endsWith doesnt return the right result when the length of string in arguments is equals to the other string's length -1

For exemple, if you have this = 'a' and string = 'ab', 'a'.endsWith('ab') will return true.
