### PR TITLE
String.prototype.endsWith updated browser support for chrome 41

### DIFF
--- a/polyfills/String.prototype.endsWith/config.json
+++ b/polyfills/String.prototype.endsWith/config.json
@@ -6,7 +6,7 @@
 	"browsers": {
 		"android": "*",
 		"bb": "*",
-		"chrome": "*",
+		"chrome": "<=40",
 		"firefox": "3.6 - 17",
 		"opera": "10 - 18",
 		"safari": "*",


### PR DESCRIPTION
According to [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith) String.prototype.endsWith is available in chrome since version 41
