### PR TITLE
_enqueueMicrotask should target all browser versions

### DIFF
--- a/polyfills/_enqueueMicrotask/config.json
+++ b/polyfills/_enqueueMicrotask/config.json
@@ -4,13 +4,13 @@
 		"caniuse:promises"
 	],
 	"browsers": {
-		"android": "* - 4.3",
-		"chrome": "* - 17",
-		"firefox": "* - 13",
-		"ie": "* - 10",
-		"ios": "* - 5.1",
-		"opera": "* - 12.1",
-		"safari": "* - 5.1"
+		"android": "*",
+		"chrome": "*",
+		"firefox": "*",
+		"ie": "*",
+		"ios": "*",
+		"opera": "*",
+		"safari": "*"
 	},
 	"variants": {
 		"MutationObserver": {

--- a/polyfills/_enqueueMicrotask/config.json
+++ b/polyfills/_enqueueMicrotask/config.json
@@ -1,27 +1,28 @@
+
 {
 	"aliases": [
 		"modernizr:promises",
 		"caniuse:promises"
 	],
 	"browsers": {
-		"android": "*",
-		"chrome": "*",
-		"firefox": "*",
-		"ie": "*",
-		"ios": "*",
-		"opera": "*",
-		"safari": "*"
+		"android": "* - 4.3",
+		"chrome": "* - 17",
+		"firefox": "* - 13",
+		"ie": "* - 10",
+		"ios": "* - 5.1",
+		"opera": "* - 12.1",
+		"safari": "* - 5.1"
 	},
 	"variants": {
 		"MutationObserver": {
 			"browsers": {
-				"android": "4.4",
-				"chrome": "18",
-				"firefox": "14",
-				"ie": "11",
-				"ios": "6.1",
-				"opera": "15",
-				"safari": "6"
+				"android": "4.4 - *",
+				"chrome": "18 - *",
+				"firefox": "14 - *",
+				"ie": "11 - *",
+				"ios": "5.2 - *",
+				"opera": "12.2 - *",
+				"safari": "5.2 - *"
 			},
 			"dependencies": [
 				"MutationObserver"


### PR DESCRIPTION
If there is a dependency on the _enqueueMicrotask it should always
be included regardless of the browser version.

This is because it is a non-standard browser API specific to some polyfills
where efficient async task scheduling is required.
