### PR TITLE
Add (most) missing docs links

### DIFF
--- a/polyfills/Document/config.json
+++ b/polyfills/Document/config.json
@@ -12,5 +12,6 @@
 			}
 		}
 	},
-	"spec": "http://dom.spec.whatwg.org/#interface-document"
+	"spec": "http://dom.spec.whatwg.org/#interface-document",
+	"docs": "https://developer.mozilla.org/en/docs/Web/API/Document"
 }

--- a/polyfills/Event.DOMContentLoaded/config.json
+++ b/polyfills/Event.DOMContentLoaded/config.json
@@ -8,5 +8,6 @@
 	},
 	"dependencies": [
 		"Event"
-	]
+	],
+	"docs": "https://developer.mozilla.org/en-US/docs/Web/Events/DOMContentLoaded"
 }

--- a/polyfills/Event.focusin/config.json
+++ b/polyfills/Event.focusin/config.json
@@ -7,5 +7,6 @@
 	},
 	"dependencies": [
 		"Event"
-	]
+	],
+	"docs": "https://developer.mozilla.org/en-US/docs/Web/Events/focusin"
 }

--- a/polyfills/Event.hashchange/config.json
+++ b/polyfills/Event.hashchange/config.json
@@ -10,5 +10,6 @@
 	},
 	"dependencies": [
 		"Event"
-	]
+	],
+	"docs": "https://developer.mozilla.org/en-US/docs/Web/Events/hashchange"
 }

--- a/polyfills/Event/config.json
+++ b/polyfills/Event/config.json
@@ -22,5 +22,6 @@
 				"Element"
 			]
 		}
-	}
+	},
+	"docs": "https://developer.mozilla.org/en/docs/Web/API/Event"
 }

--- a/polyfills/HTMLDocument/config.json
+++ b/polyfills/HTMLDocument/config.json
@@ -1,5 +1,6 @@
 {
 	"browsers": {
 		"ie": "9"
-	}
+	},
+	"docs": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLDocument"
 }

--- a/polyfills/Node.prototype.contains/config.json
+++ b/polyfills/Node.prototype.contains/config.json
@@ -20,5 +20,6 @@
 				"ie": "9 - *"
 			}
 		}
-	}
+	},
+	"docs": "https://developer.mozilla.org/en-US/docs/Web/API/Node/contains"
 }

--- a/polyfills/Object.assign/config.json
+++ b/polyfills/Object.assign/config.json
@@ -17,5 +17,6 @@
 		"op_mob": "*",
 		"op_mini": "*",
 		"safari": "*"
-	}
+	},
+	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign"
 }

--- a/polyfills/Object.create/config.json
+++ b/polyfills/Object.create/config.json
@@ -10,5 +10,6 @@
 	},
 	"dependencies": [
 		"Object.defineProperties"
-	]
+	],
+	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create"
 }

--- a/polyfills/Object.defineProperties/config.json
+++ b/polyfills/Object.defineProperties/config.json
@@ -10,5 +10,6 @@
 	},
 	"dependencies": [
 		"Object.defineProperty"
-	]
+	],
+	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperties"
 }

--- a/polyfills/Object.defineProperty/config.json
+++ b/polyfills/Object.defineProperty/config.json
@@ -20,5 +20,6 @@
 				"ie": "8"
 			}
 		}
-	}
+	},
+	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty"
 }

--- a/polyfills/Object.getOwnPropertyNames/config.json
+++ b/polyfills/Object.getOwnPropertyNames/config.json
@@ -14,5 +14,6 @@
 				"ie": "6 - 8"
 			}
 		}
-	}
+	},
+	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyNames"
 }

--- a/polyfills/Object.getPrototypeOf/config.json
+++ b/polyfills/Object.getPrototypeOf/config.json
@@ -8,5 +8,6 @@
 		"ie": "6 - 8",
 		"firefox": "3.6",
 		"safari": "4"
-	}
+	},
+	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getPrototypeOf"
 }

--- a/polyfills/Object.is/config.json
+++ b/polyfills/Object.is/config.json
@@ -14,5 +14,6 @@
 		"op_mob": "*",
 		"safari": "*",
 		"ios_saf": "*"
-	}
+	},
+	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is"
 }

--- a/polyfills/Object.keys/config.json
+++ b/polyfills/Object.keys/config.json
@@ -11,5 +11,6 @@
 		"opera": "<12"
 	},
 	"author": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys",
-	"license": "CC0"
+	"license": "CC0",
+	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys"
 }

--- a/polyfills/String.prototype.contains/config.json
+++ b/polyfills/String.prototype.contains/config.json
@@ -11,5 +11,6 @@
 	},
 	"dependencies": [
 		"String.prototype.includes"
-	]
+	],
+	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes#String.prototype.contains"
 }

--- a/polyfills/String.prototype.endsWith/config.json
+++ b/polyfills/String.prototype.endsWith/config.json
@@ -12,5 +12,6 @@
 		"safari": "*",
 		"ie": "6 - *",
 		"ios_saf": "*"
-	}
+	},
+	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith"
 }

--- a/polyfills/String.prototype.includes/config.json
+++ b/polyfills/String.prototype.includes/config.json
@@ -13,5 +13,6 @@
 		"safari": "*",
 		"ie": "6 - *",
 		"ios_saf": "*"
-	}
+	},
+	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes"
 }

--- a/polyfills/String.prototype.repeat/config.json
+++ b/polyfills/String.prototype.repeat/config.json
@@ -12,5 +12,6 @@
 		"safari": "*",
 		"ie": "6 - *",
 		"ios_saf": "*"
-	}
+	},
+	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/repeat"
 }

--- a/polyfills/String.prototype.startsWith/config.json
+++ b/polyfills/String.prototype.startsWith/config.json
@@ -12,5 +12,6 @@
 		"safari": "*",
 		"ie": "6 - *",
 		"ios_saf": "*"
-	}
+	},
+	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith"
 }

--- a/polyfills/String.prototype.trim/config.json
+++ b/polyfills/String.prototype.trim/config.json
@@ -7,5 +7,6 @@
 	"browsers": {
 		"ie": "6 - 8",
 		"safari": "4"
-	}
+	},
+	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/Trim"
 }

--- a/polyfills/URL/config.json
+++ b/polyfills/URL/config.json
@@ -13,5 +13,6 @@
 	],
 
 	"license": "CC0",
-	"repo" : "https://github.com/inexorabletash/polyfill"
+	"repo" : "https://github.com/inexorabletash/polyfill",
+	"docs": "https://developer.mozilla.org/en-US/docs/Web/API/URL"
 }

--- a/polyfills/WeakMap/config.json
+++ b/polyfills/WeakMap/config.json
@@ -15,5 +15,6 @@
 		"Array.prototype.forEach",
 		"Date.now"
 	],
-	"license": "https://github.com/webcomponents/webcomponentsjs/blob/master/LICENSE.md"
+	"license": "https://github.com/webcomponents/webcomponentsjs/blob/master/LICENSE.md",
+	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap"
 }

--- a/polyfills/WeakSet/config.json
+++ b/polyfills/WeakSet/config.json
@@ -16,5 +16,6 @@
 		"Date.now"
 	],
 	"repo": "https://github.com/webcomponents/webcomponentsjs",
-	"license": "https://github.com/webcomponents/webcomponentsjs/blob/master/LICENSE.md"
+	"license": "https://github.com/webcomponents/webcomponentsjs/blob/master/LICENSE.md",
+	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakSet"
 }

--- a/polyfills/Window/config.json
+++ b/polyfills/Window/config.json
@@ -14,5 +14,6 @@
 				"safari": "5.1"
 			}
 		}
-	}
+	},
+	"docs": "https://developer.mozilla.org/en/docs/Web/API/Window"
 }

--- a/polyfills/XMLHttpRequest/config.json
+++ b/polyfills/XMLHttpRequest/config.json
@@ -7,5 +7,6 @@
 	},
 	"dependencies": [
 		"Event"
-	]
+	],
+	"docs": "https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest"
 }

--- a/polyfills/fetch/config.json
+++ b/polyfills/fetch/config.json
@@ -18,5 +18,6 @@
 	"repo": "https://github.com/github/fetch",
 	"notes": [
 		"Uses FileReader and Blob if they exist, and depends on FormData"
-	]
+	],
+	"docs": "https://developer.mozilla.org/en-US/docs/Web/API/GlobalFetch/fetch"
 }

--- a/polyfills/performance.now/config.json
+++ b/polyfills/performance.now/config.json
@@ -11,5 +11,6 @@
 	},
 	"dependencies": [
 		"Date.now"
-	]
+	],
+	"docs": "https://developer.mozilla.org/en-US/docs/Web/API/Performance/now"
 }

--- a/polyfills/requestAnimationFrame/config.json
+++ b/polyfills/requestAnimationFrame/config.json
@@ -32,5 +32,6 @@
 		"Date.now",
 		"performance.now"
 	],
-	"license": "requestAnimationFrame polyfill by Erik Möller, fixes from Paul Irish, Tino Zijdel, and Jonathan Neal"
+	"license": "requestAnimationFrame polyfill by Erik Möller, fixes from Paul Irish, Tino Zijdel, and Jonathan Neal",
+	"docs": "https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame"
 }

--- a/polyfills/screen.orientation/config.json
+++ b/polyfills/screen.orientation/config.json
@@ -14,5 +14,6 @@
 				"ie_mob": "11 - *"
 			}
 		}
-	}
+	},
+	"docs": "https://developer.mozilla.org/en-US/docs/Web/API/Screen/orientation"
 }

--- a/polyfills/setImmediate/config.json
+++ b/polyfills/setImmediate/config.json
@@ -11,5 +11,6 @@
 				"ie": "* - 9"
 			}
 		}
-	}
+	},
+	"docs": "https://developer.mozilla.org/en-US/docs/Web/API/Window/setImmediate"
 }


### PR DESCRIPTION
couple of difficult ones:
- `viewport` – can't think of any particular docs page for this. the polyfill just ensures a mixed bag of `window.*` dimension properties are available (`innerHeight innerWidth pageXOffset pageYOffset scrollX scrollY`).
- `~html5-elements` – again not obvious how to document this. maybe the link should be to [html5 shiv on wikipedia](http://en.wikipedia.org/wiki/HTML5_Shiv)? I left it out for now
