### PR TITLE
Add note about EventTarget methods

### DIFF
--- a/polyfills/Event/config.json
+++ b/polyfills/Event/config.json
@@ -23,5 +23,8 @@
 			]
 		}
 	},
-	"docs": "https://developer.mozilla.org/en/docs/Web/API/Event"
+	"docs": "https://developer.mozilla.org/en/docs/Web/API/Event",
+	"notes": [
+		"This includes the [EventTarget](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener) methods `addEventListener`, `removeEventListener` and `dispatchEvent` for IE6-8."
+	]
 }


### PR DESCRIPTION
(addresses #358)

MDN's [Event](https://developer.mozilla.org/en/docs/Web/API/Event) page makes no mention of `addEventListener`, `removeEventListener` and `dispatchEvent`. These methods are part of a separate interface called [EventTarget](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget).

This PR adds a note to explain that with Event you also get EventTarget methods.

(in fact, as these are separate things in the spec [[Event](https://dom.spec.whatwg.org/#interface-event), [EventTarget](https://dom.spec.whatwg.org/#interface-eventtarget)], maybe we should have them as separate polyfills?)
