### PR TITLE
Update browser spec for Array.prototype.findIndex

### DIFF
--- a/polyfills/Array.prototype.findIndex/config.json
+++ b/polyfills/Array.prototype.findIndex/config.json
@@ -4,11 +4,11 @@
 		"modernizr:es6array"
 	],
 	"browsers": {
-		"chrome": "* - 29",
+		"chrome": "*",
 		"firefox": "3.6 - 24",
 		"ie": "*",
-		"opera": "* - 16",
-		"safari": "* - 7"
+		"opera": "*",
+		"safari": "* - 7.0"
 	},
 	"dependencies": [
 		"Object.defineProperty"


### PR DESCRIPTION
Applies the same change as: https://github.com/andyburke/polyfill-service/commit/9f5ea576033a4bf295b41a1027d48f833046d933
