### PR TITLE
Added failing test of matchMedia using dppx

### DIFF
--- a/polyfills/matchMedia/polyfill.js
+++ b/polyfills/matchMedia/polyfill.js
@@ -13,11 +13,11 @@
 			.replace(/,/g, '||')
 			.replace(/\band\b/g, '&&')
 			.replace(/dpi/g, '')
-			.replace(/(\d+)(cm|em|in|mm|pc|pt|px|rem)/g, function ($0, $1, $2) {
+			.replace(/(\d+)(cm|em|in|dppx|mm|pc|pt|px|rem)/g, function ($0, $1, $2) {
 				return $1 * (
 					$2 === 'cm' ? 0.3937 * 96 : (
 						$2 === 'em' || $2 === 'rem' ? 16 : (
-							$2 === 'in' ? 96 : (
+							$2 === 'in' || $2 === 'dppx' ? 96 : (
 								$2 === 'mm' ? 0.3937 * 96 / 10 : (
 									$2 === 'pc' ? 12 * 96 / 72 : (
 										$2 === 'pt' ? 96 / 72 : 1

--- a/polyfills/matchMedia/tests.js
+++ b/polyfills/matchMedia/tests.js
@@ -13,3 +13,9 @@ it("should generate valid Javascript for multiple dimensions", function() {
 		window.matchMedia('(min-width: 1px) and (max-width: 1000px)');
 	}).not.to.throwException();
 });
+
+it("should generate valid Javascript for dppx", function() {
+	expect(function() {
+		window.matchMedia('(min-resolution: 2dppx)');
+	}).not.to.throwException();
+});


### PR DESCRIPTION
When using the unit dppx in a media query the `matchMedia` polyfill throws an error. Note this happens on all browsers if you force the polyfill. I've added a failing test for it though I have yet to look into fixing it incase anyone else has a better understanding as to why it is failing.
