### PR TITLE
Updated config for String.prototype.includes to match all Firefox versions

### DIFF
--- a/polyfills/String.prototype.includes/config.json
+++ b/polyfills/String.prototype.includes/config.json
@@ -8,7 +8,7 @@
 		"android": "*",
 		"bb": "*",
 		"chrome": "*",
-		"firefox": "3.6 - 17",
+		"firefox": "*",
 		"opera": "10 - 18",
 		"safari": "*",
 		"ie": "6 - *",


### PR DESCRIPTION
String.prototype.includes is not available in Firefox (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes#Browser_compatibility) so updated the config so that the polyfill is included for all versions (incidentally this is what the feature page list implies).
