### PR TITLE
add test and fix matchMedia operator "only"

### DIFF
--- a/polyfills/matchMedia/polyfill.js
+++ b/polyfills/matchMedia/polyfill.js
@@ -1,8 +1,7 @@
 (function (global) {
 	function evalQuery(query) {
 		/* jshint evil: true */
-		return new Function('media', 'try{ return !!(%s) }catch(e){ return false }'
-			.replace('%s', query||'true')
+		query = (query || 'true')
 			.replace(/^only\s+/, '')
 			.replace(/(device)-([\w.]+)/g, '$1.$2')
 			.replace(/([\w.]+)\s*:/g, 'media.$1 ===')
@@ -27,7 +26,9 @@
 						)
 					)
 				);
-			})
+			});
+		return new Function('media', 'try{ return !!(%s) }catch(e){ return false }'
+			.replace('%s', query)
 		)({
 			width: global.innerWidth,
 			height: global.innerHeight,

--- a/polyfills/matchMedia/tests.js
+++ b/polyfills/matchMedia/tests.js
@@ -3,6 +3,11 @@ it("should match screen", function() {
 	expect(mql.matches).to.be(true);
 });
 
+it("should ignore 'only'", function() {
+	var mql = window.matchMedia('only screen');
+	expect(mql.matches).to.be(true);
+});
+
 it("should return a MediaQueryList that has a media property representing the media query string", function() {
 	var mql = window.matchMedia('screen');
 	expect(mql.media).to.be('screen');


### PR DESCRIPTION
Support for the matchMedia operator "only" was broken (IE9 error "SCRIPT1006"). The polyfill code only matched in the beginning of the string while there was always parts of the template string before the operator.
