### PR TITLE
Fix String.prototype.endsWith when more than one match is found

### DIFF
--- a/polyfills/String.prototype.endsWith/polyfill.js
+++ b/polyfills/String.prototype.endsWith/polyfill.js
@@ -1,5 +1,5 @@
 String.prototype.endsWith = function (string) {
 	var index = arguments.length < 2 ? this.length : arguments[1];
-	var foundIndex = this.indexOf(string);
+	var foundIndex = this.lastIndexOf(string);
 	return foundIndex !== -1 && foundIndex === index - string.length;
 };

--- a/polyfills/String.prototype.endsWith/tests.js
+++ b/polyfills/String.prototype.endsWith/tests.js
@@ -9,6 +9,7 @@ it('has correct argument length', function () {
 it('works with strings', function () {
 	expect('a'.endsWith('aa')).to.be(false);
 	expect('a'.endsWith('ab')).to.be(false);
+	expect('aa'.endsWith('a')).to.be(true);
 	expect('ab'.endsWith('a')).to.be(false);
 	expect('ab'.endsWith('ab')).to.be(true);
 	expect('ab'.endsWith('b')).to.be(true);


### PR DESCRIPTION
I noticed the `String.prototype.endsWith` is not correct when more than one match is found. Easily fixed by using `lastIndexOf` instead which as far as I know is as well supported as `indexOf`.

I couldn’t get the test environment up so I hope the test passes :smile: 
