### PR TITLE
Do not polyfill fetch for supporting browsers

### DIFF
--- a/polyfills/fetch/config.json
+++ b/polyfills/fetch/config.json
@@ -1,10 +1,10 @@
 {
 	"browsers": {
 		"ie": "*",
-		"firefox": "*",
-		"opera": "*",
+		"firefox": "* - 38",
+		"opera": "* - 28",
 		"safari": "*",
-		"chrome": "*",
+		"chrome": "* - 41",
 		"ios_saf": "*"
 	},
 	"dependencies": [


### PR DESCRIPTION
As per [this](https://developer.mozilla.org/en-US/docs/Web/API/GlobalFetch/fetch#Browser_compatibility) these browsers now support the fetch API.
