### PR TITLE
Strip any mention of the CriOS version from the user agent string

### DIFF
--- a/lib/UA.js
+++ b/lib/UA.js
@@ -81,12 +81,12 @@ var aliases = {
 	}
 };
 
-// Chrome on iOS uses a UIWebView of the underlying platform to render
-// content, by stripping the CriOS string the useragent parser will alias the
+// Chrome and Opera on iOS uses a UIWebView of the underlying platform to render
+// content, by stripping the CriOS or OPiOS strings the useragent parser will alias the
 // user agent to ios_saf for the UIWebView, which is closer to the actual
 // renderer
-function stripCriOS(uaString) {
-	return uaString.replace(/(CriOS\/(\d+)\.(\d+)\.(\d+)\.(\d+))/, '');
+function stripiOSWebViewBrowsers(uaString) {
+	return uaString.replace(/((CriOS|OPiOS)\/(\d+)\.(\d+)\.(\d+)\.(\d+))/, '');
 }
 
 
@@ -97,7 +97,7 @@ var UA = function(uaString) {
 	if (normalized) {
 		this.ua = new useragent.Agent(normalized[1], normalized[2], (normalized[3] || 0), (normalized[4] || 0));
 	} else {
-		this.ua = useragent.lookup(stripCriOS(uaString));
+		this.ua = useragent.lookup(stripiOSWebViewBrowsers(uaString));
 	}
 
 	// For improved cache performance, remove the patch version.  There are few cases in which a patch release drops the requirement for a polyfill, but if so, the polyfill can simply be served unnecessarily to the patch versions that contain the fix, and we can stop targeting at the next minor release.

--- a/lib/UA.js
+++ b/lib/UA.js
@@ -81,6 +81,14 @@ var aliases = {
 	}
 };
 
+// Chrome on iOS uses a UIWebView of the underlying platform to render
+// content, by stripping the CriOS string the useragent parser will alias the
+// user agent to ios_saf for the UIWebView, which is closer to the actual
+// renderer
+function stripCriOS(uaString) {
+	return uaString.replace(/(CriOS\/(\d+)\.(\d+)\.(\d+)\.(\d+))/, '');
+}
+
 
 var UA = function(uaString) {
 	var semver, a;
@@ -89,7 +97,7 @@ var UA = function(uaString) {
 	if (normalized) {
 		this.ua = new useragent.Agent(normalized[1], normalized[2], (normalized[3] || 0), (normalized[4] || 0));
 	} else {
-		this.ua = useragent.lookup(uaString);
+		this.ua = useragent.lookup(stripCriOS(uaString));
 	}
 
 	// For improved cache performance, remove the patch version.  There are few cases in which a patch release drops the requirement for a polyfill, but if so, the polyfill can simply be served unnecessarily to the patch versions that contain the fix, and we can stop targeting at the next minor release.


### PR DESCRIPTION
The UA string is then parsed as the corresponding `ios_saf` version by the user agent library.  This is done "before" the call to user agent.

(See https://developer.chrome.com/multidevice/user-agent#chrome_for_ios_user_agent)

Closes #411 
