### PR TITLE
Cache node_modules on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,6 @@ before_script:
   - npm install -g grunt-cli
 script:
   - npm run-script citest
+cache:
+  directories:
+    - node_modules


### PR DESCRIPTION
Since we are using [container-based infrastructure](http://docs.travis-ci.com/user/workers/container-based-infrastructure/) on Travis, we can cache assets for free.

Considering the biggest bottleneck in our testing is SauceLabs, don't expect a big decrease in CI executing time from this change.

Are there any other assets we should be caching?
