### PR TITLE
Switch from .semver to package.json version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 /polyfills/sources.json
 /test/results
 /.env.json
-/.semver
 /.haikro-cache
 /node-*
 /service-process.pid

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "stop": "forever stop --plain service/index.js",
     "status": "forever list | grep -q service/index.js",
     "prepublish": "grunt build",
-    "deploy": "grunt build && git describe --tags > .semver && haikro build deploy --heroku-token `heroku auth:token` --commit `git rev-parse HEAD` --app",
+    "deploy": "grunt build && haikro build deploy --heroku-token `heroku auth:token` --commit `git rev-parse HEAD` --app",
     "deploy-qa": "npm run deploy -- ft-polyfill-service-qa",
     "deploy-prod": "npm run deploy -- ft-polyfill-service",
     "test": "grunt test",

--- a/package.json
+++ b/package.json
@@ -72,5 +72,5 @@
     "sauce-tunnel": "^2.2.3",
     "wd": "^0.3.8"
   },
-  "version": "1.4.0"
+  "version": "1.5.0-rc.1"
 }

--- a/service/index.js
+++ b/service/index.js
@@ -10,7 +10,7 @@ var metrics = require('./metrics');
 var fs = require('fs');
 var testing = require('./testing');
 var docs = require('./docs');
-var appVersion = fs.existsSync('./.semver') ? fs.readFileSync('./.semver', {encoding:'UTF-8'}).replace(/\s+$/, '') : 'Unknown';
+var appVersion = require('../package.json').version
 
 'use strict';
 


### PR DESCRIPTION
Since we will be publishing the rc versions to NPM, we might as well avoid duplicating the version number in 3 places (git tag, .semver, package.json) and use the package.json version number as the value used within the application.
