### PR TITLE
Update Object.getOwnPropertyNames

### DIFF
--- a/polyfills/Object.getOwnPropertyNames/polyfill.js
+++ b/polyfills/Object.getOwnPropertyNames/polyfill.js
@@ -6,7 +6,9 @@ Object.getOwnPropertyNames = function getOwnPropertyNames(object) {
 	var buffer = [], key;
 
 	for (key in object) {
-		buffer.push(key);
+		if (object.hasOwnProperty(key)) {
+			buffer.push(key);
+		}
 	}
 
 	return buffer;


### PR DESCRIPTION
`for ... in` iterates over all properties, including those from the prototype chain. However, `getOwnPropertyNames` should only return properties for the specified object, not its ancestors. To correct this, the polyfill can use `hasOwnProperty` as a condition to filter the returned properties.
