### PR TITLE
Stop using document.head as a hook in querySelector

### DIFF
--- a/polyfills/document.querySelector/polyfill.js
+++ b/polyfills/document.querySelector/polyfill.js
@@ -1,20 +1,17 @@
 (function (global) {
-	var
-	head = document.getElementsByTagName('head')[0];
-
 	function getElementsByQuery(node, selector, one) {
 		var
 		generator = document.createElement(),
 		id = 'qsa' + String(Math.random()).slice(3),
 		style, elements;
 
-		generator.innerHTML = 'x<style>' + selector + '{qsa:' + id + '}';
+		generator.innerHTML = 'x<style>' + selector + '{qsa:' + id + ';}';
 
-		style = head.appendChild(generator.lastChild);
+		style = node.appendChild(generator.lastChild);
 
 		elements = getElements(node, selector, one, id);
 
-		head.removeChild(style);
+		node.removeChild(style);
 
 		return one ? elements[0] : elements;
 	}


### PR DESCRIPTION
remove head, we need search in node dom, not in document, because this code not working if search in document. Nodes not available in document

``` javascript
var progress = document.createElement('div');
var progress.id = 'nprogress';
var progress.innerHTML = '<div class="bar" role="bar"><div class="peg"></div></div><div class="spinner" role="spinner"><div class="spinner-icon"></div></div>';
var bar = progress.querySelector('.bar');

var spinner = progress.querySelector('.spinner');
spinner && removeElement(spinner);

document.body.appendChild(progress);
```

Also we need ";", some early version IE7 bugs without this symbols
