### PR TITLE
Fix npm licence SPDX conformity warning by using the CC0-1.0 identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "test": "grunt test",
     "citest": "grunt ci --stack"
   },
-  "license": "CC0 1.0 Universal License",
+  "license": "CC0-1.0",
   "dependencies": {
     "babel-core": "^4.6.3",
     "caniuse-db": "1.0.20140710",


### PR DESCRIPTION
This should silence the warning issued when installing polyfill-service with recent npm versions:

```
npm WARN package.json polyfill-service@0.0.0 license should be a valid SPDX license expression
```

See [spdx.org](https://spdx.org/licenses/CC0-1.0.html) for reference.
