### PR TITLE
Provide bin entry, bin for global installation and CLI usage

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -74,9 +74,7 @@ module.exports = function(grunt) {
 		},
 		"service": {
 			polyfillservice: {
-				shellCommand: process.argv[0] + ' ' + __dirname + '/service/index.js',
-				pidFile: __dirname + '/service-process.pid',
-				generatePID: true,
+				shellCommand: __dirname + '/bin/polyfill-service',
 				options: {
 					env: ENV,
 					cwd: __dirname,

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: node service/index.js
+web: bin/polyfill-service

--- a/bin/polyfill-service
+++ b/bin/polyfill-service
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+var minimist = require('minimist');
+
+var packageJSON = require('../package.json');
+var startService = require('../service');
+
+var argv = minimist(process.argv.slice(2));
+var port = argv.port || Number(process.env.PORT) || 3000;
+
+startService(port, function(err, app){
+	if (err) {
+		console.error('Error while starting service:', err);
+		throw err;
+	}
+
+	console.log(packageJSON.name + '@' + packageJSON.version ,'listening on port', port, 'in environment "'+ app.get('env') +'"...');
+});

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "polyfill-service",
   "description": "A polyfill combinator",
   "main": "lib/index.js",
+  "bin": "service/index.js",
   "contributors": [
     {
       "name": "Jonathan Neal",
@@ -22,10 +23,10 @@
     "url": "https://github.com/financial-times/polyfill-service/issues"
   },
   "scripts": {
-    "start": "forever start --minUptime=1000 --spinSleepTime=1000 --plain service/index.js",
-    "restart": "forever restart --minUptime=1000 --spinSleepTime=1000 --plain service/index.js",
-    "stop": "forever stop --plain service/index.js",
-    "status": "forever list | grep -q service/index.js",
+    "start": "forever start --minUptime=1000 --spinSleepTime=1000 --plain bin/polyfill-service",
+    "restart": "forever restart --minUptime=1000 --spinSleepTime=1000 --plain bin/polyfill-service",
+    "stop": "forever stop --plain bin/polyfill-service",
+    "status": "forever list | grep bin/polyfill-service",
     "prepublish": "grunt build",
     "deploy": "grunt build && haikro build deploy --heroku-token `heroku auth:token` --commit `git rev-parse HEAD` --app",
     "deploy-qa": "npm run deploy -- ft-polyfill-service-qa",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "polyfill-service",
   "description": "A polyfill combinator",
   "main": "lib/index.js",
-  "bin": "service/index.js",
+  "bin": "bin/polyfill-service",
   "contributors": [
     {
       "name": "Jonathan Neal",

--- a/service/index.js
+++ b/service/index.js
@@ -5,7 +5,6 @@ var origamijson = require('../origami.json');
 var PolyfillSet = require('./PolyfillSet');
 var path = require('path');
 var fs = require('fs');
-var parseArgs = require('minimist');
 var metrics = require('./metrics');
 var fs = require('fs');
 var testing = require('./testing');
@@ -13,9 +12,6 @@ var docs = require('./docs');
 var appVersion = require('../package.json').version
 
 'use strict';
-
-var argv = parseArgs(process.argv.slice(2));
-var port = argv.port || Number(process.env.PORT) || 3000;
 
 metrics.gauge('memory', function() {
 	return process.memoryUsage().rss;
@@ -185,5 +181,16 @@ app.get("/v1/normalizeUa", function(req, res, next) {
 	}
 });
 
-app.listen(port);
-console.log("Server listening on port: ", port);
+function startService(port, callback) {
+	callback = callback || function() {};
+
+	app
+		.listen(port, function (err) {
+			callback(err, app);
+		})
+		.on('error', function (err) {
+			callback(err);
+		});
+}
+
+module.exports = startService;


### PR DESCRIPTION
This
- adds a `bin` entry to package.json, exposing `service/index.js` as `polyfill-service` when installed globally or for npm run-script when installed locally
- adds `bin/polyfill-service` as central entry point for starting the service
- pulls the argument parsing / defaults from `service/index.js` into `bin/polyfill-service`
- makes `service/index.js` export a function that accepts the parameters `port` and `callback`:
  - `port`: Port to run the service on
  - `callback`: callback executed after service has started
- adapts other npm run-scripts to new entry point
- adapts the `grunt:service:polyfillservice` task to work with new entry point
