### PR TITLE
Add mobile browsers to setImmediate config

### DIFF
--- a/polyfills/setImmediate/config.json
+++ b/polyfills/setImmediate/config.json
@@ -4,7 +4,12 @@
 		"firefox": "*",
 		"opera": "*",
 		"safari": "*",
-		"ie": "* - 9"
+		"ie": "* - 9",
+		"ios_saf": "*",
+		"ios_chr": "*",
+		"android": "*",
+		"op_mob": "*",
+		"ie_mob": "*"
 	},
 	"dependencies": [
 		"_enqueueMicrotask"


### PR DESCRIPTION
Fixes #450 (maybe; please check).

Based on [compatibility table](https://developer.mozilla.org/en-US/docs/Web/API/Window/setImmediate#Browser_compatibility) on MDN, and using UA identifiers from [here](http://cdn.polyfill.io/v1/docs/contributing#browser-support) (hope this is correct).
