### PR TITLE
Change license for rAF polyfill to MIT

### DIFF
--- a/polyfills/requestAnimationFrame/config.json
+++ b/polyfills/requestAnimationFrame/config.json
@@ -39,6 +39,6 @@
 		"Date.now",
 		"performance.now"
 	],
-	"license": "requestAnimationFrame polyfill by Erik Möller, fixes from Paul Irish, Tino Zijdel, and Jonathan Neal",
+	"license": "MIT",
 	"docs": "https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame"
 }


### PR DESCRIPTION
The text `requestAnimationFrame polyfill by Erik Möller, fixes from Paul Irish, Tino Zijdel, and Jonathan Neal` seems to be taken from this gist: https://gist.github.com/paulirish/1579671

They have since revised it with the line `MIT License` so this should be safe to change
