### PR TITLE
Support Firefox for Android

### DIFF
--- a/docs/contributing.html
+++ b/docs/contributing.html
@@ -206,6 +206,7 @@ module.exports = function(grunt) {
 			<tr><td><code>safari</code></td><td>Safari</td><td>{{baselines.safari}}</td></tr>
 			<tr><td><code>ios_saf</code></td><td>Safari on iOS</td><td>{{baselines.ios_saf}}</td></tr>
 			<tr><td><code>firefox</code></td><td>Firefox</td><td>{{baselines.firefox}}</td></tr>
+			<tr><td><code>firefox_mob</code></td><td>Firefox on Android</td><td>{{baselines.firefox_mob}}</td></tr>
 			<tr><td><code>android</code></td><td>Android Browser</td><td>{{baselines.android}}</td></tr>
 			<tr><td><code>opera</code></td><td>Opera</td><td>{{baselines.opera}}</td></tr>
 			<tr><td><code>op_mob</code></td><td>Opera Mobile</td><td>{{baselines.op_mob}}</td></tr>

--- a/lib/UA.js
+++ b/lib/UA.js
@@ -22,6 +22,7 @@ var baseLineVersions = {
 	"safari": ">=3",
 	"ios_saf": ">=3",
 	"firefox": ">=3.6",
+	"firefox_mob": ">=4",
 	"android": ">=2.3",
 	"opera": ">=11",
 	"op_mob": ">=10",
@@ -42,7 +43,7 @@ var aliases = {
 	"blackberry": "bb",
 
 	"pale moon (firefox variant)": "firefox",
-	"firefox mobile": "firefox",
+	"firefox mobile": "firefox_mob",
 	"firefox namoroka": "firefox",
 	"firefox shiretoko": "firefox",
 	"firefox minefield": "firefox",

--- a/polyfills/Array/from/config.json
+++ b/polyfills/Array/from/config.json
@@ -1,19 +1,20 @@
 {
-	"aliases": [
-		"es6",
-		"modernizr:es6array"
-	],
-	"browsers": {
-		"chrome": "<45",
-		"firefox": "4 - *",
-		"ie": "6 - *",
-		"ie_mob": "10 - *",
-		"opera": "*",
-		"safari": "7 - *"
-	},
-	"dependencies": [
-		"Object.defineProperty"
-	],
-	"spec": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-array.from",
-	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from"
+    "aliases": [
+        "es6",
+        "modernizr:es6array"
+    ],
+    "browsers": {
+        "chrome": "<45",
+        "firefox": "4 - *",
+        "ie": "6 - *",
+        "ie_mob": "10 - *",
+        "opera": "*",
+        "safari": "7 - *",
+        "firefox_mob": "4 - *"
+    },
+    "dependencies": [
+        "Object.defineProperty"
+    ],
+    "spec": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-array.from",
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from"
 }

--- a/polyfills/Array/isArray/config.json
+++ b/polyfills/Array/isArray/config.json
@@ -1,17 +1,18 @@
 {
-	"aliases": [
-		"default",
-		"es5",
-		"modernizr:es5array"
-	],
-	"browsers": {
-		"ie": "6 - 8",
-		"firefox": "3.6",
-		"safari": "4"
-	},
-	"dependencies": [
-		"Object.defineProperty"
-	],
-	"spec": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-isarray",
-	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray"
+    "aliases": [
+        "default",
+        "es5",
+        "modernizr:es5array"
+    ],
+    "browsers": {
+        "ie": "6 - 8",
+        "firefox": "3.6",
+        "safari": "4",
+        "firefox_mob": "3.6"
+    },
+    "dependencies": [
+        "Object.defineProperty"
+    ],
+    "spec": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-isarray",
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray"
 }

--- a/polyfills/Array/of/config.json
+++ b/polyfills/Array/of/config.json
@@ -1,19 +1,20 @@
 {
-	"aliases": [
-		"es6",
-		"modernizr:es6array"
-	],
-	"browsers": {
-		"chrome": "*",
-		"firefox": "* - 24",
-		"ie": "*",
-		"ie_mob": "10 - *",
-		"opera": "*",
-		"safari": "*"
-	},
-	"dependencies": [
-		"Object.defineProperty"
-	],
-	"spec":"http://people.mozilla.org/~jorendorff/es6-draft.html#sec-array.of",
-	"docs":"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/of"
+    "aliases": [
+        "es6",
+        "modernizr:es6array"
+    ],
+    "browsers": {
+        "chrome": "*",
+        "firefox": "* - 24",
+        "ie": "*",
+        "ie_mob": "10 - *",
+        "opera": "*",
+        "safari": "*",
+        "firefox_mob": "* - 24"
+    },
+    "dependencies": [
+        "Object.defineProperty"
+    ],
+    "spec": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-array.of",
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/of"
 }

--- a/polyfills/Array/prototype/contains/config.json
+++ b/polyfills/Array/prototype/contains/config.json
@@ -1,16 +1,17 @@
 {
-	"browsers": {
-		"chrome": "*",
-		"firefox": "*",
-		"ie": "*",
-		"ie_mob": "10 - *",
-		"opera": "*",
-		"safari": "*"
-	},
-	"dependencies": [
-		"Array.prototype.includes"
-	],
-	"notes": [
-		"This feature was deprecated since it was found to [break older versions of Mootools](https://esdiscuss.org/topic/having-a-non-enumerable-array-prototype-contains-may-not-be-web-compatible).  Use `Array.prototype.includes` instead."
-	]
+    "browsers": {
+        "chrome": "*",
+        "firefox": "*",
+        "ie": "*",
+        "ie_mob": "10 - *",
+        "opera": "*",
+        "safari": "*",
+        "firefox_mob": "*"
+    },
+    "dependencies": [
+        "Array.prototype.includes"
+    ],
+    "notes": [
+        "This feature was deprecated since it was found to [break older versions of Mootools](https://esdiscuss.org/topic/having-a-non-enumerable-array-prototype-contains-may-not-be-web-compatible).  Use `Array.prototype.includes` instead."
+    ]
 }

--- a/polyfills/Array/prototype/find/config.json
+++ b/polyfills/Array/prototype/find/config.json
@@ -1,19 +1,20 @@
 {
-	"aliases": [
-		"es6",
-		"modernizr:es6array"
-	],
-	"browsers": {
-		"chrome": "*",
-		"firefox": "3.6 - 24",
-		"ie": "*",
-		"ie_mob": "10 - *",
-		"opera": "*",
-		"safari": "* - 7.0"
-	},
-	"dependencies": [
-		"Object.defineProperty"
-	],
-	"spec": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-array.prototype.find",
-	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find"
+    "aliases": [
+        "es6",
+        "modernizr:es6array"
+    ],
+    "browsers": {
+        "chrome": "*",
+        "firefox": "3.6 - 24",
+        "ie": "*",
+        "ie_mob": "10 - *",
+        "opera": "*",
+        "safari": "* - 7.0",
+        "firefox_mob": "3.6 - 24"
+    },
+    "dependencies": [
+        "Object.defineProperty"
+    ],
+    "spec": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-array.prototype.find",
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find"
 }

--- a/polyfills/Array/prototype/findIndex/config.json
+++ b/polyfills/Array/prototype/findIndex/config.json
@@ -1,19 +1,20 @@
 {
-	"aliases": [
-		"es6",
-		"modernizr:es6array"
-	],
-	"browsers": {
-		"chrome": "*",
-		"firefox": "3.6 - 24",
-		"ie": "*",
-		"ie_mob": "10 - *",
-		"opera": "*",
-		"safari": "* - 7.0"
-	},
-	"dependencies": [
-		"Object.defineProperty"
-	],
-	"spec": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-array.prototype.findIndex",
-	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex"
+    "aliases": [
+        "es6",
+        "modernizr:es6array"
+    ],
+    "browsers": {
+        "chrome": "*",
+        "firefox": "3.6 - 24",
+        "ie": "*",
+        "ie_mob": "10 - *",
+        "opera": "*",
+        "safari": "* - 7.0",
+        "firefox_mob": "3.6 - 24"
+    },
+    "dependencies": [
+        "Object.defineProperty"
+    ],
+    "spec": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-array.prototype.findIndex",
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex"
 }

--- a/polyfills/Array/prototype/includes/config.json
+++ b/polyfills/Array/prototype/includes/config.json
@@ -1,24 +1,25 @@
 {
-	"aliases": [
-		"es7",
-		"modernizr:es7array"
-	],
-	"browsers": {
-		"chrome": "*",
-		"firefox": "*",
-		"ie": "*",
-		"opera": "*",
-		"safari": "*",
-		"ios_saf": "*",
-		"ios_chr": "*",
-		"android": "*",
-		"op_mob": "*",
-		"ie_mob": "*"
-	},
-	"dependencies": [
-		"Object.defineProperty"
-	],
-	"license": "CC0",
-	"spec": "https://github.com/tc39/Array.prototype.includes",
-	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes"
+    "aliases": [
+        "es7",
+        "modernizr:es7array"
+    ],
+    "browsers": {
+        "chrome": "*",
+        "firefox": "*",
+        "ie": "*",
+        "opera": "*",
+        "safari": "*",
+        "ios_saf": "*",
+        "ios_chr": "*",
+        "android": "*",
+        "op_mob": "*",
+        "ie_mob": "*",
+        "firefox_mob": "*"
+    },
+    "dependencies": [
+        "Object.defineProperty"
+    ],
+    "license": "CC0",
+    "spec": "https://github.com/tc39/Array.prototype.includes",
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes"
 }

--- a/polyfills/CustomEvent/config.json
+++ b/polyfills/CustomEvent/config.json
@@ -1,30 +1,31 @@
 {
-	"aliases": [
-		"default",
-		"modernizr:customevent"
-	],
-	"browsers": {
-		"firefox": "6 - 10",
-		"ie": "9 - *",
-		"ie_mob": "10 - *",
-		"opera": "10 - 11.5",
-		"safari": "4 - 7",
-		"chrome": "1 - 14",
-		"android": "<=4.3"
-	},
-	"dependencies": [
-		"Event"
-	],
-	"variants": {
-		"ie8": {
-			"browsers": {
-				"ie": "6 - 8"
-			},
-			"dependencies": [
-				"Event"
-			]
-		}
-	},
-	"spec": "http://dom.spec.whatwg.org/#interface-customevent",
-	"docs": "https://developer.mozilla.org/en/docs/Web/API/CustomEvent"
+    "aliases": [
+        "default",
+        "modernizr:customevent"
+    ],
+    "browsers": {
+        "firefox": "6 - 10",
+        "ie": "9 - *",
+        "ie_mob": "10 - *",
+        "opera": "10 - 11.5",
+        "safari": "4 - 7",
+        "chrome": "1 - 14",
+        "android": "<=4.3",
+        "firefox_mob": "6 - 10"
+    },
+    "dependencies": [
+        "Event"
+    ],
+    "variants": {
+        "ie8": {
+            "browsers": {
+                "ie": "6 - 8"
+            },
+            "dependencies": [
+                "Event"
+            ]
+        }
+    },
+    "spec": "http://dom.spec.whatwg.org/#interface-customevent",
+    "docs": "https://developer.mozilla.org/en/docs/Web/API/CustomEvent"
 }

--- a/polyfills/Element/prototype/after/config.json
+++ b/polyfills/Element/prototype/after/config.json
@@ -1,22 +1,23 @@
 {
-	"browsers": {
-		"android": "*",
-		"bb": "*",
-		"chrome": "*",
-		"firefox": "3.6 - *",
-		"ios_chr": "*",
-		"ios_saf": "*",
-		"ie": "6 - *",
-		"ie_mob": "10 - *",
-		"opera": "*",
-		"op_mini": "*",
-		"safari": "4 - *"
-	},
-	"dependencies": [
-		"Document",
-		"Element",
-		"Text",
-		"_mutation"
-	],
-	"spec": "http://dom.spec.whatwg.org/#dom-childnode-after"
+    "browsers": {
+        "android": "*",
+        "bb": "*",
+        "chrome": "*",
+        "firefox": "3.6 - *",
+        "ios_chr": "*",
+        "ios_saf": "*",
+        "ie": "6 - *",
+        "ie_mob": "10 - *",
+        "opera": "*",
+        "op_mini": "*",
+        "safari": "4 - *",
+        "firefox_mob": "3.6 - *"
+    },
+    "dependencies": [
+        "Document",
+        "Element",
+        "Text",
+        "_mutation"
+    ],
+    "spec": "http://dom.spec.whatwg.org/#dom-childnode-after"
 }

--- a/polyfills/Element/prototype/append/config.json
+++ b/polyfills/Element/prototype/append/config.json
@@ -1,21 +1,22 @@
 {
-	"browsers": {
-		"android": "*",
-		"bb": "*",
-		"chrome": "*",
-		"firefox": "3.6 - *",
-		"ios_chr": "*",
-		"ios_saf": "*",
-		"ie": "6 - *",
-		"ie_mob": "10 - *",
-		"opera": "*",
-		"op_mini": "*",
-		"safari": "4 - *"
-	},
-	"dependencies": [
-		"Document",
-		"Element",
-		"_mutation"
-	],
-	"spec": "http://dom.spec.whatwg.org/#dom-parentnode-append"
+    "browsers": {
+        "android": "*",
+        "bb": "*",
+        "chrome": "*",
+        "firefox": "3.6 - *",
+        "ios_chr": "*",
+        "ios_saf": "*",
+        "ie": "6 - *",
+        "ie_mob": "10 - *",
+        "opera": "*",
+        "op_mini": "*",
+        "safari": "4 - *",
+        "firefox_mob": "3.6 - *"
+    },
+    "dependencies": [
+        "Document",
+        "Element",
+        "_mutation"
+    ],
+    "spec": "http://dom.spec.whatwg.org/#dom-parentnode-append"
 }

--- a/polyfills/Element/prototype/before/config.json
+++ b/polyfills/Element/prototype/before/config.json
@@ -1,22 +1,23 @@
 {
-	"browsers": {
-		"android": "*",
-		"bb": "*",
-		"chrome": "*",
-		"firefox": "3.6 - *",
-		"ios_chr": "*",
-		"ios_saf": "*",
-		"ie": "6 - *",
-		"ie_mob": "10 - *",
-		"opera": "*",
-		"op_mini": "*",
-		"safari": "4 - *"
-	},
-	"dependencies": [
-		"Document",
-		"Element",
-		"Text",
-		"_mutation"
-	],
-	"spec": "http://dom.spec.whatwg.org/#dom-childnode-before"
+    "browsers": {
+        "android": "*",
+        "bb": "*",
+        "chrome": "*",
+        "firefox": "3.6 - *",
+        "ios_chr": "*",
+        "ios_saf": "*",
+        "ie": "6 - *",
+        "ie_mob": "10 - *",
+        "opera": "*",
+        "op_mini": "*",
+        "safari": "4 - *",
+        "firefox_mob": "3.6 - *"
+    },
+    "dependencies": [
+        "Document",
+        "Element",
+        "Text",
+        "_mutation"
+    ],
+    "spec": "http://dom.spec.whatwg.org/#dom-childnode-before"
 }

--- a/polyfills/Element/prototype/closest/config.json
+++ b/polyfills/Element/prototype/closest/config.json
@@ -1,23 +1,24 @@
 {
-	"aliases": [
-		"default"
-	],
-	"browsers": {
-		"bb": "*",
-		"android": "*",
-		"chrome": "*",
-		"ie": "*",
-		"ie_mob": "*",
-		"ios_saf": "*",
-		"firefox": "6 - *",
-		"opera": "*",
-		"op_mini": "*",
-		"op_mob": "*",
-		"safari": "*"
-	},
-	"dependencies": [
-		"Element.prototype.matches"
-	],
-	"docs": "https://developer.mozilla.org/en-US/docs/Web/API/Element/closest",
-	"spec": "http://dom.spec.whatwg.org/#dom-element-closest"
+    "aliases": [
+        "default"
+    ],
+    "browsers": {
+        "bb": "*",
+        "android": "*",
+        "chrome": "*",
+        "ie": "*",
+        "ie_mob": "*",
+        "ios_saf": "*",
+        "firefox": "6 - *",
+        "opera": "*",
+        "op_mini": "*",
+        "op_mob": "*",
+        "safari": "*",
+        "firefox_mob": "6 - *"
+    },
+    "dependencies": [
+        "Element.prototype.matches"
+    ],
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/API/Element/closest",
+    "spec": "http://dom.spec.whatwg.org/#dom-element-closest"
 }

--- a/polyfills/Element/prototype/prepend/config.json
+++ b/polyfills/Element/prototype/prepend/config.json
@@ -1,21 +1,22 @@
 {
-	"browsers": {
-		"android": "*",
-		"bb": "*",
-		"chrome": "*",
-		"firefox": "3.6 - *",
-		"ios_chr": "*",
-		"ios_saf": "*",
-		"ie": "6 - *",
-		"ie_mob": "10 - *",
-		"opera": "*",
-		"op_mini": "*",
-		"safari": "4 - *"
-	},
-	"dependencies": [
-		"Document",
-		"Element",
-		"_mutation"
-	],
-	"spec": "http://dom.spec.whatwg.org/#dom-parentnode-prepend"
+    "browsers": {
+        "android": "*",
+        "bb": "*",
+        "chrome": "*",
+        "firefox": "3.6 - *",
+        "ios_chr": "*",
+        "ios_saf": "*",
+        "ie": "6 - *",
+        "ie_mob": "10 - *",
+        "opera": "*",
+        "op_mini": "*",
+        "safari": "4 - *",
+        "firefox_mob": "3.6 - *"
+    },
+    "dependencies": [
+        "Document",
+        "Element",
+        "_mutation"
+    ],
+    "spec": "http://dom.spec.whatwg.org/#dom-parentnode-prepend"
 }

--- a/polyfills/Element/prototype/remove/config.json
+++ b/polyfills/Element/prototype/remove/config.json
@@ -1,22 +1,23 @@
 {
-	"browsers": {
-		"android": "*",
-		"bb": "*",
-		"chrome": "* - 28",
-		"firefox": "3.6 - *",
-		"ios_chr": "*",
-		"ios_saf": "*",
-		"ie": "6 - *",
-		"ie_mob": "10 - *",
-		"opera": "* - 15",
-		"op_mini": "*",
-		"safari": "4 - *"
-	},
-	"dependencies": [
-		"Document",
-		"Element",
-		"Text",
-		"_mutation"
-	],
-	"spec": "http://dom.spec.whatwg.org/#dom-childnode-remove"
+    "browsers": {
+        "android": "*",
+        "bb": "*",
+        "chrome": "* - 28",
+        "firefox": "3.6 - *",
+        "ios_chr": "*",
+        "ios_saf": "*",
+        "ie": "6 - *",
+        "ie_mob": "10 - *",
+        "opera": "* - 15",
+        "op_mini": "*",
+        "safari": "4 - *",
+        "firefox_mob": "3.6 - *"
+    },
+    "dependencies": [
+        "Document",
+        "Element",
+        "Text",
+        "_mutation"
+    ],
+    "spec": "http://dom.spec.whatwg.org/#dom-childnode-remove"
 }

--- a/polyfills/Element/prototype/replaceWith/config.json
+++ b/polyfills/Element/prototype/replaceWith/config.json
@@ -1,22 +1,23 @@
 {
-	"browsers": {
-		"android": "*",
-		"bb": "*",
-		"chrome": "*",
-		"firefox": "3.6 - *",
-		"ios_chr": "*",
-		"ios_saf": "*",
-		"ie": "6 - *",
-		"ie_mob": "10 - *",
-		"opera": "*",
-		"op_mini": "*",
-		"safari": "4 - *"
-	},
-	"dependencies": [
-		"Document",
-		"Element",
-		"Text",
-		"_mutation"
-	],
-	"spec": "http://dom.spec.whatwg.org/#dom-childnode-replacewith"
+    "browsers": {
+        "android": "*",
+        "bb": "*",
+        "chrome": "*",
+        "firefox": "3.6 - *",
+        "ios_chr": "*",
+        "ios_saf": "*",
+        "ie": "6 - *",
+        "ie_mob": "10 - *",
+        "opera": "*",
+        "op_mini": "*",
+        "safari": "4 - *",
+        "firefox_mob": "3.6 - *"
+    },
+    "dependencies": [
+        "Document",
+        "Element",
+        "Text",
+        "_mutation"
+    ],
+    "spec": "http://dom.spec.whatwg.org/#dom-childnode-replacewith"
 }

--- a/polyfills/Event/config.json
+++ b/polyfills/Event/config.json
@@ -1,31 +1,32 @@
 {
-	"aliases": [
-		"default"
-	],
-	"browsers": {
-		"firefox": "6 - 10",
-		"ie": "9 - 10",
-		"ie_mob": "10",
-		"opera": "10 - 11.5",
-		"safari": "4 - 7"
-	},
-	"dependencies": [
-		"Window"
-	],
-	"variants": {
-		"ie8": {
-			"browsers": {
-				"ie": "6 - 8"
-			},
-			"dependencies": [
-				"Window",
-				"Document",
-				"Element"
-			]
-		}
-	},
-	"docs": "https://developer.mozilla.org/en/docs/Web/API/Event",
-	"notes": [
-		"This includes the [EventTarget](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener) methods `addEventListener`, `removeEventListener` and `dispatchEvent` for IE6-8."
-	]
+    "aliases": [
+        "default"
+    ],
+    "browsers": {
+        "firefox": "6 - 10",
+        "ie": "9 - 10",
+        "ie_mob": "10",
+        "opera": "10 - 11.5",
+        "safari": "4 - 7",
+        "firefox_mob": "6 - 10"
+    },
+    "dependencies": [
+        "Window"
+    ],
+    "variants": {
+        "ie8": {
+            "browsers": {
+                "ie": "6 - 8"
+            },
+            "dependencies": [
+                "Window",
+                "Document",
+                "Element"
+            ]
+        }
+    },
+    "docs": "https://developer.mozilla.org/en/docs/Web/API/Event",
+    "notes": [
+        "This includes the [EventTarget](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener) methods `addEventListener`, `removeEventListener` and `dispatchEvent` for IE6-8."
+    ]
 }

--- a/polyfills/Event/focusin/config.json
+++ b/polyfills/Event/focusin/config.json
@@ -1,12 +1,13 @@
 {
-	"aliases": [
-		"default"
-	],
-	"browsers": {
-		"firefox": "6 - *"
-	},
-	"dependencies": [
-		"Event"
-	],
-	"docs": "https://developer.mozilla.org/en-US/docs/Web/Events/focusin"
+    "aliases": [
+        "default"
+    ],
+    "browsers": {
+        "firefox": "6 - *",
+        "firefox_mob": "6 - *"
+    },
+    "dependencies": [
+        "Event"
+    ],
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/Events/focusin"
 }

--- a/polyfills/Function/prototype/bind/config.json
+++ b/polyfills/Function/prototype/bind/config.json
@@ -1,20 +1,21 @@
 {
-	"aliases": [
-		"default",
-		"es5",
-		"modernizr:es5function"
-	],
-	"browsers": {
-		"ie": "6 - 8",
-		"firefox": "3.6",
-		"safari": "4 - 5.1",
-		"ios_saf": "<=5"
-	},
-	"dependencies": [
-		"Object.defineProperty"
-	],
-	"repo": "https://github.com/es-shims/es5-shim",
-	"license": "MIT",
-	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind",
-	"spec": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-function.prototype.bind"
+    "aliases": [
+        "default",
+        "es5",
+        "modernizr:es5function"
+    ],
+    "browsers": {
+        "ie": "6 - 8",
+        "firefox": "3.6",
+        "safari": "4 - 5.1",
+        "ios_saf": "<=5",
+        "firefox_mob": "3.6"
+    },
+    "dependencies": [
+        "Object.defineProperty"
+    ],
+    "repo": "https://github.com/es-shims/es5-shim",
+    "license": "MIT",
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind",
+    "spec": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-function.prototype.bind"
 }

--- a/polyfills/HTMLPictureElement/config.json
+++ b/polyfills/HTMLPictureElement/config.json
@@ -1,17 +1,17 @@
 {
-	"browsers": {
-		"ie": "9 - *",
-		"ie_mob": "10 - *",
-		"firefox": "4 - 37",
-		"opera": "11.6 - 29",
-		"safari": "6 - *",
-		"chrome": "* - 38",
-		"ios_saf": "*"
-	},
-	"dependencies": [
-	],
-	"license": "MIT",
-	"spec": "https://html.spec.whatwg.org/multipage/embedded-content.html#embedded-content",
-	"repo": "https://github.com/scottjehl/picturefill",
-	"docs": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture"
+    "browsers": {
+        "ie": "9 - *",
+        "ie_mob": "10 - *",
+        "firefox": "4 - 37",
+        "opera": "11.6 - 29",
+        "safari": "6 - *",
+        "chrome": "* - 38",
+        "ios_saf": "*",
+        "firefox_mob": "4 - 37"
+    },
+    "dependencies": [],
+    "license": "MIT",
+    "spec": "https://html.spec.whatwg.org/multipage/embedded-content.html#embedded-content",
+    "repo": "https://github.com/scottjehl/picturefill",
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture"
 }

--- a/polyfills/Intl/config.json
+++ b/polyfills/Intl/config.json
@@ -1,22 +1,23 @@
 {
-	"browsers": {
-		"ie": "<11",
-		"ie_mob": "10",
-		"firefox": "<29",
-		"opera": "<15",
-		"chrome": "<24",
-		"safari": "*",
-		"ios_saf": "*"
-	},
-	"dependencies": [],
-	"build": {
-		"minify": false
-	},
-	"license": "MIT",
-	"spec": "http://www.ecma-international.org/ecma-402/1.0/",
-	"repo": "https://github.com/andyearnshaw/Intl.js",
-	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
-	"notes": [
-		"Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
-	]
+    "browsers": {
+        "ie": "<11",
+        "ie_mob": "10",
+        "firefox": "<29",
+        "opera": "<15",
+        "chrome": "<24",
+        "safari": "*",
+        "ios_saf": "*",
+        "firefox_mob": "<29"
+    },
+    "dependencies": [],
+    "build": {
+        "minify": false
+    },
+    "license": "MIT",
+    "spec": "http://www.ecma-international.org/ecma-402/1.0/",
+    "repo": "https://github.com/andyearnshaw/Intl.js",
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ]
 }

--- a/polyfills/Intl/config.json
+++ b/polyfills/Intl/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [],
     "build": {

--- a/polyfills/Intl/~locale/af-NA/config.json
+++ b/polyfills/Intl/~locale/af-NA/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/af-NA/config.json
+++ b/polyfills/Intl/~locale/af-NA/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/af-ZA/config.json
+++ b/polyfills/Intl/~locale/af-ZA/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/af-ZA/config.json
+++ b/polyfills/Intl/~locale/af-ZA/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/af/config.json
+++ b/polyfills/Intl/~locale/af/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/af/config.json
+++ b/polyfills/Intl/~locale/af/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/agq-CM/config.json
+++ b/polyfills/Intl/~locale/agq-CM/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/agq-CM/config.json
+++ b/polyfills/Intl/~locale/agq-CM/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/agq/config.json
+++ b/polyfills/Intl/~locale/agq/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/agq/config.json
+++ b/polyfills/Intl/~locale/agq/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ak-GH/config.json
+++ b/polyfills/Intl/~locale/ak-GH/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ak-GH/config.json
+++ b/polyfills/Intl/~locale/ak-GH/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ak/config.json
+++ b/polyfills/Intl/~locale/ak/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ak/config.json
+++ b/polyfills/Intl/~locale/ak/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/am-ET/config.json
+++ b/polyfills/Intl/~locale/am-ET/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/am-ET/config.json
+++ b/polyfills/Intl/~locale/am-ET/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/am/config.json
+++ b/polyfills/Intl/~locale/am/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/am/config.json
+++ b/polyfills/Intl/~locale/am/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ar-001/config.json
+++ b/polyfills/Intl/~locale/ar-001/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ar-001/config.json
+++ b/polyfills/Intl/~locale/ar-001/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ar-AE/config.json
+++ b/polyfills/Intl/~locale/ar-AE/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ar-AE/config.json
+++ b/polyfills/Intl/~locale/ar-AE/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ar-BH/config.json
+++ b/polyfills/Intl/~locale/ar-BH/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ar-BH/config.json
+++ b/polyfills/Intl/~locale/ar-BH/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ar-DJ/config.json
+++ b/polyfills/Intl/~locale/ar-DJ/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ar-DJ/config.json
+++ b/polyfills/Intl/~locale/ar-DJ/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ar-DZ/config.json
+++ b/polyfills/Intl/~locale/ar-DZ/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ar-DZ/config.json
+++ b/polyfills/Intl/~locale/ar-DZ/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ar-EG/config.json
+++ b/polyfills/Intl/~locale/ar-EG/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ar-EG/config.json
+++ b/polyfills/Intl/~locale/ar-EG/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ar-EH/config.json
+++ b/polyfills/Intl/~locale/ar-EH/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ar-EH/config.json
+++ b/polyfills/Intl/~locale/ar-EH/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ar-ER/config.json
+++ b/polyfills/Intl/~locale/ar-ER/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ar-ER/config.json
+++ b/polyfills/Intl/~locale/ar-ER/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ar-IL/config.json
+++ b/polyfills/Intl/~locale/ar-IL/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ar-IL/config.json
+++ b/polyfills/Intl/~locale/ar-IL/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ar-IQ/config.json
+++ b/polyfills/Intl/~locale/ar-IQ/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ar-IQ/config.json
+++ b/polyfills/Intl/~locale/ar-IQ/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ar-JO/config.json
+++ b/polyfills/Intl/~locale/ar-JO/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ar-JO/config.json
+++ b/polyfills/Intl/~locale/ar-JO/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ar-KM/config.json
+++ b/polyfills/Intl/~locale/ar-KM/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ar-KM/config.json
+++ b/polyfills/Intl/~locale/ar-KM/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ar-KW/config.json
+++ b/polyfills/Intl/~locale/ar-KW/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ar-KW/config.json
+++ b/polyfills/Intl/~locale/ar-KW/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ar-LB/config.json
+++ b/polyfills/Intl/~locale/ar-LB/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ar-LB/config.json
+++ b/polyfills/Intl/~locale/ar-LB/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ar-LY/config.json
+++ b/polyfills/Intl/~locale/ar-LY/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ar-LY/config.json
+++ b/polyfills/Intl/~locale/ar-LY/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ar-MA/config.json
+++ b/polyfills/Intl/~locale/ar-MA/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ar-MA/config.json
+++ b/polyfills/Intl/~locale/ar-MA/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ar-MR/config.json
+++ b/polyfills/Intl/~locale/ar-MR/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ar-MR/config.json
+++ b/polyfills/Intl/~locale/ar-MR/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ar-OM/config.json
+++ b/polyfills/Intl/~locale/ar-OM/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ar-OM/config.json
+++ b/polyfills/Intl/~locale/ar-OM/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ar-PS/config.json
+++ b/polyfills/Intl/~locale/ar-PS/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ar-PS/config.json
+++ b/polyfills/Intl/~locale/ar-PS/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ar-QA/config.json
+++ b/polyfills/Intl/~locale/ar-QA/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ar-QA/config.json
+++ b/polyfills/Intl/~locale/ar-QA/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ar-SA/config.json
+++ b/polyfills/Intl/~locale/ar-SA/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ar-SA/config.json
+++ b/polyfills/Intl/~locale/ar-SA/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ar-SD/config.json
+++ b/polyfills/Intl/~locale/ar-SD/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ar-SD/config.json
+++ b/polyfills/Intl/~locale/ar-SD/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ar-SO/config.json
+++ b/polyfills/Intl/~locale/ar-SO/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ar-SO/config.json
+++ b/polyfills/Intl/~locale/ar-SO/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ar-SS/config.json
+++ b/polyfills/Intl/~locale/ar-SS/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ar-SS/config.json
+++ b/polyfills/Intl/~locale/ar-SS/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ar-SY/config.json
+++ b/polyfills/Intl/~locale/ar-SY/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ar-SY/config.json
+++ b/polyfills/Intl/~locale/ar-SY/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ar-TD/config.json
+++ b/polyfills/Intl/~locale/ar-TD/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ar-TD/config.json
+++ b/polyfills/Intl/~locale/ar-TD/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ar-TN/config.json
+++ b/polyfills/Intl/~locale/ar-TN/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ar-TN/config.json
+++ b/polyfills/Intl/~locale/ar-TN/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ar-YE/config.json
+++ b/polyfills/Intl/~locale/ar-YE/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ar-YE/config.json
+++ b/polyfills/Intl/~locale/ar-YE/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ar/config.json
+++ b/polyfills/Intl/~locale/ar/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ar/config.json
+++ b/polyfills/Intl/~locale/ar/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/as-IN/config.json
+++ b/polyfills/Intl/~locale/as-IN/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/as-IN/config.json
+++ b/polyfills/Intl/~locale/as-IN/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/as/config.json
+++ b/polyfills/Intl/~locale/as/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/as/config.json
+++ b/polyfills/Intl/~locale/as/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/asa-TZ/config.json
+++ b/polyfills/Intl/~locale/asa-TZ/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/asa-TZ/config.json
+++ b/polyfills/Intl/~locale/asa-TZ/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/asa/config.json
+++ b/polyfills/Intl/~locale/asa/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/asa/config.json
+++ b/polyfills/Intl/~locale/asa/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ast-ES/config.json
+++ b/polyfills/Intl/~locale/ast-ES/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ast-ES/config.json
+++ b/polyfills/Intl/~locale/ast-ES/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ast/config.json
+++ b/polyfills/Intl/~locale/ast/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ast/config.json
+++ b/polyfills/Intl/~locale/ast/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/az-Cyrl-AZ/config.json
+++ b/polyfills/Intl/~locale/az-Cyrl-AZ/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/az-Cyrl-AZ/config.json
+++ b/polyfills/Intl/~locale/az-Cyrl-AZ/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/az-Cyrl/config.json
+++ b/polyfills/Intl/~locale/az-Cyrl/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/az-Cyrl/config.json
+++ b/polyfills/Intl/~locale/az-Cyrl/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/az-Latn-AZ/config.json
+++ b/polyfills/Intl/~locale/az-Latn-AZ/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/az-Latn-AZ/config.json
+++ b/polyfills/Intl/~locale/az-Latn-AZ/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/az-Latn/config.json
+++ b/polyfills/Intl/~locale/az-Latn/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/az-Latn/config.json
+++ b/polyfills/Intl/~locale/az-Latn/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/az/config.json
+++ b/polyfills/Intl/~locale/az/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/az/config.json
+++ b/polyfills/Intl/~locale/az/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/bas-CM/config.json
+++ b/polyfills/Intl/~locale/bas-CM/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/bas-CM/config.json
+++ b/polyfills/Intl/~locale/bas-CM/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/bas/config.json
+++ b/polyfills/Intl/~locale/bas/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/bas/config.json
+++ b/polyfills/Intl/~locale/bas/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/be-BY/config.json
+++ b/polyfills/Intl/~locale/be-BY/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/be-BY/config.json
+++ b/polyfills/Intl/~locale/be-BY/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/be/config.json
+++ b/polyfills/Intl/~locale/be/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/be/config.json
+++ b/polyfills/Intl/~locale/be/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/bem-ZM/config.json
+++ b/polyfills/Intl/~locale/bem-ZM/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/bem-ZM/config.json
+++ b/polyfills/Intl/~locale/bem-ZM/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/bem/config.json
+++ b/polyfills/Intl/~locale/bem/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/bem/config.json
+++ b/polyfills/Intl/~locale/bem/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/bez-TZ/config.json
+++ b/polyfills/Intl/~locale/bez-TZ/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/bez-TZ/config.json
+++ b/polyfills/Intl/~locale/bez-TZ/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/bez/config.json
+++ b/polyfills/Intl/~locale/bez/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/bez/config.json
+++ b/polyfills/Intl/~locale/bez/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/bg-BG/config.json
+++ b/polyfills/Intl/~locale/bg-BG/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/bg-BG/config.json
+++ b/polyfills/Intl/~locale/bg-BG/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/bg/config.json
+++ b/polyfills/Intl/~locale/bg/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/bg/config.json
+++ b/polyfills/Intl/~locale/bg/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/bm-Latn-ML/config.json
+++ b/polyfills/Intl/~locale/bm-Latn-ML/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/bm-Latn-ML/config.json
+++ b/polyfills/Intl/~locale/bm-Latn-ML/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/bm-Latn/config.json
+++ b/polyfills/Intl/~locale/bm-Latn/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/bm-Latn/config.json
+++ b/polyfills/Intl/~locale/bm-Latn/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/bm-Nkoo/config.json
+++ b/polyfills/Intl/~locale/bm-Nkoo/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/bm-Nkoo/config.json
+++ b/polyfills/Intl/~locale/bm-Nkoo/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/bm/config.json
+++ b/polyfills/Intl/~locale/bm/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/bm/config.json
+++ b/polyfills/Intl/~locale/bm/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/bn-BD/config.json
+++ b/polyfills/Intl/~locale/bn-BD/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/bn-BD/config.json
+++ b/polyfills/Intl/~locale/bn-BD/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/bn-IN/config.json
+++ b/polyfills/Intl/~locale/bn-IN/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/bn-IN/config.json
+++ b/polyfills/Intl/~locale/bn-IN/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/bn/config.json
+++ b/polyfills/Intl/~locale/bn/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/bn/config.json
+++ b/polyfills/Intl/~locale/bn/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/bo-CN/config.json
+++ b/polyfills/Intl/~locale/bo-CN/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/bo-CN/config.json
+++ b/polyfills/Intl/~locale/bo-CN/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/bo-IN/config.json
+++ b/polyfills/Intl/~locale/bo-IN/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/bo-IN/config.json
+++ b/polyfills/Intl/~locale/bo-IN/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/bo/config.json
+++ b/polyfills/Intl/~locale/bo/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/bo/config.json
+++ b/polyfills/Intl/~locale/bo/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/br-FR/config.json
+++ b/polyfills/Intl/~locale/br-FR/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/br-FR/config.json
+++ b/polyfills/Intl/~locale/br-FR/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/br/config.json
+++ b/polyfills/Intl/~locale/br/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/br/config.json
+++ b/polyfills/Intl/~locale/br/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/brx-IN/config.json
+++ b/polyfills/Intl/~locale/brx-IN/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/brx-IN/config.json
+++ b/polyfills/Intl/~locale/brx-IN/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/brx/config.json
+++ b/polyfills/Intl/~locale/brx/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/brx/config.json
+++ b/polyfills/Intl/~locale/brx/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/bs-Cyrl-BA/config.json
+++ b/polyfills/Intl/~locale/bs-Cyrl-BA/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/bs-Cyrl-BA/config.json
+++ b/polyfills/Intl/~locale/bs-Cyrl-BA/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/bs-Cyrl/config.json
+++ b/polyfills/Intl/~locale/bs-Cyrl/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/bs-Cyrl/config.json
+++ b/polyfills/Intl/~locale/bs-Cyrl/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/bs-Latn-BA/config.json
+++ b/polyfills/Intl/~locale/bs-Latn-BA/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/bs-Latn-BA/config.json
+++ b/polyfills/Intl/~locale/bs-Latn-BA/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/bs-Latn/config.json
+++ b/polyfills/Intl/~locale/bs-Latn/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/bs-Latn/config.json
+++ b/polyfills/Intl/~locale/bs-Latn/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/bs/config.json
+++ b/polyfills/Intl/~locale/bs/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/bs/config.json
+++ b/polyfills/Intl/~locale/bs/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ca-AD/config.json
+++ b/polyfills/Intl/~locale/ca-AD/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ca-AD/config.json
+++ b/polyfills/Intl/~locale/ca-AD/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ca-ES-VALENCIA/config.json
+++ b/polyfills/Intl/~locale/ca-ES-VALENCIA/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ca-ES-VALENCIA/config.json
+++ b/polyfills/Intl/~locale/ca-ES-VALENCIA/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ca-ES/config.json
+++ b/polyfills/Intl/~locale/ca-ES/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ca-ES/config.json
+++ b/polyfills/Intl/~locale/ca-ES/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ca-FR/config.json
+++ b/polyfills/Intl/~locale/ca-FR/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ca-FR/config.json
+++ b/polyfills/Intl/~locale/ca-FR/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ca-IT/config.json
+++ b/polyfills/Intl/~locale/ca-IT/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ca-IT/config.json
+++ b/polyfills/Intl/~locale/ca-IT/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ca/config.json
+++ b/polyfills/Intl/~locale/ca/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ca/config.json
+++ b/polyfills/Intl/~locale/ca/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/cgg-UG/config.json
+++ b/polyfills/Intl/~locale/cgg-UG/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/cgg-UG/config.json
+++ b/polyfills/Intl/~locale/cgg-UG/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/cgg/config.json
+++ b/polyfills/Intl/~locale/cgg/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/cgg/config.json
+++ b/polyfills/Intl/~locale/cgg/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/chr-US/config.json
+++ b/polyfills/Intl/~locale/chr-US/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/chr-US/config.json
+++ b/polyfills/Intl/~locale/chr-US/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/chr/config.json
+++ b/polyfills/Intl/~locale/chr/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/chr/config.json
+++ b/polyfills/Intl/~locale/chr/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/cs-CZ/config.json
+++ b/polyfills/Intl/~locale/cs-CZ/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/cs-CZ/config.json
+++ b/polyfills/Intl/~locale/cs-CZ/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/cs/config.json
+++ b/polyfills/Intl/~locale/cs/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/cs/config.json
+++ b/polyfills/Intl/~locale/cs/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/cy-GB/config.json
+++ b/polyfills/Intl/~locale/cy-GB/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/cy-GB/config.json
+++ b/polyfills/Intl/~locale/cy-GB/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/cy/config.json
+++ b/polyfills/Intl/~locale/cy/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/cy/config.json
+++ b/polyfills/Intl/~locale/cy/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/da-DK/config.json
+++ b/polyfills/Intl/~locale/da-DK/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/da-DK/config.json
+++ b/polyfills/Intl/~locale/da-DK/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/da-GL/config.json
+++ b/polyfills/Intl/~locale/da-GL/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/da-GL/config.json
+++ b/polyfills/Intl/~locale/da-GL/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/da/config.json
+++ b/polyfills/Intl/~locale/da/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/da/config.json
+++ b/polyfills/Intl/~locale/da/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/dav-KE/config.json
+++ b/polyfills/Intl/~locale/dav-KE/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/dav-KE/config.json
+++ b/polyfills/Intl/~locale/dav-KE/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/dav/config.json
+++ b/polyfills/Intl/~locale/dav/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/dav/config.json
+++ b/polyfills/Intl/~locale/dav/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/de-AT/config.json
+++ b/polyfills/Intl/~locale/de-AT/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/de-AT/config.json
+++ b/polyfills/Intl/~locale/de-AT/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/de-BE/config.json
+++ b/polyfills/Intl/~locale/de-BE/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/de-BE/config.json
+++ b/polyfills/Intl/~locale/de-BE/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/de-CH/config.json
+++ b/polyfills/Intl/~locale/de-CH/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/de-CH/config.json
+++ b/polyfills/Intl/~locale/de-CH/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/de-DE/config.json
+++ b/polyfills/Intl/~locale/de-DE/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/de-DE/config.json
+++ b/polyfills/Intl/~locale/de-DE/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/de-LI/config.json
+++ b/polyfills/Intl/~locale/de-LI/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/de-LI/config.json
+++ b/polyfills/Intl/~locale/de-LI/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/de-LU/config.json
+++ b/polyfills/Intl/~locale/de-LU/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/de-LU/config.json
+++ b/polyfills/Intl/~locale/de-LU/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/de/config.json
+++ b/polyfills/Intl/~locale/de/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/de/config.json
+++ b/polyfills/Intl/~locale/de/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/dje-NE/config.json
+++ b/polyfills/Intl/~locale/dje-NE/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/dje-NE/config.json
+++ b/polyfills/Intl/~locale/dje-NE/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/dje/config.json
+++ b/polyfills/Intl/~locale/dje/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/dje/config.json
+++ b/polyfills/Intl/~locale/dje/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/dsb-DE/config.json
+++ b/polyfills/Intl/~locale/dsb-DE/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/dsb-DE/config.json
+++ b/polyfills/Intl/~locale/dsb-DE/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/dsb/config.json
+++ b/polyfills/Intl/~locale/dsb/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/dsb/config.json
+++ b/polyfills/Intl/~locale/dsb/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/dua-CM/config.json
+++ b/polyfills/Intl/~locale/dua-CM/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/dua-CM/config.json
+++ b/polyfills/Intl/~locale/dua-CM/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/dua/config.json
+++ b/polyfills/Intl/~locale/dua/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/dua/config.json
+++ b/polyfills/Intl/~locale/dua/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/dyo-SN/config.json
+++ b/polyfills/Intl/~locale/dyo-SN/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/dyo-SN/config.json
+++ b/polyfills/Intl/~locale/dyo-SN/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/dyo/config.json
+++ b/polyfills/Intl/~locale/dyo/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/dyo/config.json
+++ b/polyfills/Intl/~locale/dyo/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/dz-BT/config.json
+++ b/polyfills/Intl/~locale/dz-BT/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/dz-BT/config.json
+++ b/polyfills/Intl/~locale/dz-BT/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/dz/config.json
+++ b/polyfills/Intl/~locale/dz/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/dz/config.json
+++ b/polyfills/Intl/~locale/dz/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ebu-KE/config.json
+++ b/polyfills/Intl/~locale/ebu-KE/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ebu-KE/config.json
+++ b/polyfills/Intl/~locale/ebu-KE/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ebu/config.json
+++ b/polyfills/Intl/~locale/ebu/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ebu/config.json
+++ b/polyfills/Intl/~locale/ebu/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ee-GH/config.json
+++ b/polyfills/Intl/~locale/ee-GH/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ee-GH/config.json
+++ b/polyfills/Intl/~locale/ee-GH/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ee-TG/config.json
+++ b/polyfills/Intl/~locale/ee-TG/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ee-TG/config.json
+++ b/polyfills/Intl/~locale/ee-TG/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ee/config.json
+++ b/polyfills/Intl/~locale/ee/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ee/config.json
+++ b/polyfills/Intl/~locale/ee/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/el-CY/config.json
+++ b/polyfills/Intl/~locale/el-CY/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/el-CY/config.json
+++ b/polyfills/Intl/~locale/el-CY/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/el-GR/config.json
+++ b/polyfills/Intl/~locale/el-GR/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/el-GR/config.json
+++ b/polyfills/Intl/~locale/el-GR/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/el/config.json
+++ b/polyfills/Intl/~locale/el/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/el/config.json
+++ b/polyfills/Intl/~locale/el/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-001/config.json
+++ b/polyfills/Intl/~locale/en-001/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-001/config.json
+++ b/polyfills/Intl/~locale/en-001/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-150/config.json
+++ b/polyfills/Intl/~locale/en-150/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-150/config.json
+++ b/polyfills/Intl/~locale/en-150/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-AG/config.json
+++ b/polyfills/Intl/~locale/en-AG/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-AG/config.json
+++ b/polyfills/Intl/~locale/en-AG/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-AI/config.json
+++ b/polyfills/Intl/~locale/en-AI/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-AI/config.json
+++ b/polyfills/Intl/~locale/en-AI/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-AS/config.json
+++ b/polyfills/Intl/~locale/en-AS/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-AS/config.json
+++ b/polyfills/Intl/~locale/en-AS/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-AU/config.json
+++ b/polyfills/Intl/~locale/en-AU/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-AU/config.json
+++ b/polyfills/Intl/~locale/en-AU/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-BB/config.json
+++ b/polyfills/Intl/~locale/en-BB/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-BB/config.json
+++ b/polyfills/Intl/~locale/en-BB/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-BE/config.json
+++ b/polyfills/Intl/~locale/en-BE/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-BE/config.json
+++ b/polyfills/Intl/~locale/en-BE/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-BM/config.json
+++ b/polyfills/Intl/~locale/en-BM/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-BM/config.json
+++ b/polyfills/Intl/~locale/en-BM/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-BS/config.json
+++ b/polyfills/Intl/~locale/en-BS/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-BS/config.json
+++ b/polyfills/Intl/~locale/en-BS/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-BW/config.json
+++ b/polyfills/Intl/~locale/en-BW/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-BW/config.json
+++ b/polyfills/Intl/~locale/en-BW/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-BZ/config.json
+++ b/polyfills/Intl/~locale/en-BZ/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-BZ/config.json
+++ b/polyfills/Intl/~locale/en-BZ/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-CA/config.json
+++ b/polyfills/Intl/~locale/en-CA/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-CA/config.json
+++ b/polyfills/Intl/~locale/en-CA/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-CC/config.json
+++ b/polyfills/Intl/~locale/en-CC/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-CC/config.json
+++ b/polyfills/Intl/~locale/en-CC/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-CK/config.json
+++ b/polyfills/Intl/~locale/en-CK/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-CK/config.json
+++ b/polyfills/Intl/~locale/en-CK/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-CM/config.json
+++ b/polyfills/Intl/~locale/en-CM/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-CM/config.json
+++ b/polyfills/Intl/~locale/en-CM/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-CX/config.json
+++ b/polyfills/Intl/~locale/en-CX/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-CX/config.json
+++ b/polyfills/Intl/~locale/en-CX/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-DG/config.json
+++ b/polyfills/Intl/~locale/en-DG/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-DG/config.json
+++ b/polyfills/Intl/~locale/en-DG/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-DM/config.json
+++ b/polyfills/Intl/~locale/en-DM/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-DM/config.json
+++ b/polyfills/Intl/~locale/en-DM/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-Dsrt/config.json
+++ b/polyfills/Intl/~locale/en-Dsrt/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-Dsrt/config.json
+++ b/polyfills/Intl/~locale/en-Dsrt/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-ER/config.json
+++ b/polyfills/Intl/~locale/en-ER/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-ER/config.json
+++ b/polyfills/Intl/~locale/en-ER/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-FJ/config.json
+++ b/polyfills/Intl/~locale/en-FJ/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-FJ/config.json
+++ b/polyfills/Intl/~locale/en-FJ/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-FK/config.json
+++ b/polyfills/Intl/~locale/en-FK/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-FK/config.json
+++ b/polyfills/Intl/~locale/en-FK/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-FM/config.json
+++ b/polyfills/Intl/~locale/en-FM/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-FM/config.json
+++ b/polyfills/Intl/~locale/en-FM/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-GB/config.json
+++ b/polyfills/Intl/~locale/en-GB/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-GB/config.json
+++ b/polyfills/Intl/~locale/en-GB/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-GD/config.json
+++ b/polyfills/Intl/~locale/en-GD/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-GD/config.json
+++ b/polyfills/Intl/~locale/en-GD/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-GG/config.json
+++ b/polyfills/Intl/~locale/en-GG/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-GG/config.json
+++ b/polyfills/Intl/~locale/en-GG/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-GH/config.json
+++ b/polyfills/Intl/~locale/en-GH/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-GH/config.json
+++ b/polyfills/Intl/~locale/en-GH/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-GI/config.json
+++ b/polyfills/Intl/~locale/en-GI/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-GI/config.json
+++ b/polyfills/Intl/~locale/en-GI/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-GM/config.json
+++ b/polyfills/Intl/~locale/en-GM/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-GM/config.json
+++ b/polyfills/Intl/~locale/en-GM/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-GU/config.json
+++ b/polyfills/Intl/~locale/en-GU/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-GU/config.json
+++ b/polyfills/Intl/~locale/en-GU/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-GY/config.json
+++ b/polyfills/Intl/~locale/en-GY/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-GY/config.json
+++ b/polyfills/Intl/~locale/en-GY/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-HK/config.json
+++ b/polyfills/Intl/~locale/en-HK/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-HK/config.json
+++ b/polyfills/Intl/~locale/en-HK/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-IE/config.json
+++ b/polyfills/Intl/~locale/en-IE/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-IE/config.json
+++ b/polyfills/Intl/~locale/en-IE/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-IM/config.json
+++ b/polyfills/Intl/~locale/en-IM/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-IM/config.json
+++ b/polyfills/Intl/~locale/en-IM/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-IN/config.json
+++ b/polyfills/Intl/~locale/en-IN/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-IN/config.json
+++ b/polyfills/Intl/~locale/en-IN/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-IO/config.json
+++ b/polyfills/Intl/~locale/en-IO/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-IO/config.json
+++ b/polyfills/Intl/~locale/en-IO/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-JE/config.json
+++ b/polyfills/Intl/~locale/en-JE/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-JE/config.json
+++ b/polyfills/Intl/~locale/en-JE/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-JM/config.json
+++ b/polyfills/Intl/~locale/en-JM/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-JM/config.json
+++ b/polyfills/Intl/~locale/en-JM/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-KE/config.json
+++ b/polyfills/Intl/~locale/en-KE/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-KE/config.json
+++ b/polyfills/Intl/~locale/en-KE/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-KI/config.json
+++ b/polyfills/Intl/~locale/en-KI/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-KI/config.json
+++ b/polyfills/Intl/~locale/en-KI/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-KN/config.json
+++ b/polyfills/Intl/~locale/en-KN/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-KN/config.json
+++ b/polyfills/Intl/~locale/en-KN/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-KY/config.json
+++ b/polyfills/Intl/~locale/en-KY/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-KY/config.json
+++ b/polyfills/Intl/~locale/en-KY/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-LC/config.json
+++ b/polyfills/Intl/~locale/en-LC/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-LC/config.json
+++ b/polyfills/Intl/~locale/en-LC/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-LR/config.json
+++ b/polyfills/Intl/~locale/en-LR/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-LR/config.json
+++ b/polyfills/Intl/~locale/en-LR/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-LS/config.json
+++ b/polyfills/Intl/~locale/en-LS/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-LS/config.json
+++ b/polyfills/Intl/~locale/en-LS/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-MG/config.json
+++ b/polyfills/Intl/~locale/en-MG/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-MG/config.json
+++ b/polyfills/Intl/~locale/en-MG/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-MH/config.json
+++ b/polyfills/Intl/~locale/en-MH/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-MH/config.json
+++ b/polyfills/Intl/~locale/en-MH/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-MO/config.json
+++ b/polyfills/Intl/~locale/en-MO/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-MO/config.json
+++ b/polyfills/Intl/~locale/en-MO/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-MP/config.json
+++ b/polyfills/Intl/~locale/en-MP/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-MP/config.json
+++ b/polyfills/Intl/~locale/en-MP/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-MS/config.json
+++ b/polyfills/Intl/~locale/en-MS/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-MS/config.json
+++ b/polyfills/Intl/~locale/en-MS/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-MT/config.json
+++ b/polyfills/Intl/~locale/en-MT/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-MT/config.json
+++ b/polyfills/Intl/~locale/en-MT/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-MU/config.json
+++ b/polyfills/Intl/~locale/en-MU/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-MU/config.json
+++ b/polyfills/Intl/~locale/en-MU/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-MW/config.json
+++ b/polyfills/Intl/~locale/en-MW/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-MW/config.json
+++ b/polyfills/Intl/~locale/en-MW/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-MY/config.json
+++ b/polyfills/Intl/~locale/en-MY/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-MY/config.json
+++ b/polyfills/Intl/~locale/en-MY/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-NA/config.json
+++ b/polyfills/Intl/~locale/en-NA/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-NA/config.json
+++ b/polyfills/Intl/~locale/en-NA/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-NF/config.json
+++ b/polyfills/Intl/~locale/en-NF/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-NF/config.json
+++ b/polyfills/Intl/~locale/en-NF/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-NG/config.json
+++ b/polyfills/Intl/~locale/en-NG/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-NG/config.json
+++ b/polyfills/Intl/~locale/en-NG/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-NR/config.json
+++ b/polyfills/Intl/~locale/en-NR/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-NR/config.json
+++ b/polyfills/Intl/~locale/en-NR/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-NU/config.json
+++ b/polyfills/Intl/~locale/en-NU/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-NU/config.json
+++ b/polyfills/Intl/~locale/en-NU/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-NZ/config.json
+++ b/polyfills/Intl/~locale/en-NZ/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-NZ/config.json
+++ b/polyfills/Intl/~locale/en-NZ/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-PG/config.json
+++ b/polyfills/Intl/~locale/en-PG/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-PG/config.json
+++ b/polyfills/Intl/~locale/en-PG/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-PH/config.json
+++ b/polyfills/Intl/~locale/en-PH/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-PH/config.json
+++ b/polyfills/Intl/~locale/en-PH/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-PK/config.json
+++ b/polyfills/Intl/~locale/en-PK/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-PK/config.json
+++ b/polyfills/Intl/~locale/en-PK/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-PN/config.json
+++ b/polyfills/Intl/~locale/en-PN/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-PN/config.json
+++ b/polyfills/Intl/~locale/en-PN/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-PR/config.json
+++ b/polyfills/Intl/~locale/en-PR/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-PR/config.json
+++ b/polyfills/Intl/~locale/en-PR/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-PW/config.json
+++ b/polyfills/Intl/~locale/en-PW/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-PW/config.json
+++ b/polyfills/Intl/~locale/en-PW/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-RW/config.json
+++ b/polyfills/Intl/~locale/en-RW/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-RW/config.json
+++ b/polyfills/Intl/~locale/en-RW/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-SB/config.json
+++ b/polyfills/Intl/~locale/en-SB/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-SB/config.json
+++ b/polyfills/Intl/~locale/en-SB/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-SC/config.json
+++ b/polyfills/Intl/~locale/en-SC/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-SC/config.json
+++ b/polyfills/Intl/~locale/en-SC/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-SD/config.json
+++ b/polyfills/Intl/~locale/en-SD/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-SD/config.json
+++ b/polyfills/Intl/~locale/en-SD/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-SG/config.json
+++ b/polyfills/Intl/~locale/en-SG/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-SG/config.json
+++ b/polyfills/Intl/~locale/en-SG/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-SH/config.json
+++ b/polyfills/Intl/~locale/en-SH/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-SH/config.json
+++ b/polyfills/Intl/~locale/en-SH/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-SL/config.json
+++ b/polyfills/Intl/~locale/en-SL/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-SL/config.json
+++ b/polyfills/Intl/~locale/en-SL/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-SS/config.json
+++ b/polyfills/Intl/~locale/en-SS/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-SS/config.json
+++ b/polyfills/Intl/~locale/en-SS/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-SX/config.json
+++ b/polyfills/Intl/~locale/en-SX/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-SX/config.json
+++ b/polyfills/Intl/~locale/en-SX/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-SZ/config.json
+++ b/polyfills/Intl/~locale/en-SZ/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-SZ/config.json
+++ b/polyfills/Intl/~locale/en-SZ/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-Shaw/config.json
+++ b/polyfills/Intl/~locale/en-Shaw/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-Shaw/config.json
+++ b/polyfills/Intl/~locale/en-Shaw/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-TC/config.json
+++ b/polyfills/Intl/~locale/en-TC/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-TC/config.json
+++ b/polyfills/Intl/~locale/en-TC/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-TK/config.json
+++ b/polyfills/Intl/~locale/en-TK/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-TK/config.json
+++ b/polyfills/Intl/~locale/en-TK/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-TO/config.json
+++ b/polyfills/Intl/~locale/en-TO/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-TO/config.json
+++ b/polyfills/Intl/~locale/en-TO/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-TT/config.json
+++ b/polyfills/Intl/~locale/en-TT/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-TT/config.json
+++ b/polyfills/Intl/~locale/en-TT/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-TV/config.json
+++ b/polyfills/Intl/~locale/en-TV/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-TV/config.json
+++ b/polyfills/Intl/~locale/en-TV/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-TZ/config.json
+++ b/polyfills/Intl/~locale/en-TZ/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-TZ/config.json
+++ b/polyfills/Intl/~locale/en-TZ/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-UG/config.json
+++ b/polyfills/Intl/~locale/en-UG/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-UG/config.json
+++ b/polyfills/Intl/~locale/en-UG/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-UM/config.json
+++ b/polyfills/Intl/~locale/en-UM/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-UM/config.json
+++ b/polyfills/Intl/~locale/en-UM/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-US/config.json
+++ b/polyfills/Intl/~locale/en-US/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-US/config.json
+++ b/polyfills/Intl/~locale/en-US/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-VC/config.json
+++ b/polyfills/Intl/~locale/en-VC/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-VC/config.json
+++ b/polyfills/Intl/~locale/en-VC/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-VG/config.json
+++ b/polyfills/Intl/~locale/en-VG/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-VG/config.json
+++ b/polyfills/Intl/~locale/en-VG/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-VI/config.json
+++ b/polyfills/Intl/~locale/en-VI/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-VI/config.json
+++ b/polyfills/Intl/~locale/en-VI/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-VU/config.json
+++ b/polyfills/Intl/~locale/en-VU/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-VU/config.json
+++ b/polyfills/Intl/~locale/en-VU/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-WS/config.json
+++ b/polyfills/Intl/~locale/en-WS/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-WS/config.json
+++ b/polyfills/Intl/~locale/en-WS/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-ZA/config.json
+++ b/polyfills/Intl/~locale/en-ZA/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-ZA/config.json
+++ b/polyfills/Intl/~locale/en-ZA/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-ZM/config.json
+++ b/polyfills/Intl/~locale/en-ZM/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-ZM/config.json
+++ b/polyfills/Intl/~locale/en-ZM/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en-ZW/config.json
+++ b/polyfills/Intl/~locale/en-ZW/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en-ZW/config.json
+++ b/polyfills/Intl/~locale/en-ZW/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/en/config.json
+++ b/polyfills/Intl/~locale/en/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/en/config.json
+++ b/polyfills/Intl/~locale/en/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/eo-001/config.json
+++ b/polyfills/Intl/~locale/eo-001/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/eo-001/config.json
+++ b/polyfills/Intl/~locale/eo-001/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/eo/config.json
+++ b/polyfills/Intl/~locale/eo/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/eo/config.json
+++ b/polyfills/Intl/~locale/eo/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/es-419/config.json
+++ b/polyfills/Intl/~locale/es-419/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/es-419/config.json
+++ b/polyfills/Intl/~locale/es-419/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/es-AR/config.json
+++ b/polyfills/Intl/~locale/es-AR/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/es-AR/config.json
+++ b/polyfills/Intl/~locale/es-AR/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/es-BO/config.json
+++ b/polyfills/Intl/~locale/es-BO/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/es-BO/config.json
+++ b/polyfills/Intl/~locale/es-BO/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/es-CL/config.json
+++ b/polyfills/Intl/~locale/es-CL/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/es-CL/config.json
+++ b/polyfills/Intl/~locale/es-CL/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/es-CO/config.json
+++ b/polyfills/Intl/~locale/es-CO/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/es-CO/config.json
+++ b/polyfills/Intl/~locale/es-CO/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/es-CR/config.json
+++ b/polyfills/Intl/~locale/es-CR/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/es-CR/config.json
+++ b/polyfills/Intl/~locale/es-CR/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/es-CU/config.json
+++ b/polyfills/Intl/~locale/es-CU/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/es-CU/config.json
+++ b/polyfills/Intl/~locale/es-CU/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/es-DO/config.json
+++ b/polyfills/Intl/~locale/es-DO/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/es-DO/config.json
+++ b/polyfills/Intl/~locale/es-DO/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/es-EA/config.json
+++ b/polyfills/Intl/~locale/es-EA/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/es-EA/config.json
+++ b/polyfills/Intl/~locale/es-EA/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/es-EC/config.json
+++ b/polyfills/Intl/~locale/es-EC/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/es-EC/config.json
+++ b/polyfills/Intl/~locale/es-EC/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/es-ES/config.json
+++ b/polyfills/Intl/~locale/es-ES/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/es-ES/config.json
+++ b/polyfills/Intl/~locale/es-ES/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/es-GQ/config.json
+++ b/polyfills/Intl/~locale/es-GQ/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/es-GQ/config.json
+++ b/polyfills/Intl/~locale/es-GQ/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/es-GT/config.json
+++ b/polyfills/Intl/~locale/es-GT/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/es-GT/config.json
+++ b/polyfills/Intl/~locale/es-GT/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/es-HN/config.json
+++ b/polyfills/Intl/~locale/es-HN/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/es-HN/config.json
+++ b/polyfills/Intl/~locale/es-HN/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/es-IC/config.json
+++ b/polyfills/Intl/~locale/es-IC/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/es-IC/config.json
+++ b/polyfills/Intl/~locale/es-IC/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/es-MX/config.json
+++ b/polyfills/Intl/~locale/es-MX/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/es-MX/config.json
+++ b/polyfills/Intl/~locale/es-MX/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/es-NI/config.json
+++ b/polyfills/Intl/~locale/es-NI/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/es-NI/config.json
+++ b/polyfills/Intl/~locale/es-NI/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/es-PA/config.json
+++ b/polyfills/Intl/~locale/es-PA/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/es-PA/config.json
+++ b/polyfills/Intl/~locale/es-PA/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/es-PE/config.json
+++ b/polyfills/Intl/~locale/es-PE/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/es-PE/config.json
+++ b/polyfills/Intl/~locale/es-PE/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/es-PH/config.json
+++ b/polyfills/Intl/~locale/es-PH/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/es-PH/config.json
+++ b/polyfills/Intl/~locale/es-PH/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/es-PR/config.json
+++ b/polyfills/Intl/~locale/es-PR/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/es-PR/config.json
+++ b/polyfills/Intl/~locale/es-PR/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/es-PY/config.json
+++ b/polyfills/Intl/~locale/es-PY/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/es-PY/config.json
+++ b/polyfills/Intl/~locale/es-PY/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/es-SV/config.json
+++ b/polyfills/Intl/~locale/es-SV/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/es-SV/config.json
+++ b/polyfills/Intl/~locale/es-SV/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/es-US/config.json
+++ b/polyfills/Intl/~locale/es-US/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/es-US/config.json
+++ b/polyfills/Intl/~locale/es-US/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/es-UY/config.json
+++ b/polyfills/Intl/~locale/es-UY/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/es-UY/config.json
+++ b/polyfills/Intl/~locale/es-UY/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/es-VE/config.json
+++ b/polyfills/Intl/~locale/es-VE/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/es-VE/config.json
+++ b/polyfills/Intl/~locale/es-VE/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/es/config.json
+++ b/polyfills/Intl/~locale/es/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/es/config.json
+++ b/polyfills/Intl/~locale/es/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/et-EE/config.json
+++ b/polyfills/Intl/~locale/et-EE/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/et-EE/config.json
+++ b/polyfills/Intl/~locale/et-EE/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/et/config.json
+++ b/polyfills/Intl/~locale/et/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/et/config.json
+++ b/polyfills/Intl/~locale/et/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/eu-ES/config.json
+++ b/polyfills/Intl/~locale/eu-ES/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/eu-ES/config.json
+++ b/polyfills/Intl/~locale/eu-ES/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/eu/config.json
+++ b/polyfills/Intl/~locale/eu/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/eu/config.json
+++ b/polyfills/Intl/~locale/eu/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ewo-CM/config.json
+++ b/polyfills/Intl/~locale/ewo-CM/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ewo-CM/config.json
+++ b/polyfills/Intl/~locale/ewo-CM/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ewo/config.json
+++ b/polyfills/Intl/~locale/ewo/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ewo/config.json
+++ b/polyfills/Intl/~locale/ewo/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fa-AF/config.json
+++ b/polyfills/Intl/~locale/fa-AF/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fa-AF/config.json
+++ b/polyfills/Intl/~locale/fa-AF/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fa-IR/config.json
+++ b/polyfills/Intl/~locale/fa-IR/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fa-IR/config.json
+++ b/polyfills/Intl/~locale/fa-IR/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fa/config.json
+++ b/polyfills/Intl/~locale/fa/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fa/config.json
+++ b/polyfills/Intl/~locale/fa/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ff-CM/config.json
+++ b/polyfills/Intl/~locale/ff-CM/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ff-CM/config.json
+++ b/polyfills/Intl/~locale/ff-CM/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ff-GN/config.json
+++ b/polyfills/Intl/~locale/ff-GN/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ff-GN/config.json
+++ b/polyfills/Intl/~locale/ff-GN/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ff-MR/config.json
+++ b/polyfills/Intl/~locale/ff-MR/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ff-MR/config.json
+++ b/polyfills/Intl/~locale/ff-MR/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ff-SN/config.json
+++ b/polyfills/Intl/~locale/ff-SN/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ff-SN/config.json
+++ b/polyfills/Intl/~locale/ff-SN/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ff/config.json
+++ b/polyfills/Intl/~locale/ff/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ff/config.json
+++ b/polyfills/Intl/~locale/ff/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fi-FI/config.json
+++ b/polyfills/Intl/~locale/fi-FI/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fi-FI/config.json
+++ b/polyfills/Intl/~locale/fi-FI/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fi/config.json
+++ b/polyfills/Intl/~locale/fi/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fi/config.json
+++ b/polyfills/Intl/~locale/fi/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fil-PH/config.json
+++ b/polyfills/Intl/~locale/fil-PH/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fil-PH/config.json
+++ b/polyfills/Intl/~locale/fil-PH/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fil/config.json
+++ b/polyfills/Intl/~locale/fil/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fil/config.json
+++ b/polyfills/Intl/~locale/fil/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fo-FO/config.json
+++ b/polyfills/Intl/~locale/fo-FO/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fo-FO/config.json
+++ b/polyfills/Intl/~locale/fo-FO/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fo/config.json
+++ b/polyfills/Intl/~locale/fo/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fo/config.json
+++ b/polyfills/Intl/~locale/fo/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fr-BE/config.json
+++ b/polyfills/Intl/~locale/fr-BE/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fr-BE/config.json
+++ b/polyfills/Intl/~locale/fr-BE/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fr-BF/config.json
+++ b/polyfills/Intl/~locale/fr-BF/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fr-BF/config.json
+++ b/polyfills/Intl/~locale/fr-BF/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fr-BI/config.json
+++ b/polyfills/Intl/~locale/fr-BI/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fr-BI/config.json
+++ b/polyfills/Intl/~locale/fr-BI/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fr-BJ/config.json
+++ b/polyfills/Intl/~locale/fr-BJ/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fr-BJ/config.json
+++ b/polyfills/Intl/~locale/fr-BJ/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fr-BL/config.json
+++ b/polyfills/Intl/~locale/fr-BL/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fr-BL/config.json
+++ b/polyfills/Intl/~locale/fr-BL/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fr-CA/config.json
+++ b/polyfills/Intl/~locale/fr-CA/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fr-CA/config.json
+++ b/polyfills/Intl/~locale/fr-CA/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fr-CD/config.json
+++ b/polyfills/Intl/~locale/fr-CD/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fr-CD/config.json
+++ b/polyfills/Intl/~locale/fr-CD/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fr-CF/config.json
+++ b/polyfills/Intl/~locale/fr-CF/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fr-CF/config.json
+++ b/polyfills/Intl/~locale/fr-CF/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fr-CG/config.json
+++ b/polyfills/Intl/~locale/fr-CG/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fr-CG/config.json
+++ b/polyfills/Intl/~locale/fr-CG/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fr-CH/config.json
+++ b/polyfills/Intl/~locale/fr-CH/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fr-CH/config.json
+++ b/polyfills/Intl/~locale/fr-CH/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fr-CI/config.json
+++ b/polyfills/Intl/~locale/fr-CI/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fr-CI/config.json
+++ b/polyfills/Intl/~locale/fr-CI/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fr-CM/config.json
+++ b/polyfills/Intl/~locale/fr-CM/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fr-CM/config.json
+++ b/polyfills/Intl/~locale/fr-CM/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fr-DJ/config.json
+++ b/polyfills/Intl/~locale/fr-DJ/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fr-DJ/config.json
+++ b/polyfills/Intl/~locale/fr-DJ/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fr-DZ/config.json
+++ b/polyfills/Intl/~locale/fr-DZ/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fr-DZ/config.json
+++ b/polyfills/Intl/~locale/fr-DZ/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fr-FR/config.json
+++ b/polyfills/Intl/~locale/fr-FR/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fr-FR/config.json
+++ b/polyfills/Intl/~locale/fr-FR/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fr-GA/config.json
+++ b/polyfills/Intl/~locale/fr-GA/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fr-GA/config.json
+++ b/polyfills/Intl/~locale/fr-GA/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fr-GF/config.json
+++ b/polyfills/Intl/~locale/fr-GF/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fr-GF/config.json
+++ b/polyfills/Intl/~locale/fr-GF/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fr-GN/config.json
+++ b/polyfills/Intl/~locale/fr-GN/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fr-GN/config.json
+++ b/polyfills/Intl/~locale/fr-GN/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fr-GP/config.json
+++ b/polyfills/Intl/~locale/fr-GP/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fr-GP/config.json
+++ b/polyfills/Intl/~locale/fr-GP/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fr-GQ/config.json
+++ b/polyfills/Intl/~locale/fr-GQ/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fr-GQ/config.json
+++ b/polyfills/Intl/~locale/fr-GQ/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fr-HT/config.json
+++ b/polyfills/Intl/~locale/fr-HT/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fr-HT/config.json
+++ b/polyfills/Intl/~locale/fr-HT/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fr-KM/config.json
+++ b/polyfills/Intl/~locale/fr-KM/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fr-KM/config.json
+++ b/polyfills/Intl/~locale/fr-KM/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fr-LU/config.json
+++ b/polyfills/Intl/~locale/fr-LU/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fr-LU/config.json
+++ b/polyfills/Intl/~locale/fr-LU/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fr-MA/config.json
+++ b/polyfills/Intl/~locale/fr-MA/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fr-MA/config.json
+++ b/polyfills/Intl/~locale/fr-MA/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fr-MC/config.json
+++ b/polyfills/Intl/~locale/fr-MC/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fr-MC/config.json
+++ b/polyfills/Intl/~locale/fr-MC/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fr-MF/config.json
+++ b/polyfills/Intl/~locale/fr-MF/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fr-MF/config.json
+++ b/polyfills/Intl/~locale/fr-MF/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fr-MG/config.json
+++ b/polyfills/Intl/~locale/fr-MG/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fr-MG/config.json
+++ b/polyfills/Intl/~locale/fr-MG/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fr-ML/config.json
+++ b/polyfills/Intl/~locale/fr-ML/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fr-ML/config.json
+++ b/polyfills/Intl/~locale/fr-ML/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fr-MQ/config.json
+++ b/polyfills/Intl/~locale/fr-MQ/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fr-MQ/config.json
+++ b/polyfills/Intl/~locale/fr-MQ/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fr-MR/config.json
+++ b/polyfills/Intl/~locale/fr-MR/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fr-MR/config.json
+++ b/polyfills/Intl/~locale/fr-MR/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fr-MU/config.json
+++ b/polyfills/Intl/~locale/fr-MU/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fr-MU/config.json
+++ b/polyfills/Intl/~locale/fr-MU/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fr-NC/config.json
+++ b/polyfills/Intl/~locale/fr-NC/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fr-NC/config.json
+++ b/polyfills/Intl/~locale/fr-NC/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fr-NE/config.json
+++ b/polyfills/Intl/~locale/fr-NE/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fr-NE/config.json
+++ b/polyfills/Intl/~locale/fr-NE/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fr-PF/config.json
+++ b/polyfills/Intl/~locale/fr-PF/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fr-PF/config.json
+++ b/polyfills/Intl/~locale/fr-PF/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fr-PM/config.json
+++ b/polyfills/Intl/~locale/fr-PM/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fr-PM/config.json
+++ b/polyfills/Intl/~locale/fr-PM/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fr-RE/config.json
+++ b/polyfills/Intl/~locale/fr-RE/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fr-RE/config.json
+++ b/polyfills/Intl/~locale/fr-RE/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fr-RW/config.json
+++ b/polyfills/Intl/~locale/fr-RW/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fr-RW/config.json
+++ b/polyfills/Intl/~locale/fr-RW/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fr-SC/config.json
+++ b/polyfills/Intl/~locale/fr-SC/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fr-SC/config.json
+++ b/polyfills/Intl/~locale/fr-SC/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fr-SN/config.json
+++ b/polyfills/Intl/~locale/fr-SN/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fr-SN/config.json
+++ b/polyfills/Intl/~locale/fr-SN/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fr-SY/config.json
+++ b/polyfills/Intl/~locale/fr-SY/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fr-SY/config.json
+++ b/polyfills/Intl/~locale/fr-SY/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fr-TD/config.json
+++ b/polyfills/Intl/~locale/fr-TD/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fr-TD/config.json
+++ b/polyfills/Intl/~locale/fr-TD/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fr-TG/config.json
+++ b/polyfills/Intl/~locale/fr-TG/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fr-TG/config.json
+++ b/polyfills/Intl/~locale/fr-TG/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fr-TN/config.json
+++ b/polyfills/Intl/~locale/fr-TN/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fr-TN/config.json
+++ b/polyfills/Intl/~locale/fr-TN/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fr-VU/config.json
+++ b/polyfills/Intl/~locale/fr-VU/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fr-VU/config.json
+++ b/polyfills/Intl/~locale/fr-VU/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fr-WF/config.json
+++ b/polyfills/Intl/~locale/fr-WF/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fr-WF/config.json
+++ b/polyfills/Intl/~locale/fr-WF/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fr-YT/config.json
+++ b/polyfills/Intl/~locale/fr-YT/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fr-YT/config.json
+++ b/polyfills/Intl/~locale/fr-YT/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fr/config.json
+++ b/polyfills/Intl/~locale/fr/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fr/config.json
+++ b/polyfills/Intl/~locale/fr/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fur-IT/config.json
+++ b/polyfills/Intl/~locale/fur-IT/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fur-IT/config.json
+++ b/polyfills/Intl/~locale/fur-IT/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fur/config.json
+++ b/polyfills/Intl/~locale/fur/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fur/config.json
+++ b/polyfills/Intl/~locale/fur/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fy-NL/config.json
+++ b/polyfills/Intl/~locale/fy-NL/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fy-NL/config.json
+++ b/polyfills/Intl/~locale/fy-NL/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/fy/config.json
+++ b/polyfills/Intl/~locale/fy/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/fy/config.json
+++ b/polyfills/Intl/~locale/fy/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ga-IE/config.json
+++ b/polyfills/Intl/~locale/ga-IE/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ga-IE/config.json
+++ b/polyfills/Intl/~locale/ga-IE/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ga/config.json
+++ b/polyfills/Intl/~locale/ga/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ga/config.json
+++ b/polyfills/Intl/~locale/ga/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/gd-GB/config.json
+++ b/polyfills/Intl/~locale/gd-GB/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/gd-GB/config.json
+++ b/polyfills/Intl/~locale/gd-GB/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/gd/config.json
+++ b/polyfills/Intl/~locale/gd/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/gd/config.json
+++ b/polyfills/Intl/~locale/gd/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/gl-ES/config.json
+++ b/polyfills/Intl/~locale/gl-ES/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/gl-ES/config.json
+++ b/polyfills/Intl/~locale/gl-ES/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/gl/config.json
+++ b/polyfills/Intl/~locale/gl/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/gl/config.json
+++ b/polyfills/Intl/~locale/gl/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/gsw-CH/config.json
+++ b/polyfills/Intl/~locale/gsw-CH/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/gsw-CH/config.json
+++ b/polyfills/Intl/~locale/gsw-CH/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/gsw-FR/config.json
+++ b/polyfills/Intl/~locale/gsw-FR/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/gsw-FR/config.json
+++ b/polyfills/Intl/~locale/gsw-FR/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/gsw-LI/config.json
+++ b/polyfills/Intl/~locale/gsw-LI/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/gsw-LI/config.json
+++ b/polyfills/Intl/~locale/gsw-LI/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/gsw/config.json
+++ b/polyfills/Intl/~locale/gsw/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/gsw/config.json
+++ b/polyfills/Intl/~locale/gsw/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/gu-IN/config.json
+++ b/polyfills/Intl/~locale/gu-IN/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/gu-IN/config.json
+++ b/polyfills/Intl/~locale/gu-IN/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/gu/config.json
+++ b/polyfills/Intl/~locale/gu/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/gu/config.json
+++ b/polyfills/Intl/~locale/gu/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/guz-KE/config.json
+++ b/polyfills/Intl/~locale/guz-KE/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/guz-KE/config.json
+++ b/polyfills/Intl/~locale/guz-KE/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/guz/config.json
+++ b/polyfills/Intl/~locale/guz/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/guz/config.json
+++ b/polyfills/Intl/~locale/guz/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/gv-IM/config.json
+++ b/polyfills/Intl/~locale/gv-IM/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/gv-IM/config.json
+++ b/polyfills/Intl/~locale/gv-IM/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/gv/config.json
+++ b/polyfills/Intl/~locale/gv/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/gv/config.json
+++ b/polyfills/Intl/~locale/gv/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ha-Arab/config.json
+++ b/polyfills/Intl/~locale/ha-Arab/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ha-Arab/config.json
+++ b/polyfills/Intl/~locale/ha-Arab/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ha-Latn-GH/config.json
+++ b/polyfills/Intl/~locale/ha-Latn-GH/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ha-Latn-GH/config.json
+++ b/polyfills/Intl/~locale/ha-Latn-GH/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ha-Latn-NE/config.json
+++ b/polyfills/Intl/~locale/ha-Latn-NE/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ha-Latn-NE/config.json
+++ b/polyfills/Intl/~locale/ha-Latn-NE/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ha-Latn-NG/config.json
+++ b/polyfills/Intl/~locale/ha-Latn-NG/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ha-Latn-NG/config.json
+++ b/polyfills/Intl/~locale/ha-Latn-NG/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ha-Latn/config.json
+++ b/polyfills/Intl/~locale/ha-Latn/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ha-Latn/config.json
+++ b/polyfills/Intl/~locale/ha-Latn/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ha/config.json
+++ b/polyfills/Intl/~locale/ha/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ha/config.json
+++ b/polyfills/Intl/~locale/ha/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/haw-US/config.json
+++ b/polyfills/Intl/~locale/haw-US/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/haw-US/config.json
+++ b/polyfills/Intl/~locale/haw-US/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/haw/config.json
+++ b/polyfills/Intl/~locale/haw/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/haw/config.json
+++ b/polyfills/Intl/~locale/haw/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/he-IL/config.json
+++ b/polyfills/Intl/~locale/he-IL/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/he-IL/config.json
+++ b/polyfills/Intl/~locale/he-IL/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/he/config.json
+++ b/polyfills/Intl/~locale/he/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/he/config.json
+++ b/polyfills/Intl/~locale/he/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/hi-IN/config.json
+++ b/polyfills/Intl/~locale/hi-IN/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/hi-IN/config.json
+++ b/polyfills/Intl/~locale/hi-IN/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/hi/config.json
+++ b/polyfills/Intl/~locale/hi/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/hi/config.json
+++ b/polyfills/Intl/~locale/hi/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/hr-BA/config.json
+++ b/polyfills/Intl/~locale/hr-BA/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/hr-BA/config.json
+++ b/polyfills/Intl/~locale/hr-BA/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/hr-HR/config.json
+++ b/polyfills/Intl/~locale/hr-HR/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/hr-HR/config.json
+++ b/polyfills/Intl/~locale/hr-HR/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/hr/config.json
+++ b/polyfills/Intl/~locale/hr/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/hr/config.json
+++ b/polyfills/Intl/~locale/hr/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/hsb-DE/config.json
+++ b/polyfills/Intl/~locale/hsb-DE/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/hsb-DE/config.json
+++ b/polyfills/Intl/~locale/hsb-DE/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/hsb/config.json
+++ b/polyfills/Intl/~locale/hsb/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/hsb/config.json
+++ b/polyfills/Intl/~locale/hsb/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/hu-HU/config.json
+++ b/polyfills/Intl/~locale/hu-HU/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/hu-HU/config.json
+++ b/polyfills/Intl/~locale/hu-HU/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/hu/config.json
+++ b/polyfills/Intl/~locale/hu/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/hu/config.json
+++ b/polyfills/Intl/~locale/hu/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/hy-AM/config.json
+++ b/polyfills/Intl/~locale/hy-AM/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/hy-AM/config.json
+++ b/polyfills/Intl/~locale/hy-AM/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/hy/config.json
+++ b/polyfills/Intl/~locale/hy/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/hy/config.json
+++ b/polyfills/Intl/~locale/hy/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/id-ID/config.json
+++ b/polyfills/Intl/~locale/id-ID/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/id-ID/config.json
+++ b/polyfills/Intl/~locale/id-ID/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/id/config.json
+++ b/polyfills/Intl/~locale/id/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/id/config.json
+++ b/polyfills/Intl/~locale/id/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ig-NG/config.json
+++ b/polyfills/Intl/~locale/ig-NG/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ig-NG/config.json
+++ b/polyfills/Intl/~locale/ig-NG/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ig/config.json
+++ b/polyfills/Intl/~locale/ig/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ig/config.json
+++ b/polyfills/Intl/~locale/ig/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ii-CN/config.json
+++ b/polyfills/Intl/~locale/ii-CN/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ii-CN/config.json
+++ b/polyfills/Intl/~locale/ii-CN/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ii/config.json
+++ b/polyfills/Intl/~locale/ii/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ii/config.json
+++ b/polyfills/Intl/~locale/ii/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/is-IS/config.json
+++ b/polyfills/Intl/~locale/is-IS/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/is-IS/config.json
+++ b/polyfills/Intl/~locale/is-IS/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/is/config.json
+++ b/polyfills/Intl/~locale/is/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/is/config.json
+++ b/polyfills/Intl/~locale/is/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/it-CH/config.json
+++ b/polyfills/Intl/~locale/it-CH/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/it-CH/config.json
+++ b/polyfills/Intl/~locale/it-CH/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/it-IT/config.json
+++ b/polyfills/Intl/~locale/it-IT/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/it-IT/config.json
+++ b/polyfills/Intl/~locale/it-IT/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/it-SM/config.json
+++ b/polyfills/Intl/~locale/it-SM/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/it-SM/config.json
+++ b/polyfills/Intl/~locale/it-SM/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/it/config.json
+++ b/polyfills/Intl/~locale/it/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/it/config.json
+++ b/polyfills/Intl/~locale/it/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/iu-Latn/config.json
+++ b/polyfills/Intl/~locale/iu-Latn/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/iu-Latn/config.json
+++ b/polyfills/Intl/~locale/iu-Latn/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ja-JP/config.json
+++ b/polyfills/Intl/~locale/ja-JP/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ja-JP/config.json
+++ b/polyfills/Intl/~locale/ja-JP/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ja/config.json
+++ b/polyfills/Intl/~locale/ja/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ja/config.json
+++ b/polyfills/Intl/~locale/ja/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/jgo-CM/config.json
+++ b/polyfills/Intl/~locale/jgo-CM/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/jgo-CM/config.json
+++ b/polyfills/Intl/~locale/jgo-CM/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/jgo/config.json
+++ b/polyfills/Intl/~locale/jgo/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/jgo/config.json
+++ b/polyfills/Intl/~locale/jgo/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/jmc-TZ/config.json
+++ b/polyfills/Intl/~locale/jmc-TZ/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/jmc-TZ/config.json
+++ b/polyfills/Intl/~locale/jmc-TZ/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/jmc/config.json
+++ b/polyfills/Intl/~locale/jmc/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/jmc/config.json
+++ b/polyfills/Intl/~locale/jmc/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ka-GE/config.json
+++ b/polyfills/Intl/~locale/ka-GE/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ka-GE/config.json
+++ b/polyfills/Intl/~locale/ka-GE/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ka/config.json
+++ b/polyfills/Intl/~locale/ka/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ka/config.json
+++ b/polyfills/Intl/~locale/ka/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/kab-DZ/config.json
+++ b/polyfills/Intl/~locale/kab-DZ/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/kab-DZ/config.json
+++ b/polyfills/Intl/~locale/kab-DZ/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/kab/config.json
+++ b/polyfills/Intl/~locale/kab/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/kab/config.json
+++ b/polyfills/Intl/~locale/kab/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/kam-KE/config.json
+++ b/polyfills/Intl/~locale/kam-KE/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/kam-KE/config.json
+++ b/polyfills/Intl/~locale/kam-KE/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/kam/config.json
+++ b/polyfills/Intl/~locale/kam/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/kam/config.json
+++ b/polyfills/Intl/~locale/kam/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/kde-TZ/config.json
+++ b/polyfills/Intl/~locale/kde-TZ/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/kde-TZ/config.json
+++ b/polyfills/Intl/~locale/kde-TZ/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/kde/config.json
+++ b/polyfills/Intl/~locale/kde/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/kde/config.json
+++ b/polyfills/Intl/~locale/kde/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/kea-CV/config.json
+++ b/polyfills/Intl/~locale/kea-CV/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/kea-CV/config.json
+++ b/polyfills/Intl/~locale/kea-CV/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/kea/config.json
+++ b/polyfills/Intl/~locale/kea/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/kea/config.json
+++ b/polyfills/Intl/~locale/kea/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/khq-ML/config.json
+++ b/polyfills/Intl/~locale/khq-ML/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/khq-ML/config.json
+++ b/polyfills/Intl/~locale/khq-ML/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/khq/config.json
+++ b/polyfills/Intl/~locale/khq/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/khq/config.json
+++ b/polyfills/Intl/~locale/khq/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ki-KE/config.json
+++ b/polyfills/Intl/~locale/ki-KE/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ki-KE/config.json
+++ b/polyfills/Intl/~locale/ki-KE/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ki/config.json
+++ b/polyfills/Intl/~locale/ki/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ki/config.json
+++ b/polyfills/Intl/~locale/ki/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/kk-Cyrl-KZ/config.json
+++ b/polyfills/Intl/~locale/kk-Cyrl-KZ/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/kk-Cyrl-KZ/config.json
+++ b/polyfills/Intl/~locale/kk-Cyrl-KZ/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/kk-Cyrl/config.json
+++ b/polyfills/Intl/~locale/kk-Cyrl/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/kk-Cyrl/config.json
+++ b/polyfills/Intl/~locale/kk-Cyrl/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/kk/config.json
+++ b/polyfills/Intl/~locale/kk/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/kk/config.json
+++ b/polyfills/Intl/~locale/kk/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/kkj-CM/config.json
+++ b/polyfills/Intl/~locale/kkj-CM/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/kkj-CM/config.json
+++ b/polyfills/Intl/~locale/kkj-CM/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/kkj/config.json
+++ b/polyfills/Intl/~locale/kkj/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/kkj/config.json
+++ b/polyfills/Intl/~locale/kkj/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/kl-GL/config.json
+++ b/polyfills/Intl/~locale/kl-GL/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/kl-GL/config.json
+++ b/polyfills/Intl/~locale/kl-GL/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/kl/config.json
+++ b/polyfills/Intl/~locale/kl/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/kl/config.json
+++ b/polyfills/Intl/~locale/kl/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/kln-KE/config.json
+++ b/polyfills/Intl/~locale/kln-KE/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/kln-KE/config.json
+++ b/polyfills/Intl/~locale/kln-KE/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/kln/config.json
+++ b/polyfills/Intl/~locale/kln/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/kln/config.json
+++ b/polyfills/Intl/~locale/kln/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/km-KH/config.json
+++ b/polyfills/Intl/~locale/km-KH/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/km-KH/config.json
+++ b/polyfills/Intl/~locale/km-KH/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/km/config.json
+++ b/polyfills/Intl/~locale/km/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/km/config.json
+++ b/polyfills/Intl/~locale/km/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/kn-IN/config.json
+++ b/polyfills/Intl/~locale/kn-IN/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/kn-IN/config.json
+++ b/polyfills/Intl/~locale/kn-IN/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/kn/config.json
+++ b/polyfills/Intl/~locale/kn/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/kn/config.json
+++ b/polyfills/Intl/~locale/kn/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ko-KP/config.json
+++ b/polyfills/Intl/~locale/ko-KP/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ko-KP/config.json
+++ b/polyfills/Intl/~locale/ko-KP/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ko-KR/config.json
+++ b/polyfills/Intl/~locale/ko-KR/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ko-KR/config.json
+++ b/polyfills/Intl/~locale/ko-KR/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ko/config.json
+++ b/polyfills/Intl/~locale/ko/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ko/config.json
+++ b/polyfills/Intl/~locale/ko/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/kok-IN/config.json
+++ b/polyfills/Intl/~locale/kok-IN/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/kok-IN/config.json
+++ b/polyfills/Intl/~locale/kok-IN/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/kok/config.json
+++ b/polyfills/Intl/~locale/kok/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/kok/config.json
+++ b/polyfills/Intl/~locale/kok/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ks-Arab-IN/config.json
+++ b/polyfills/Intl/~locale/ks-Arab-IN/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ks-Arab-IN/config.json
+++ b/polyfills/Intl/~locale/ks-Arab-IN/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ks-Arab/config.json
+++ b/polyfills/Intl/~locale/ks-Arab/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ks-Arab/config.json
+++ b/polyfills/Intl/~locale/ks-Arab/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ks/config.json
+++ b/polyfills/Intl/~locale/ks/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ks/config.json
+++ b/polyfills/Intl/~locale/ks/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ksb-TZ/config.json
+++ b/polyfills/Intl/~locale/ksb-TZ/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ksb-TZ/config.json
+++ b/polyfills/Intl/~locale/ksb-TZ/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ksb/config.json
+++ b/polyfills/Intl/~locale/ksb/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ksb/config.json
+++ b/polyfills/Intl/~locale/ksb/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ksf-CM/config.json
+++ b/polyfills/Intl/~locale/ksf-CM/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ksf-CM/config.json
+++ b/polyfills/Intl/~locale/ksf-CM/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ksf/config.json
+++ b/polyfills/Intl/~locale/ksf/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ksf/config.json
+++ b/polyfills/Intl/~locale/ksf/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ksh-DE/config.json
+++ b/polyfills/Intl/~locale/ksh-DE/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ksh-DE/config.json
+++ b/polyfills/Intl/~locale/ksh-DE/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ksh/config.json
+++ b/polyfills/Intl/~locale/ksh/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ksh/config.json
+++ b/polyfills/Intl/~locale/ksh/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/kw-GB/config.json
+++ b/polyfills/Intl/~locale/kw-GB/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/kw-GB/config.json
+++ b/polyfills/Intl/~locale/kw-GB/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/kw/config.json
+++ b/polyfills/Intl/~locale/kw/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/kw/config.json
+++ b/polyfills/Intl/~locale/kw/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ky-Cyrl-KG/config.json
+++ b/polyfills/Intl/~locale/ky-Cyrl-KG/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ky-Cyrl-KG/config.json
+++ b/polyfills/Intl/~locale/ky-Cyrl-KG/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ky-Cyrl/config.json
+++ b/polyfills/Intl/~locale/ky-Cyrl/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ky-Cyrl/config.json
+++ b/polyfills/Intl/~locale/ky-Cyrl/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ky/config.json
+++ b/polyfills/Intl/~locale/ky/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ky/config.json
+++ b/polyfills/Intl/~locale/ky/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/lag-TZ/config.json
+++ b/polyfills/Intl/~locale/lag-TZ/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/lag-TZ/config.json
+++ b/polyfills/Intl/~locale/lag-TZ/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/lag/config.json
+++ b/polyfills/Intl/~locale/lag/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/lag/config.json
+++ b/polyfills/Intl/~locale/lag/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/lb-LU/config.json
+++ b/polyfills/Intl/~locale/lb-LU/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/lb-LU/config.json
+++ b/polyfills/Intl/~locale/lb-LU/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/lb/config.json
+++ b/polyfills/Intl/~locale/lb/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/lb/config.json
+++ b/polyfills/Intl/~locale/lb/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/lg-UG/config.json
+++ b/polyfills/Intl/~locale/lg-UG/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/lg-UG/config.json
+++ b/polyfills/Intl/~locale/lg-UG/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/lg/config.json
+++ b/polyfills/Intl/~locale/lg/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/lg/config.json
+++ b/polyfills/Intl/~locale/lg/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/lkt-US/config.json
+++ b/polyfills/Intl/~locale/lkt-US/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/lkt-US/config.json
+++ b/polyfills/Intl/~locale/lkt-US/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/lkt/config.json
+++ b/polyfills/Intl/~locale/lkt/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/lkt/config.json
+++ b/polyfills/Intl/~locale/lkt/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ln-AO/config.json
+++ b/polyfills/Intl/~locale/ln-AO/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ln-AO/config.json
+++ b/polyfills/Intl/~locale/ln-AO/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ln-CD/config.json
+++ b/polyfills/Intl/~locale/ln-CD/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ln-CD/config.json
+++ b/polyfills/Intl/~locale/ln-CD/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ln-CF/config.json
+++ b/polyfills/Intl/~locale/ln-CF/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ln-CF/config.json
+++ b/polyfills/Intl/~locale/ln-CF/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ln-CG/config.json
+++ b/polyfills/Intl/~locale/ln-CG/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ln-CG/config.json
+++ b/polyfills/Intl/~locale/ln-CG/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ln/config.json
+++ b/polyfills/Intl/~locale/ln/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ln/config.json
+++ b/polyfills/Intl/~locale/ln/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/lo-LA/config.json
+++ b/polyfills/Intl/~locale/lo-LA/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/lo-LA/config.json
+++ b/polyfills/Intl/~locale/lo-LA/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/lo/config.json
+++ b/polyfills/Intl/~locale/lo/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/lo/config.json
+++ b/polyfills/Intl/~locale/lo/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/lt-LT/config.json
+++ b/polyfills/Intl/~locale/lt-LT/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/lt-LT/config.json
+++ b/polyfills/Intl/~locale/lt-LT/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/lt/config.json
+++ b/polyfills/Intl/~locale/lt/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/lt/config.json
+++ b/polyfills/Intl/~locale/lt/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/lu-CD/config.json
+++ b/polyfills/Intl/~locale/lu-CD/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/lu-CD/config.json
+++ b/polyfills/Intl/~locale/lu-CD/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/lu/config.json
+++ b/polyfills/Intl/~locale/lu/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/lu/config.json
+++ b/polyfills/Intl/~locale/lu/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/luo-KE/config.json
+++ b/polyfills/Intl/~locale/luo-KE/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/luo-KE/config.json
+++ b/polyfills/Intl/~locale/luo-KE/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/luo/config.json
+++ b/polyfills/Intl/~locale/luo/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/luo/config.json
+++ b/polyfills/Intl/~locale/luo/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/luy-KE/config.json
+++ b/polyfills/Intl/~locale/luy-KE/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/luy-KE/config.json
+++ b/polyfills/Intl/~locale/luy-KE/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/luy/config.json
+++ b/polyfills/Intl/~locale/luy/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/luy/config.json
+++ b/polyfills/Intl/~locale/luy/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/lv-LV/config.json
+++ b/polyfills/Intl/~locale/lv-LV/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/lv-LV/config.json
+++ b/polyfills/Intl/~locale/lv-LV/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/lv/config.json
+++ b/polyfills/Intl/~locale/lv/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/lv/config.json
+++ b/polyfills/Intl/~locale/lv/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/mas-KE/config.json
+++ b/polyfills/Intl/~locale/mas-KE/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/mas-KE/config.json
+++ b/polyfills/Intl/~locale/mas-KE/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/mas-TZ/config.json
+++ b/polyfills/Intl/~locale/mas-TZ/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/mas-TZ/config.json
+++ b/polyfills/Intl/~locale/mas-TZ/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/mas/config.json
+++ b/polyfills/Intl/~locale/mas/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/mas/config.json
+++ b/polyfills/Intl/~locale/mas/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/mer-KE/config.json
+++ b/polyfills/Intl/~locale/mer-KE/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/mer-KE/config.json
+++ b/polyfills/Intl/~locale/mer-KE/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/mer/config.json
+++ b/polyfills/Intl/~locale/mer/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/mer/config.json
+++ b/polyfills/Intl/~locale/mer/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/mfe-MU/config.json
+++ b/polyfills/Intl/~locale/mfe-MU/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/mfe-MU/config.json
+++ b/polyfills/Intl/~locale/mfe-MU/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/mfe/config.json
+++ b/polyfills/Intl/~locale/mfe/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/mfe/config.json
+++ b/polyfills/Intl/~locale/mfe/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/mg-MG/config.json
+++ b/polyfills/Intl/~locale/mg-MG/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/mg-MG/config.json
+++ b/polyfills/Intl/~locale/mg-MG/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/mg/config.json
+++ b/polyfills/Intl/~locale/mg/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/mg/config.json
+++ b/polyfills/Intl/~locale/mg/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/mgh-MZ/config.json
+++ b/polyfills/Intl/~locale/mgh-MZ/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/mgh-MZ/config.json
+++ b/polyfills/Intl/~locale/mgh-MZ/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/mgh/config.json
+++ b/polyfills/Intl/~locale/mgh/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/mgh/config.json
+++ b/polyfills/Intl/~locale/mgh/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/mgo-CM/config.json
+++ b/polyfills/Intl/~locale/mgo-CM/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/mgo-CM/config.json
+++ b/polyfills/Intl/~locale/mgo-CM/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/mgo/config.json
+++ b/polyfills/Intl/~locale/mgo/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/mgo/config.json
+++ b/polyfills/Intl/~locale/mgo/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/mk-MK/config.json
+++ b/polyfills/Intl/~locale/mk-MK/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/mk-MK/config.json
+++ b/polyfills/Intl/~locale/mk-MK/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/mk/config.json
+++ b/polyfills/Intl/~locale/mk/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/mk/config.json
+++ b/polyfills/Intl/~locale/mk/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ml-IN/config.json
+++ b/polyfills/Intl/~locale/ml-IN/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ml-IN/config.json
+++ b/polyfills/Intl/~locale/ml-IN/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ml/config.json
+++ b/polyfills/Intl/~locale/ml/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ml/config.json
+++ b/polyfills/Intl/~locale/ml/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/mn-Cyrl-MN/config.json
+++ b/polyfills/Intl/~locale/mn-Cyrl-MN/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/mn-Cyrl-MN/config.json
+++ b/polyfills/Intl/~locale/mn-Cyrl-MN/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/mn-Cyrl/config.json
+++ b/polyfills/Intl/~locale/mn-Cyrl/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/mn-Cyrl/config.json
+++ b/polyfills/Intl/~locale/mn-Cyrl/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/mn-Mong/config.json
+++ b/polyfills/Intl/~locale/mn-Mong/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/mn-Mong/config.json
+++ b/polyfills/Intl/~locale/mn-Mong/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/mn/config.json
+++ b/polyfills/Intl/~locale/mn/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/mn/config.json
+++ b/polyfills/Intl/~locale/mn/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/mr-IN/config.json
+++ b/polyfills/Intl/~locale/mr-IN/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/mr-IN/config.json
+++ b/polyfills/Intl/~locale/mr-IN/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/mr/config.json
+++ b/polyfills/Intl/~locale/mr/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/mr/config.json
+++ b/polyfills/Intl/~locale/mr/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ms-Arab/config.json
+++ b/polyfills/Intl/~locale/ms-Arab/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ms-Arab/config.json
+++ b/polyfills/Intl/~locale/ms-Arab/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ms-Latn-BN/config.json
+++ b/polyfills/Intl/~locale/ms-Latn-BN/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ms-Latn-BN/config.json
+++ b/polyfills/Intl/~locale/ms-Latn-BN/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ms-Latn-MY/config.json
+++ b/polyfills/Intl/~locale/ms-Latn-MY/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ms-Latn-MY/config.json
+++ b/polyfills/Intl/~locale/ms-Latn-MY/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ms-Latn-SG/config.json
+++ b/polyfills/Intl/~locale/ms-Latn-SG/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ms-Latn-SG/config.json
+++ b/polyfills/Intl/~locale/ms-Latn-SG/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ms-Latn/config.json
+++ b/polyfills/Intl/~locale/ms-Latn/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ms-Latn/config.json
+++ b/polyfills/Intl/~locale/ms-Latn/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ms/config.json
+++ b/polyfills/Intl/~locale/ms/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ms/config.json
+++ b/polyfills/Intl/~locale/ms/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/mt-MT/config.json
+++ b/polyfills/Intl/~locale/mt-MT/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/mt-MT/config.json
+++ b/polyfills/Intl/~locale/mt-MT/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/mt/config.json
+++ b/polyfills/Intl/~locale/mt/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/mt/config.json
+++ b/polyfills/Intl/~locale/mt/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/mua-CM/config.json
+++ b/polyfills/Intl/~locale/mua-CM/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/mua-CM/config.json
+++ b/polyfills/Intl/~locale/mua-CM/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/mua/config.json
+++ b/polyfills/Intl/~locale/mua/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/mua/config.json
+++ b/polyfills/Intl/~locale/mua/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/my-MM/config.json
+++ b/polyfills/Intl/~locale/my-MM/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/my-MM/config.json
+++ b/polyfills/Intl/~locale/my-MM/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/my/config.json
+++ b/polyfills/Intl/~locale/my/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/my/config.json
+++ b/polyfills/Intl/~locale/my/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/naq-NA/config.json
+++ b/polyfills/Intl/~locale/naq-NA/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/naq-NA/config.json
+++ b/polyfills/Intl/~locale/naq-NA/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/naq/config.json
+++ b/polyfills/Intl/~locale/naq/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/naq/config.json
+++ b/polyfills/Intl/~locale/naq/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/nb-NO/config.json
+++ b/polyfills/Intl/~locale/nb-NO/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/nb-NO/config.json
+++ b/polyfills/Intl/~locale/nb-NO/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/nb-SJ/config.json
+++ b/polyfills/Intl/~locale/nb-SJ/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/nb-SJ/config.json
+++ b/polyfills/Intl/~locale/nb-SJ/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/nb/config.json
+++ b/polyfills/Intl/~locale/nb/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/nb/config.json
+++ b/polyfills/Intl/~locale/nb/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/nd-ZW/config.json
+++ b/polyfills/Intl/~locale/nd-ZW/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/nd-ZW/config.json
+++ b/polyfills/Intl/~locale/nd-ZW/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/nd/config.json
+++ b/polyfills/Intl/~locale/nd/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/nd/config.json
+++ b/polyfills/Intl/~locale/nd/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ne-IN/config.json
+++ b/polyfills/Intl/~locale/ne-IN/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ne-IN/config.json
+++ b/polyfills/Intl/~locale/ne-IN/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ne-NP/config.json
+++ b/polyfills/Intl/~locale/ne-NP/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ne-NP/config.json
+++ b/polyfills/Intl/~locale/ne-NP/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ne/config.json
+++ b/polyfills/Intl/~locale/ne/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ne/config.json
+++ b/polyfills/Intl/~locale/ne/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/nl-AW/config.json
+++ b/polyfills/Intl/~locale/nl-AW/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/nl-AW/config.json
+++ b/polyfills/Intl/~locale/nl-AW/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/nl-BE/config.json
+++ b/polyfills/Intl/~locale/nl-BE/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/nl-BE/config.json
+++ b/polyfills/Intl/~locale/nl-BE/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/nl-BQ/config.json
+++ b/polyfills/Intl/~locale/nl-BQ/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/nl-BQ/config.json
+++ b/polyfills/Intl/~locale/nl-BQ/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/nl-CW/config.json
+++ b/polyfills/Intl/~locale/nl-CW/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/nl-CW/config.json
+++ b/polyfills/Intl/~locale/nl-CW/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/nl-NL/config.json
+++ b/polyfills/Intl/~locale/nl-NL/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/nl-NL/config.json
+++ b/polyfills/Intl/~locale/nl-NL/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/nl-SR/config.json
+++ b/polyfills/Intl/~locale/nl-SR/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/nl-SR/config.json
+++ b/polyfills/Intl/~locale/nl-SR/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/nl-SX/config.json
+++ b/polyfills/Intl/~locale/nl-SX/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/nl-SX/config.json
+++ b/polyfills/Intl/~locale/nl-SX/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/nl/config.json
+++ b/polyfills/Intl/~locale/nl/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/nl/config.json
+++ b/polyfills/Intl/~locale/nl/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/nmg-CM/config.json
+++ b/polyfills/Intl/~locale/nmg-CM/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/nmg-CM/config.json
+++ b/polyfills/Intl/~locale/nmg-CM/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/nmg/config.json
+++ b/polyfills/Intl/~locale/nmg/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/nmg/config.json
+++ b/polyfills/Intl/~locale/nmg/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/nn-NO/config.json
+++ b/polyfills/Intl/~locale/nn-NO/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/nn-NO/config.json
+++ b/polyfills/Intl/~locale/nn-NO/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/nn/config.json
+++ b/polyfills/Intl/~locale/nn/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/nn/config.json
+++ b/polyfills/Intl/~locale/nn/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/nnh-CM/config.json
+++ b/polyfills/Intl/~locale/nnh-CM/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/nnh-CM/config.json
+++ b/polyfills/Intl/~locale/nnh-CM/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/nnh/config.json
+++ b/polyfills/Intl/~locale/nnh/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/nnh/config.json
+++ b/polyfills/Intl/~locale/nnh/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/nus-SD/config.json
+++ b/polyfills/Intl/~locale/nus-SD/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/nus-SD/config.json
+++ b/polyfills/Intl/~locale/nus-SD/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/nus/config.json
+++ b/polyfills/Intl/~locale/nus/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/nus/config.json
+++ b/polyfills/Intl/~locale/nus/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/nyn-UG/config.json
+++ b/polyfills/Intl/~locale/nyn-UG/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/nyn-UG/config.json
+++ b/polyfills/Intl/~locale/nyn-UG/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/nyn/config.json
+++ b/polyfills/Intl/~locale/nyn/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/nyn/config.json
+++ b/polyfills/Intl/~locale/nyn/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/om-ET/config.json
+++ b/polyfills/Intl/~locale/om-ET/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/om-ET/config.json
+++ b/polyfills/Intl/~locale/om-ET/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/om-KE/config.json
+++ b/polyfills/Intl/~locale/om-KE/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/om-KE/config.json
+++ b/polyfills/Intl/~locale/om-KE/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/om/config.json
+++ b/polyfills/Intl/~locale/om/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/om/config.json
+++ b/polyfills/Intl/~locale/om/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/or-IN/config.json
+++ b/polyfills/Intl/~locale/or-IN/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/or-IN/config.json
+++ b/polyfills/Intl/~locale/or-IN/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/or/config.json
+++ b/polyfills/Intl/~locale/or/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/or/config.json
+++ b/polyfills/Intl/~locale/or/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/os-GE/config.json
+++ b/polyfills/Intl/~locale/os-GE/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/os-GE/config.json
+++ b/polyfills/Intl/~locale/os-GE/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/os-RU/config.json
+++ b/polyfills/Intl/~locale/os-RU/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/os-RU/config.json
+++ b/polyfills/Intl/~locale/os-RU/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/os/config.json
+++ b/polyfills/Intl/~locale/os/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/os/config.json
+++ b/polyfills/Intl/~locale/os/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/pa-Arab-PK/config.json
+++ b/polyfills/Intl/~locale/pa-Arab-PK/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/pa-Arab-PK/config.json
+++ b/polyfills/Intl/~locale/pa-Arab-PK/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/pa-Arab/config.json
+++ b/polyfills/Intl/~locale/pa-Arab/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/pa-Arab/config.json
+++ b/polyfills/Intl/~locale/pa-Arab/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/pa-Guru-IN/config.json
+++ b/polyfills/Intl/~locale/pa-Guru-IN/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/pa-Guru-IN/config.json
+++ b/polyfills/Intl/~locale/pa-Guru-IN/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/pa-Guru/config.json
+++ b/polyfills/Intl/~locale/pa-Guru/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/pa-Guru/config.json
+++ b/polyfills/Intl/~locale/pa-Guru/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/pa/config.json
+++ b/polyfills/Intl/~locale/pa/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/pa/config.json
+++ b/polyfills/Intl/~locale/pa/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/pl-PL/config.json
+++ b/polyfills/Intl/~locale/pl-PL/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/pl-PL/config.json
+++ b/polyfills/Intl/~locale/pl-PL/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/pl/config.json
+++ b/polyfills/Intl/~locale/pl/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/pl/config.json
+++ b/polyfills/Intl/~locale/pl/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ps-AF/config.json
+++ b/polyfills/Intl/~locale/ps-AF/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ps-AF/config.json
+++ b/polyfills/Intl/~locale/ps-AF/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ps/config.json
+++ b/polyfills/Intl/~locale/ps/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ps/config.json
+++ b/polyfills/Intl/~locale/ps/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/pt-AO/config.json
+++ b/polyfills/Intl/~locale/pt-AO/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/pt-AO/config.json
+++ b/polyfills/Intl/~locale/pt-AO/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/pt-BR/config.json
+++ b/polyfills/Intl/~locale/pt-BR/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/pt-BR/config.json
+++ b/polyfills/Intl/~locale/pt-BR/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/pt-CV/config.json
+++ b/polyfills/Intl/~locale/pt-CV/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/pt-CV/config.json
+++ b/polyfills/Intl/~locale/pt-CV/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/pt-GW/config.json
+++ b/polyfills/Intl/~locale/pt-GW/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/pt-GW/config.json
+++ b/polyfills/Intl/~locale/pt-GW/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/pt-MO/config.json
+++ b/polyfills/Intl/~locale/pt-MO/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/pt-MO/config.json
+++ b/polyfills/Intl/~locale/pt-MO/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/pt-MZ/config.json
+++ b/polyfills/Intl/~locale/pt-MZ/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/pt-MZ/config.json
+++ b/polyfills/Intl/~locale/pt-MZ/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/pt-PT/config.json
+++ b/polyfills/Intl/~locale/pt-PT/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/pt-PT/config.json
+++ b/polyfills/Intl/~locale/pt-PT/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/pt-ST/config.json
+++ b/polyfills/Intl/~locale/pt-ST/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/pt-ST/config.json
+++ b/polyfills/Intl/~locale/pt-ST/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/pt-TL/config.json
+++ b/polyfills/Intl/~locale/pt-TL/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/pt-TL/config.json
+++ b/polyfills/Intl/~locale/pt-TL/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/pt/config.json
+++ b/polyfills/Intl/~locale/pt/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/pt/config.json
+++ b/polyfills/Intl/~locale/pt/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/qu-BO/config.json
+++ b/polyfills/Intl/~locale/qu-BO/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/qu-BO/config.json
+++ b/polyfills/Intl/~locale/qu-BO/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/qu-EC/config.json
+++ b/polyfills/Intl/~locale/qu-EC/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/qu-EC/config.json
+++ b/polyfills/Intl/~locale/qu-EC/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/qu-PE/config.json
+++ b/polyfills/Intl/~locale/qu-PE/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/qu-PE/config.json
+++ b/polyfills/Intl/~locale/qu-PE/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/qu/config.json
+++ b/polyfills/Intl/~locale/qu/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/qu/config.json
+++ b/polyfills/Intl/~locale/qu/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/rm-CH/config.json
+++ b/polyfills/Intl/~locale/rm-CH/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/rm-CH/config.json
+++ b/polyfills/Intl/~locale/rm-CH/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/rm/config.json
+++ b/polyfills/Intl/~locale/rm/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/rm/config.json
+++ b/polyfills/Intl/~locale/rm/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/rn-BI/config.json
+++ b/polyfills/Intl/~locale/rn-BI/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/rn-BI/config.json
+++ b/polyfills/Intl/~locale/rn-BI/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/rn/config.json
+++ b/polyfills/Intl/~locale/rn/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/rn/config.json
+++ b/polyfills/Intl/~locale/rn/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ro-MD/config.json
+++ b/polyfills/Intl/~locale/ro-MD/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ro-MD/config.json
+++ b/polyfills/Intl/~locale/ro-MD/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ro-RO/config.json
+++ b/polyfills/Intl/~locale/ro-RO/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ro-RO/config.json
+++ b/polyfills/Intl/~locale/ro-RO/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ro/config.json
+++ b/polyfills/Intl/~locale/ro/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ro/config.json
+++ b/polyfills/Intl/~locale/ro/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/rof-TZ/config.json
+++ b/polyfills/Intl/~locale/rof-TZ/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/rof-TZ/config.json
+++ b/polyfills/Intl/~locale/rof-TZ/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/rof/config.json
+++ b/polyfills/Intl/~locale/rof/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/rof/config.json
+++ b/polyfills/Intl/~locale/rof/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/root/config.json
+++ b/polyfills/Intl/~locale/root/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/root/config.json
+++ b/polyfills/Intl/~locale/root/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ru-BY/config.json
+++ b/polyfills/Intl/~locale/ru-BY/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ru-BY/config.json
+++ b/polyfills/Intl/~locale/ru-BY/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ru-KG/config.json
+++ b/polyfills/Intl/~locale/ru-KG/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ru-KG/config.json
+++ b/polyfills/Intl/~locale/ru-KG/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ru-KZ/config.json
+++ b/polyfills/Intl/~locale/ru-KZ/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ru-KZ/config.json
+++ b/polyfills/Intl/~locale/ru-KZ/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ru-MD/config.json
+++ b/polyfills/Intl/~locale/ru-MD/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ru-MD/config.json
+++ b/polyfills/Intl/~locale/ru-MD/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ru-RU/config.json
+++ b/polyfills/Intl/~locale/ru-RU/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ru-RU/config.json
+++ b/polyfills/Intl/~locale/ru-RU/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ru-UA/config.json
+++ b/polyfills/Intl/~locale/ru-UA/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ru-UA/config.json
+++ b/polyfills/Intl/~locale/ru-UA/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ru/config.json
+++ b/polyfills/Intl/~locale/ru/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ru/config.json
+++ b/polyfills/Intl/~locale/ru/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/rw-RW/config.json
+++ b/polyfills/Intl/~locale/rw-RW/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/rw-RW/config.json
+++ b/polyfills/Intl/~locale/rw-RW/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/rw/config.json
+++ b/polyfills/Intl/~locale/rw/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/rw/config.json
+++ b/polyfills/Intl/~locale/rw/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/rwk-TZ/config.json
+++ b/polyfills/Intl/~locale/rwk-TZ/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/rwk-TZ/config.json
+++ b/polyfills/Intl/~locale/rwk-TZ/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/rwk/config.json
+++ b/polyfills/Intl/~locale/rwk/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/rwk/config.json
+++ b/polyfills/Intl/~locale/rwk/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/sah-RU/config.json
+++ b/polyfills/Intl/~locale/sah-RU/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/sah-RU/config.json
+++ b/polyfills/Intl/~locale/sah-RU/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/sah/config.json
+++ b/polyfills/Intl/~locale/sah/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/sah/config.json
+++ b/polyfills/Intl/~locale/sah/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/saq-KE/config.json
+++ b/polyfills/Intl/~locale/saq-KE/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/saq-KE/config.json
+++ b/polyfills/Intl/~locale/saq-KE/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/saq/config.json
+++ b/polyfills/Intl/~locale/saq/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/saq/config.json
+++ b/polyfills/Intl/~locale/saq/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/sbp-TZ/config.json
+++ b/polyfills/Intl/~locale/sbp-TZ/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/sbp-TZ/config.json
+++ b/polyfills/Intl/~locale/sbp-TZ/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/sbp/config.json
+++ b/polyfills/Intl/~locale/sbp/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/sbp/config.json
+++ b/polyfills/Intl/~locale/sbp/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/se-FI/config.json
+++ b/polyfills/Intl/~locale/se-FI/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/se-FI/config.json
+++ b/polyfills/Intl/~locale/se-FI/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/se-NO/config.json
+++ b/polyfills/Intl/~locale/se-NO/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/se-NO/config.json
+++ b/polyfills/Intl/~locale/se-NO/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/se-SE/config.json
+++ b/polyfills/Intl/~locale/se-SE/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/se-SE/config.json
+++ b/polyfills/Intl/~locale/se-SE/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/se/config.json
+++ b/polyfills/Intl/~locale/se/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/se/config.json
+++ b/polyfills/Intl/~locale/se/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/seh-MZ/config.json
+++ b/polyfills/Intl/~locale/seh-MZ/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/seh-MZ/config.json
+++ b/polyfills/Intl/~locale/seh-MZ/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/seh/config.json
+++ b/polyfills/Intl/~locale/seh/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/seh/config.json
+++ b/polyfills/Intl/~locale/seh/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ses-ML/config.json
+++ b/polyfills/Intl/~locale/ses-ML/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ses-ML/config.json
+++ b/polyfills/Intl/~locale/ses-ML/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ses/config.json
+++ b/polyfills/Intl/~locale/ses/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ses/config.json
+++ b/polyfills/Intl/~locale/ses/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/sg-CF/config.json
+++ b/polyfills/Intl/~locale/sg-CF/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/sg-CF/config.json
+++ b/polyfills/Intl/~locale/sg-CF/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/sg/config.json
+++ b/polyfills/Intl/~locale/sg/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/sg/config.json
+++ b/polyfills/Intl/~locale/sg/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/shi-Latn-MA/config.json
+++ b/polyfills/Intl/~locale/shi-Latn-MA/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/shi-Latn-MA/config.json
+++ b/polyfills/Intl/~locale/shi-Latn-MA/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/shi-Latn/config.json
+++ b/polyfills/Intl/~locale/shi-Latn/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/shi-Latn/config.json
+++ b/polyfills/Intl/~locale/shi-Latn/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/shi-Tfng-MA/config.json
+++ b/polyfills/Intl/~locale/shi-Tfng-MA/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/shi-Tfng-MA/config.json
+++ b/polyfills/Intl/~locale/shi-Tfng-MA/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/shi-Tfng/config.json
+++ b/polyfills/Intl/~locale/shi-Tfng/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/shi-Tfng/config.json
+++ b/polyfills/Intl/~locale/shi-Tfng/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/shi/config.json
+++ b/polyfills/Intl/~locale/shi/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/shi/config.json
+++ b/polyfills/Intl/~locale/shi/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/si-LK/config.json
+++ b/polyfills/Intl/~locale/si-LK/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/si-LK/config.json
+++ b/polyfills/Intl/~locale/si-LK/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/si/config.json
+++ b/polyfills/Intl/~locale/si/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/si/config.json
+++ b/polyfills/Intl/~locale/si/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/sk-SK/config.json
+++ b/polyfills/Intl/~locale/sk-SK/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/sk-SK/config.json
+++ b/polyfills/Intl/~locale/sk-SK/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/sk/config.json
+++ b/polyfills/Intl/~locale/sk/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/sk/config.json
+++ b/polyfills/Intl/~locale/sk/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/sl-SI/config.json
+++ b/polyfills/Intl/~locale/sl-SI/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/sl-SI/config.json
+++ b/polyfills/Intl/~locale/sl-SI/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/sl/config.json
+++ b/polyfills/Intl/~locale/sl/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/sl/config.json
+++ b/polyfills/Intl/~locale/sl/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/smn-FI/config.json
+++ b/polyfills/Intl/~locale/smn-FI/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/smn-FI/config.json
+++ b/polyfills/Intl/~locale/smn-FI/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/smn/config.json
+++ b/polyfills/Intl/~locale/smn/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/smn/config.json
+++ b/polyfills/Intl/~locale/smn/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/sn-ZW/config.json
+++ b/polyfills/Intl/~locale/sn-ZW/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/sn-ZW/config.json
+++ b/polyfills/Intl/~locale/sn-ZW/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/sn/config.json
+++ b/polyfills/Intl/~locale/sn/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/sn/config.json
+++ b/polyfills/Intl/~locale/sn/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/so-DJ/config.json
+++ b/polyfills/Intl/~locale/so-DJ/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/so-DJ/config.json
+++ b/polyfills/Intl/~locale/so-DJ/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/so-ET/config.json
+++ b/polyfills/Intl/~locale/so-ET/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/so-ET/config.json
+++ b/polyfills/Intl/~locale/so-ET/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/so-KE/config.json
+++ b/polyfills/Intl/~locale/so-KE/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/so-KE/config.json
+++ b/polyfills/Intl/~locale/so-KE/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/so-SO/config.json
+++ b/polyfills/Intl/~locale/so-SO/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/so-SO/config.json
+++ b/polyfills/Intl/~locale/so-SO/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/so/config.json
+++ b/polyfills/Intl/~locale/so/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/so/config.json
+++ b/polyfills/Intl/~locale/so/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/sq-AL/config.json
+++ b/polyfills/Intl/~locale/sq-AL/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/sq-AL/config.json
+++ b/polyfills/Intl/~locale/sq-AL/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/sq-MK/config.json
+++ b/polyfills/Intl/~locale/sq-MK/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/sq-MK/config.json
+++ b/polyfills/Intl/~locale/sq-MK/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/sq-XK/config.json
+++ b/polyfills/Intl/~locale/sq-XK/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/sq-XK/config.json
+++ b/polyfills/Intl/~locale/sq-XK/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/sq/config.json
+++ b/polyfills/Intl/~locale/sq/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/sq/config.json
+++ b/polyfills/Intl/~locale/sq/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/sr-Cyrl-BA/config.json
+++ b/polyfills/Intl/~locale/sr-Cyrl-BA/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/sr-Cyrl-BA/config.json
+++ b/polyfills/Intl/~locale/sr-Cyrl-BA/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/sr-Cyrl-ME/config.json
+++ b/polyfills/Intl/~locale/sr-Cyrl-ME/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/sr-Cyrl-ME/config.json
+++ b/polyfills/Intl/~locale/sr-Cyrl-ME/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/sr-Cyrl-RS/config.json
+++ b/polyfills/Intl/~locale/sr-Cyrl-RS/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/sr-Cyrl-RS/config.json
+++ b/polyfills/Intl/~locale/sr-Cyrl-RS/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/sr-Cyrl-XK/config.json
+++ b/polyfills/Intl/~locale/sr-Cyrl-XK/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/sr-Cyrl-XK/config.json
+++ b/polyfills/Intl/~locale/sr-Cyrl-XK/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/sr-Cyrl/config.json
+++ b/polyfills/Intl/~locale/sr-Cyrl/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/sr-Cyrl/config.json
+++ b/polyfills/Intl/~locale/sr-Cyrl/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/sr-Latn-BA/config.json
+++ b/polyfills/Intl/~locale/sr-Latn-BA/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/sr-Latn-BA/config.json
+++ b/polyfills/Intl/~locale/sr-Latn-BA/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/sr-Latn-ME/config.json
+++ b/polyfills/Intl/~locale/sr-Latn-ME/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/sr-Latn-ME/config.json
+++ b/polyfills/Intl/~locale/sr-Latn-ME/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/sr-Latn-RS/config.json
+++ b/polyfills/Intl/~locale/sr-Latn-RS/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/sr-Latn-RS/config.json
+++ b/polyfills/Intl/~locale/sr-Latn-RS/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/sr-Latn-XK/config.json
+++ b/polyfills/Intl/~locale/sr-Latn-XK/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/sr-Latn-XK/config.json
+++ b/polyfills/Intl/~locale/sr-Latn-XK/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/sr-Latn/config.json
+++ b/polyfills/Intl/~locale/sr-Latn/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/sr-Latn/config.json
+++ b/polyfills/Intl/~locale/sr-Latn/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/sr/config.json
+++ b/polyfills/Intl/~locale/sr/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/sr/config.json
+++ b/polyfills/Intl/~locale/sr/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/sv-AX/config.json
+++ b/polyfills/Intl/~locale/sv-AX/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/sv-AX/config.json
+++ b/polyfills/Intl/~locale/sv-AX/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/sv-FI/config.json
+++ b/polyfills/Intl/~locale/sv-FI/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/sv-FI/config.json
+++ b/polyfills/Intl/~locale/sv-FI/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/sv-SE/config.json
+++ b/polyfills/Intl/~locale/sv-SE/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/sv-SE/config.json
+++ b/polyfills/Intl/~locale/sv-SE/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/sv/config.json
+++ b/polyfills/Intl/~locale/sv/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/sv/config.json
+++ b/polyfills/Intl/~locale/sv/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/sw-CD/config.json
+++ b/polyfills/Intl/~locale/sw-CD/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/sw-CD/config.json
+++ b/polyfills/Intl/~locale/sw-CD/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/sw-KE/config.json
+++ b/polyfills/Intl/~locale/sw-KE/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/sw-KE/config.json
+++ b/polyfills/Intl/~locale/sw-KE/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/sw-TZ/config.json
+++ b/polyfills/Intl/~locale/sw-TZ/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/sw-TZ/config.json
+++ b/polyfills/Intl/~locale/sw-TZ/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/sw-UG/config.json
+++ b/polyfills/Intl/~locale/sw-UG/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/sw-UG/config.json
+++ b/polyfills/Intl/~locale/sw-UG/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/sw/config.json
+++ b/polyfills/Intl/~locale/sw/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/sw/config.json
+++ b/polyfills/Intl/~locale/sw/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ta-IN/config.json
+++ b/polyfills/Intl/~locale/ta-IN/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ta-IN/config.json
+++ b/polyfills/Intl/~locale/ta-IN/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ta-LK/config.json
+++ b/polyfills/Intl/~locale/ta-LK/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ta-LK/config.json
+++ b/polyfills/Intl/~locale/ta-LK/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ta-MY/config.json
+++ b/polyfills/Intl/~locale/ta-MY/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ta-MY/config.json
+++ b/polyfills/Intl/~locale/ta-MY/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ta-SG/config.json
+++ b/polyfills/Intl/~locale/ta-SG/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ta-SG/config.json
+++ b/polyfills/Intl/~locale/ta-SG/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ta/config.json
+++ b/polyfills/Intl/~locale/ta/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ta/config.json
+++ b/polyfills/Intl/~locale/ta/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/te-IN/config.json
+++ b/polyfills/Intl/~locale/te-IN/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/te-IN/config.json
+++ b/polyfills/Intl/~locale/te-IN/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/te/config.json
+++ b/polyfills/Intl/~locale/te/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/te/config.json
+++ b/polyfills/Intl/~locale/te/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/teo-KE/config.json
+++ b/polyfills/Intl/~locale/teo-KE/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/teo-KE/config.json
+++ b/polyfills/Intl/~locale/teo-KE/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/teo-UG/config.json
+++ b/polyfills/Intl/~locale/teo-UG/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/teo-UG/config.json
+++ b/polyfills/Intl/~locale/teo-UG/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/teo/config.json
+++ b/polyfills/Intl/~locale/teo/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/teo/config.json
+++ b/polyfills/Intl/~locale/teo/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/th-TH/config.json
+++ b/polyfills/Intl/~locale/th-TH/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/th-TH/config.json
+++ b/polyfills/Intl/~locale/th-TH/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/th/config.json
+++ b/polyfills/Intl/~locale/th/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/th/config.json
+++ b/polyfills/Intl/~locale/th/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ti-ER/config.json
+++ b/polyfills/Intl/~locale/ti-ER/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ti-ER/config.json
+++ b/polyfills/Intl/~locale/ti-ER/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ti-ET/config.json
+++ b/polyfills/Intl/~locale/ti-ET/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ti-ET/config.json
+++ b/polyfills/Intl/~locale/ti-ET/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ti/config.json
+++ b/polyfills/Intl/~locale/ti/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ti/config.json
+++ b/polyfills/Intl/~locale/ti/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/to-TO/config.json
+++ b/polyfills/Intl/~locale/to-TO/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/to-TO/config.json
+++ b/polyfills/Intl/~locale/to-TO/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/to/config.json
+++ b/polyfills/Intl/~locale/to/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/to/config.json
+++ b/polyfills/Intl/~locale/to/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/tr-CY/config.json
+++ b/polyfills/Intl/~locale/tr-CY/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/tr-CY/config.json
+++ b/polyfills/Intl/~locale/tr-CY/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/tr-TR/config.json
+++ b/polyfills/Intl/~locale/tr-TR/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/tr-TR/config.json
+++ b/polyfills/Intl/~locale/tr-TR/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/tr/config.json
+++ b/polyfills/Intl/~locale/tr/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/tr/config.json
+++ b/polyfills/Intl/~locale/tr/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/twq-NE/config.json
+++ b/polyfills/Intl/~locale/twq-NE/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/twq-NE/config.json
+++ b/polyfills/Intl/~locale/twq-NE/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/twq/config.json
+++ b/polyfills/Intl/~locale/twq/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/twq/config.json
+++ b/polyfills/Intl/~locale/twq/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/tzm-Latn-MA/config.json
+++ b/polyfills/Intl/~locale/tzm-Latn-MA/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/tzm-Latn-MA/config.json
+++ b/polyfills/Intl/~locale/tzm-Latn-MA/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/tzm-Latn/config.json
+++ b/polyfills/Intl/~locale/tzm-Latn/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/tzm-Latn/config.json
+++ b/polyfills/Intl/~locale/tzm-Latn/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/tzm/config.json
+++ b/polyfills/Intl/~locale/tzm/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/tzm/config.json
+++ b/polyfills/Intl/~locale/tzm/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ug-Arab-CN/config.json
+++ b/polyfills/Intl/~locale/ug-Arab-CN/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ug-Arab-CN/config.json
+++ b/polyfills/Intl/~locale/ug-Arab-CN/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ug-Arab/config.json
+++ b/polyfills/Intl/~locale/ug-Arab/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ug-Arab/config.json
+++ b/polyfills/Intl/~locale/ug-Arab/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ug/config.json
+++ b/polyfills/Intl/~locale/ug/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ug/config.json
+++ b/polyfills/Intl/~locale/ug/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/uk-UA/config.json
+++ b/polyfills/Intl/~locale/uk-UA/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/uk-UA/config.json
+++ b/polyfills/Intl/~locale/uk-UA/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/uk/config.json
+++ b/polyfills/Intl/~locale/uk/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/uk/config.json
+++ b/polyfills/Intl/~locale/uk/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ur-IN/config.json
+++ b/polyfills/Intl/~locale/ur-IN/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ur-IN/config.json
+++ b/polyfills/Intl/~locale/ur-IN/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ur-PK/config.json
+++ b/polyfills/Intl/~locale/ur-PK/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ur-PK/config.json
+++ b/polyfills/Intl/~locale/ur-PK/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/ur/config.json
+++ b/polyfills/Intl/~locale/ur/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/ur/config.json
+++ b/polyfills/Intl/~locale/ur/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/uz-Arab-AF/config.json
+++ b/polyfills/Intl/~locale/uz-Arab-AF/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/uz-Arab-AF/config.json
+++ b/polyfills/Intl/~locale/uz-Arab-AF/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/uz-Arab/config.json
+++ b/polyfills/Intl/~locale/uz-Arab/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/uz-Arab/config.json
+++ b/polyfills/Intl/~locale/uz-Arab/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/uz-Cyrl-UZ/config.json
+++ b/polyfills/Intl/~locale/uz-Cyrl-UZ/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/uz-Cyrl-UZ/config.json
+++ b/polyfills/Intl/~locale/uz-Cyrl-UZ/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/uz-Cyrl/config.json
+++ b/polyfills/Intl/~locale/uz-Cyrl/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/uz-Cyrl/config.json
+++ b/polyfills/Intl/~locale/uz-Cyrl/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/uz-Latn-UZ/config.json
+++ b/polyfills/Intl/~locale/uz-Latn-UZ/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/uz-Latn-UZ/config.json
+++ b/polyfills/Intl/~locale/uz-Latn-UZ/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/uz-Latn/config.json
+++ b/polyfills/Intl/~locale/uz-Latn/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/uz-Latn/config.json
+++ b/polyfills/Intl/~locale/uz-Latn/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/uz/config.json
+++ b/polyfills/Intl/~locale/uz/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/uz/config.json
+++ b/polyfills/Intl/~locale/uz/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/vai-Latn-LR/config.json
+++ b/polyfills/Intl/~locale/vai-Latn-LR/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/vai-Latn-LR/config.json
+++ b/polyfills/Intl/~locale/vai-Latn-LR/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/vai-Latn/config.json
+++ b/polyfills/Intl/~locale/vai-Latn/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/vai-Latn/config.json
+++ b/polyfills/Intl/~locale/vai-Latn/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/vai-Vaii-LR/config.json
+++ b/polyfills/Intl/~locale/vai-Vaii-LR/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/vai-Vaii-LR/config.json
+++ b/polyfills/Intl/~locale/vai-Vaii-LR/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/vai-Vaii/config.json
+++ b/polyfills/Intl/~locale/vai-Vaii/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/vai-Vaii/config.json
+++ b/polyfills/Intl/~locale/vai-Vaii/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/vai/config.json
+++ b/polyfills/Intl/~locale/vai/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/vai/config.json
+++ b/polyfills/Intl/~locale/vai/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/vi-VN/config.json
+++ b/polyfills/Intl/~locale/vi-VN/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/vi-VN/config.json
+++ b/polyfills/Intl/~locale/vi-VN/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/vi/config.json
+++ b/polyfills/Intl/~locale/vi/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/vi/config.json
+++ b/polyfills/Intl/~locale/vi/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/vun-TZ/config.json
+++ b/polyfills/Intl/~locale/vun-TZ/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/vun-TZ/config.json
+++ b/polyfills/Intl/~locale/vun-TZ/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/vun/config.json
+++ b/polyfills/Intl/~locale/vun/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/vun/config.json
+++ b/polyfills/Intl/~locale/vun/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/wae-CH/config.json
+++ b/polyfills/Intl/~locale/wae-CH/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/wae-CH/config.json
+++ b/polyfills/Intl/~locale/wae-CH/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/wae/config.json
+++ b/polyfills/Intl/~locale/wae/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/wae/config.json
+++ b/polyfills/Intl/~locale/wae/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/xog-UG/config.json
+++ b/polyfills/Intl/~locale/xog-UG/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/xog-UG/config.json
+++ b/polyfills/Intl/~locale/xog-UG/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/xog/config.json
+++ b/polyfills/Intl/~locale/xog/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/xog/config.json
+++ b/polyfills/Intl/~locale/xog/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/yav-CM/config.json
+++ b/polyfills/Intl/~locale/yav-CM/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/yav-CM/config.json
+++ b/polyfills/Intl/~locale/yav-CM/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/yav/config.json
+++ b/polyfills/Intl/~locale/yav/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/yav/config.json
+++ b/polyfills/Intl/~locale/yav/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/yi-001/config.json
+++ b/polyfills/Intl/~locale/yi-001/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/yi-001/config.json
+++ b/polyfills/Intl/~locale/yi-001/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/yi/config.json
+++ b/polyfills/Intl/~locale/yi/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/yi/config.json
+++ b/polyfills/Intl/~locale/yi/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/yo-BJ/config.json
+++ b/polyfills/Intl/~locale/yo-BJ/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/yo-BJ/config.json
+++ b/polyfills/Intl/~locale/yo-BJ/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/yo-NG/config.json
+++ b/polyfills/Intl/~locale/yo-NG/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/yo-NG/config.json
+++ b/polyfills/Intl/~locale/yo-NG/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/yo/config.json
+++ b/polyfills/Intl/~locale/yo/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/yo/config.json
+++ b/polyfills/Intl/~locale/yo/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/zgh-MA/config.json
+++ b/polyfills/Intl/~locale/zgh-MA/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/zgh-MA/config.json
+++ b/polyfills/Intl/~locale/zgh-MA/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/zgh/config.json
+++ b/polyfills/Intl/~locale/zgh/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/zgh/config.json
+++ b/polyfills/Intl/~locale/zgh/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/zh-Hans-CN/config.json
+++ b/polyfills/Intl/~locale/zh-Hans-CN/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/zh-Hans-CN/config.json
+++ b/polyfills/Intl/~locale/zh-Hans-CN/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/zh-Hans-HK/config.json
+++ b/polyfills/Intl/~locale/zh-Hans-HK/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/zh-Hans-HK/config.json
+++ b/polyfills/Intl/~locale/zh-Hans-HK/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/zh-Hans-MO/config.json
+++ b/polyfills/Intl/~locale/zh-Hans-MO/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/zh-Hans-MO/config.json
+++ b/polyfills/Intl/~locale/zh-Hans-MO/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/zh-Hans-SG/config.json
+++ b/polyfills/Intl/~locale/zh-Hans-SG/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/zh-Hans-SG/config.json
+++ b/polyfills/Intl/~locale/zh-Hans-SG/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/zh-Hans/config.json
+++ b/polyfills/Intl/~locale/zh-Hans/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/zh-Hans/config.json
+++ b/polyfills/Intl/~locale/zh-Hans/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/zh-Hant-HK/config.json
+++ b/polyfills/Intl/~locale/zh-Hant-HK/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/zh-Hant-HK/config.json
+++ b/polyfills/Intl/~locale/zh-Hant-HK/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/zh-Hant-MO/config.json
+++ b/polyfills/Intl/~locale/zh-Hant-MO/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/zh-Hant-MO/config.json
+++ b/polyfills/Intl/~locale/zh-Hant-MO/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/zh-Hant-TW/config.json
+++ b/polyfills/Intl/~locale/zh-Hant-TW/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/zh-Hant-TW/config.json
+++ b/polyfills/Intl/~locale/zh-Hant-TW/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/zh-Hant/config.json
+++ b/polyfills/Intl/~locale/zh-Hant/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/zh-Hant/config.json
+++ b/polyfills/Intl/~locale/zh-Hant/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/zh/config.json
+++ b/polyfills/Intl/~locale/zh/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/zh/config.json
+++ b/polyfills/Intl/~locale/zh/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/zu-ZA/config.json
+++ b/polyfills/Intl/~locale/zu-ZA/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/zu-ZA/config.json
+++ b/polyfills/Intl/~locale/zu-ZA/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Intl/~locale/zu/config.json
+++ b/polyfills/Intl/~locale/zu/config.json
@@ -6,7 +6,8 @@
         "opera": "<15",
         "chrome": "<24",
         "safari": "*",
-        "ios_saf": "*"
+        "ios_saf": "*",
+        "firefox_mob": "<29"
     },
     "dependencies": [
         "Intl"

--- a/polyfills/Intl/~locale/zu/config.json
+++ b/polyfills/Intl/~locale/zu/config.json
@@ -7,7 +7,7 @@
         "chrome": "<24",
         "safari": "*",
         "ios_saf": "*",
-        "firefox_mob": "<29"
+        "firefox_mob": "*"
     },
     "dependencies": [
         "Intl"
@@ -15,11 +15,14 @@
     "build": {
         "minify": false
     },
-    "test": {
-        "ci": false
-    },
     "license": "MIT",
     "spec": "http://www.ecma-international.org/ecma-402/1.0/",
     "repo": "https://github.com/andyearnshaw/Intl.js",
-    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+    "notes": [
+        "Locales must be specified separately by prefixing the locale name with `Intl.~locale`, eg `Intl.~locale.en-GB`."
+    ],
+    "test": {
+        "ci": false
+    }
 }

--- a/polyfills/Math/acosh/config.json
+++ b/polyfills/Math/acosh/config.json
@@ -1,22 +1,23 @@
 {
-	"aliases": [
-		"es6"
-	],
-	"browsers": {
-		"android": "*",
-		"bb": "*",
-		"chrome": "1 - 37",
-		"firefox": "1 - 24",
-		"ie": "*",
-		"ie_mob": "10 - *",
-		"ios_chr": "*",
-		"ios_saf": "4 - 7",
-		"opera": "10 - 20",
-		"op_mob": "*",
-		"op_mini": "*",
-		"safari": "4 - 7"
-	},
-	"esversion": 6,
-	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/acosh",
-	"spec": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-math.acosh"
+    "aliases": [
+        "es6"
+    ],
+    "browsers": {
+        "android": "*",
+        "bb": "*",
+        "chrome": "1 - 37",
+        "firefox": "1 - 24",
+        "ie": "*",
+        "ie_mob": "10 - *",
+        "ios_chr": "*",
+        "ios_saf": "4 - 7",
+        "opera": "10 - 20",
+        "op_mob": "*",
+        "op_mini": "*",
+        "safari": "4 - 7",
+        "firefox_mob": "1 - 24"
+    },
+    "esversion": 6,
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/acosh",
+    "spec": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-math.acosh"
 }

--- a/polyfills/Math/asinh/config.json
+++ b/polyfills/Math/asinh/config.json
@@ -1,21 +1,22 @@
 {
-	"aliases": [
-		"es6"
-	],
-	"browsers": {
-		"android": "*",
-		"bb": "*",
-		"chrome": "1 - 37",
-		"firefox": "1 - 24",
-		"ie": "*",
-		"ie_mob": "10 - *",
-		"ios_chr": "*",
-		"ios_saf": "4 - 7",
-		"opera": "10 - 20",
-		"op_mob": "*",
-		"op_mini": "*",
-		"safari": "4 - 7"
-	},
-	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/asinh",
-	"spec": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-math.asinh"
+    "aliases": [
+        "es6"
+    ],
+    "browsers": {
+        "android": "*",
+        "bb": "*",
+        "chrome": "1 - 37",
+        "firefox": "1 - 24",
+        "ie": "*",
+        "ie_mob": "10 - *",
+        "ios_chr": "*",
+        "ios_saf": "4 - 7",
+        "opera": "10 - 20",
+        "op_mob": "*",
+        "op_mini": "*",
+        "safari": "4 - 7",
+        "firefox_mob": "1 - 24"
+    },
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/asinh",
+    "spec": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-math.asinh"
 }

--- a/polyfills/Math/atanh/config.json
+++ b/polyfills/Math/atanh/config.json
@@ -1,21 +1,22 @@
 {
-	"aliases": [
-		"es6"
-	],
-	"browsers": {
-		"android": "*",
-		"bb": "*",
-		"chrome": "1 - 37",
-		"firefox": "1 - 24",
-		"ie": "*",
-		"ie_mob": "10 - *",
-		"ios_chr": "*",
-		"ios_saf": "4 - 7",
-		"opera": "10 - 20",
-		"op_mob": "*",
-		"op_mini": "*",
-		"safari": "4 - 7"
-	},
-	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/atanh",
-	"spec": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-math.atanh"
+    "aliases": [
+        "es6"
+    ],
+    "browsers": {
+        "android": "*",
+        "bb": "*",
+        "chrome": "1 - 37",
+        "firefox": "1 - 24",
+        "ie": "*",
+        "ie_mob": "10 - *",
+        "ios_chr": "*",
+        "ios_saf": "4 - 7",
+        "opera": "10 - 20",
+        "op_mob": "*",
+        "op_mini": "*",
+        "safari": "4 - 7",
+        "firefox_mob": "1 - 24"
+    },
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/atanh",
+    "spec": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-math.atanh"
 }

--- a/polyfills/Math/cbrt/config.json
+++ b/polyfills/Math/cbrt/config.json
@@ -1,21 +1,22 @@
 {
-	"aliases": [
-		"es6"
-	],
-	"browsers": {
-		"android": "*",
-		"bb": "*",
-		"chrome": "1 - 37",
-		"firefox": "1 - 24",
-		"ie": "*",
-		"ie_mob": "10 - *",
-		"ios_chr": "*",
-		"ios_saf": "4 - 7",
-		"opera": "10 - 20",
-		"op_mob": "*",
-		"op_mini": "*",
-		"safari": "4 - 7"
-	},
-	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/cbrt",
-	"spec": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-math.cbrt"
+    "aliases": [
+        "es6"
+    ],
+    "browsers": {
+        "android": "*",
+        "bb": "*",
+        "chrome": "1 - 37",
+        "firefox": "1 - 24",
+        "ie": "*",
+        "ie_mob": "10 - *",
+        "ios_chr": "*",
+        "ios_saf": "4 - 7",
+        "opera": "10 - 20",
+        "op_mob": "*",
+        "op_mini": "*",
+        "safari": "4 - 7",
+        "firefox_mob": "1 - 24"
+    },
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/cbrt",
+    "spec": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-math.cbrt"
 }

--- a/polyfills/Math/clz32/config.json
+++ b/polyfills/Math/clz32/config.json
@@ -1,21 +1,22 @@
 {
-	"aliases": [
-		"es6"
-	],
-	"browsers": {
-		"android": "*",
-		"bb": "*",
-		"chrome": "1 - 37",
-		"firefox": "1 - 24",
-		"ie": "*",
-		"ie_mob": "10 - *",
-		"ios_chr": "*",
-		"ios_saf": "4 - *",
-		"opera": "10 - 20",
-		"op_mob": "*",
-		"op_mini": "*",
-		"safari": "4 - *"
-	},
-	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/clz32",
-	"spec": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-math.clz32"
+    "aliases": [
+        "es6"
+    ],
+    "browsers": {
+        "android": "*",
+        "bb": "*",
+        "chrome": "1 - 37",
+        "firefox": "1 - 24",
+        "ie": "*",
+        "ie_mob": "10 - *",
+        "ios_chr": "*",
+        "ios_saf": "4 - *",
+        "opera": "10 - 20",
+        "op_mob": "*",
+        "op_mini": "*",
+        "safari": "4 - *",
+        "firefox_mob": "1 - 24"
+    },
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/clz32",
+    "spec": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-math.clz32"
 }

--- a/polyfills/Math/cosh/config.json
+++ b/polyfills/Math/cosh/config.json
@@ -1,21 +1,22 @@
 {
-	"aliases": [
-		"es6"
-	],
-	"browsers": {
-		"android": "*",
-		"bb": "*",
-		"chrome": "1 - 37",
-		"firefox": "1 - 24",
-		"ie": "*",
-		"ie_mob": "10 - *",
-		"ios_chr": "*",
-		"ios_saf": "4 - 7",
-		"opera": "10 - 20",
-		"op_mob": "*",
-		"op_mini": "*",
-		"safari": "4 - 7"
-	},
-	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/cosh",
-	"spec": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-math.cosh"
+    "aliases": [
+        "es6"
+    ],
+    "browsers": {
+        "android": "*",
+        "bb": "*",
+        "chrome": "1 - 37",
+        "firefox": "1 - 24",
+        "ie": "*",
+        "ie_mob": "10 - *",
+        "ios_chr": "*",
+        "ios_saf": "4 - 7",
+        "opera": "10 - 20",
+        "op_mob": "*",
+        "op_mini": "*",
+        "safari": "4 - 7",
+        "firefox_mob": "1 - 24"
+    },
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/cosh",
+    "spec": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-math.cosh"
 }

--- a/polyfills/Math/expm1/config.json
+++ b/polyfills/Math/expm1/config.json
@@ -1,21 +1,22 @@
 {
-	"aliases": [
-		"es6"
-	],
-	"browsers": {
-		"android": "*",
-		"bb": "*",
-		"chrome": "1 - 37",
-		"firefox": "1 - 24",
-		"ie": "*",
-		"ie_mob": "10 - *",
-		"ios_chr": "*",
-		"ios_saf": "4 - 7",
-		"opera": "*",
-		"op_mob": "*",
-		"op_mini": "*",
-		"safari": "4 - 7"
-	},
-	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/expm1",
-	"spec": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-math.expm1"
+    "aliases": [
+        "es6"
+    ],
+    "browsers": {
+        "android": "*",
+        "bb": "*",
+        "chrome": "1 - 37",
+        "firefox": "1 - 24",
+        "ie": "*",
+        "ie_mob": "10 - *",
+        "ios_chr": "*",
+        "ios_saf": "4 - 7",
+        "opera": "*",
+        "op_mob": "*",
+        "op_mini": "*",
+        "safari": "4 - 7",
+        "firefox_mob": "1 - 24"
+    },
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/expm1",
+    "spec": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-math.expm1"
 }

--- a/polyfills/Math/hypot/config.json
+++ b/polyfills/Math/hypot/config.json
@@ -1,21 +1,22 @@
 {
-	"aliases": [
-		"es6"
-	],
-	"browsers": {
-		"android": "*",
-		"bb": "*",
-		"chrome": "1 - 37",
-		"firefox": "1 - 26",
-		"ie": "*",
-		"ie_mob": "10 - *",
-		"ios_chr": "*",
-		"ios_saf": "4 - 7",
-		"opera": "10 - 20",
-		"op_mob": "*",
-		"op_mini": "*",
-		"safari": "4 - 7"
-	},
-	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/hypot",
-	"spec": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-math.hypot"
+    "aliases": [
+        "es6"
+    ],
+    "browsers": {
+        "android": "*",
+        "bb": "*",
+        "chrome": "1 - 37",
+        "firefox": "1 - 26",
+        "ie": "*",
+        "ie_mob": "10 - *",
+        "ios_chr": "*",
+        "ios_saf": "4 - 7",
+        "opera": "10 - 20",
+        "op_mob": "*",
+        "op_mini": "*",
+        "safari": "4 - 7",
+        "firefox_mob": "1 - 26"
+    },
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/hypot",
+    "spec": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-math.hypot"
 }

--- a/polyfills/Math/imul/config.json
+++ b/polyfills/Math/imul/config.json
@@ -1,21 +1,22 @@
 {
-	"aliases": [
-		"es6"
-	],
-	"browsers": {
-		"android": "*",
-		"bb": "*",
-		"chrome": "1 - 27",
-		"firefox": "1 - 19",
-		"ie": "*",
-		"ie_mob": "10 - *",
-		"ios_chr": "*",
-		"ios_saf": "4 - 6.1",
-		"opera": "10 - 15",
-		"op_mob": "*",
-		"op_mini": "*",
-		"safari": "4 - 6.1"
-	},
-	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/imul",
-	"spec": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-math.imul"
+    "aliases": [
+        "es6"
+    ],
+    "browsers": {
+        "android": "*",
+        "bb": "*",
+        "chrome": "1 - 27",
+        "firefox": "1 - 19",
+        "ie": "*",
+        "ie_mob": "10 - *",
+        "ios_chr": "*",
+        "ios_saf": "4 - 6.1",
+        "opera": "10 - 15",
+        "op_mob": "*",
+        "op_mini": "*",
+        "safari": "4 - 6.1",
+        "firefox_mob": "1 - 19"
+    },
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/imul",
+    "spec": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-math.imul"
 }

--- a/polyfills/Math/log10/config.json
+++ b/polyfills/Math/log10/config.json
@@ -1,21 +1,22 @@
 {
-	"aliases": [
-		"es6"
-	],
-	"browsers": {
-		"android": "*",
-		"bb": "*",
-		"chrome": "1 - 37",
-		"firefox": "1 - 24",
-		"ie": "*",
-		"ie_mob": "10 - *",
-		"ios_chr": "*",
-		"ios_saf": "4 - 7",
-		"opera": "10 - 20",
-		"op_mob": "*",
-		"op_mini": "*",
-		"safari": "4 - 7"
-	},
-	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/log10",
-	"spec": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-math.log10"
+    "aliases": [
+        "es6"
+    ],
+    "browsers": {
+        "android": "*",
+        "bb": "*",
+        "chrome": "1 - 37",
+        "firefox": "1 - 24",
+        "ie": "*",
+        "ie_mob": "10 - *",
+        "ios_chr": "*",
+        "ios_saf": "4 - 7",
+        "opera": "10 - 20",
+        "op_mob": "*",
+        "op_mini": "*",
+        "safari": "4 - 7",
+        "firefox_mob": "1 - 24"
+    },
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/log10",
+    "spec": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-math.log10"
 }

--- a/polyfills/Math/log1p/config.json
+++ b/polyfills/Math/log1p/config.json
@@ -1,21 +1,22 @@
 {
-	"aliases": [
-		"es6"
-	],
-	"browsers": {
-		"android": "*",
-		"bb": "*",
-		"chrome": "1 - 37",
-		"firefox": "1 - 24",
-		"ie": "*",
-		"ie_mob": "10 - *",
-		"ios_chr": "*",
-		"ios_saf": "4 - 7",
-		"opera": "10 - 20",
-		"op_mob": "*",
-		"op_mini": "*",
-		"safari": "4 - 7"
-	},
-	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/log1p",
-	"spec": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-math.log1p"
+    "aliases": [
+        "es6"
+    ],
+    "browsers": {
+        "android": "*",
+        "bb": "*",
+        "chrome": "1 - 37",
+        "firefox": "1 - 24",
+        "ie": "*",
+        "ie_mob": "10 - *",
+        "ios_chr": "*",
+        "ios_saf": "4 - 7",
+        "opera": "10 - 20",
+        "op_mob": "*",
+        "op_mini": "*",
+        "safari": "4 - 7",
+        "firefox_mob": "1 - 24"
+    },
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/log1p",
+    "spec": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-math.log1p"
 }

--- a/polyfills/Math/log2/config.json
+++ b/polyfills/Math/log2/config.json
@@ -1,21 +1,22 @@
 {
-	"aliases": [
-		"es6"
-	],
-	"browsers": {
-		"android": "*",
-		"bb": "*",
-		"chrome": "1 - 37",
-		"firefox": "1 - 24",
-		"ie": "*",
-		"ie_mob": "10 - *",
-		"ios_chr": "*",
-		"ios_saf": "4 - 7",
-		"opera": "10 - 20",
-		"op_mob": "*",
-		"op_mini": "*",
-		"safari": "4 - 7"
-	},
-	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/log2",
-	"spec": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-math.log2"
+    "aliases": [
+        "es6"
+    ],
+    "browsers": {
+        "android": "*",
+        "bb": "*",
+        "chrome": "1 - 37",
+        "firefox": "1 - 24",
+        "ie": "*",
+        "ie_mob": "10 - *",
+        "ios_chr": "*",
+        "ios_saf": "4 - 7",
+        "opera": "10 - 20",
+        "op_mob": "*",
+        "op_mini": "*",
+        "safari": "4 - 7",
+        "firefox_mob": "1 - 24"
+    },
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/log2",
+    "spec": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-math.log2"
 }

--- a/polyfills/Math/sign/config.json
+++ b/polyfills/Math/sign/config.json
@@ -1,27 +1,28 @@
 {
-	"aliases": [
-		"es6"
-	],
-	"browsers": {
-		"android": "*",
-		"bb": "*",
-		"chrome": "1 - 37",
-		"firefox": "1 - 24",
-		"ios_chr": "*",
-		"ios_saf": "*",
-		"opera": "10 - 20",
-		"op_mob": "*",
-		"op_mini": "*"
-	},
-	"variants": {
-		"plus": {
-			"browsers": {
-				"ie": "*",
-				"ie_mob": "10 - *",
-				"safari": "*"
-			}
-		}
-	},
-	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sign",
-	"spec": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-math.sign"
+    "aliases": [
+        "es6"
+    ],
+    "browsers": {
+        "android": "*",
+        "bb": "*",
+        "chrome": "1 - 37",
+        "firefox": "1 - 24",
+        "ios_chr": "*",
+        "ios_saf": "*",
+        "opera": "10 - 20",
+        "op_mob": "*",
+        "op_mini": "*",
+        "firefox_mob": "1 - 24"
+    },
+    "variants": {
+        "plus": {
+            "browsers": {
+                "ie": "*",
+                "ie_mob": "10 - *",
+                "safari": "*"
+            }
+        }
+    },
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sign",
+    "spec": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-math.sign"
 }

--- a/polyfills/Math/sinh/config.json
+++ b/polyfills/Math/sinh/config.json
@@ -1,21 +1,22 @@
 {
-	"aliases": [
-		"es6"
-	],
-	"browsers": {
-		"android": "*",
-		"bb": "*",
-		"chrome": "1 - 37",
-		"firefox": "1 - 24",
-		"ie": "*",
-		"ie_mob": "10 - *",
-		"ios_chr": "*",
-		"ios_saf": "4 - 6.1",
-		"opera": "10 - 20",
-		"op_mob": "*",
-		"op_mini": "*",
-		"safari": "4 - 6.1"
-	},
-	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sinh",
-	"spec": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-math.sinh"
+    "aliases": [
+        "es6"
+    ],
+    "browsers": {
+        "android": "*",
+        "bb": "*",
+        "chrome": "1 - 37",
+        "firefox": "1 - 24",
+        "ie": "*",
+        "ie_mob": "10 - *",
+        "ios_chr": "*",
+        "ios_saf": "4 - 6.1",
+        "opera": "10 - 20",
+        "op_mob": "*",
+        "op_mini": "*",
+        "safari": "4 - 6.1",
+        "firefox_mob": "1 - 24"
+    },
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sinh",
+    "spec": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-math.sinh"
 }

--- a/polyfills/Math/tanh/config.json
+++ b/polyfills/Math/tanh/config.json
@@ -1,21 +1,22 @@
 {
-	"aliases": [
-		"es6"
-	],
-	"browsers": {
-		"android": "*",
-		"bb": "*",
-		"chrome": "1 - 37",
-		"firefox": "1 - 24",
-		"ie": "*",
-		"ie_mob": "10 - *",
-		"ios_chr": "*",
-		"ios_saf": "4 - 6.1",
-		"opera": "10 - 20",
-		"op_mob": "*",
-		"op_mini": "*",
-		"safari": "4 - 6.1"
-	},
-	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/tanh",
-	"spec": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-math.tanh"
+    "aliases": [
+        "es6"
+    ],
+    "browsers": {
+        "android": "*",
+        "bb": "*",
+        "chrome": "1 - 37",
+        "firefox": "1 - 24",
+        "ie": "*",
+        "ie_mob": "10 - *",
+        "ios_chr": "*",
+        "ios_saf": "4 - 6.1",
+        "opera": "10 - 20",
+        "op_mob": "*",
+        "op_mini": "*",
+        "safari": "4 - 6.1",
+        "firefox_mob": "1 - 24"
+    },
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/tanh",
+    "spec": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-math.tanh"
 }

--- a/polyfills/Math/trunc/config.json
+++ b/polyfills/Math/trunc/config.json
@@ -1,21 +1,22 @@
 {
-	"aliases": [
-		"es6"
-	],
-	"browsers": {
-		"android": "*",
-		"bb": "*",
-		"chrome": "1 - 37",
-		"firefox": "1 - 24",
-		"ie": "*",
-		"ie_mob": "10 - *",
-		"ios_chr": "*",
-		"ios_saf": "4 - 6.1",
-		"opera": "10 - 20",
-		"op_mob": "*",
-		"op_mini": "*",
-		"safari": "4 - 6.1"
-	},
-	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/trunc",
-	"spec": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-math.trunc"
+    "aliases": [
+        "es6"
+    ],
+    "browsers": {
+        "android": "*",
+        "bb": "*",
+        "chrome": "1 - 37",
+        "firefox": "1 - 24",
+        "ie": "*",
+        "ie_mob": "10 - *",
+        "ios_chr": "*",
+        "ios_saf": "4 - 6.1",
+        "opera": "10 - 20",
+        "op_mob": "*",
+        "op_mini": "*",
+        "safari": "4 - 6.1",
+        "firefox_mob": "1 - 24"
+    },
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/trunc",
+    "spec": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-math.trunc"
 }

--- a/polyfills/Node/prototype/contains/config.json
+++ b/polyfills/Node/prototype/contains/config.json
@@ -1,22 +1,23 @@
 {
-	"aliases": [
-		"dom4"
-	],
-	"browsers": {
-		"firefox": "* - 8",
-		"safari": "* - 2",
-		"ie": "9 - *",
-		"ie_mob": "10 - *"
-	},
-	"variants": {
-		"document": {
-			"browsers": {
-				"ie": "* - 8"
-			},
-			"dependencies": [
-				"Element"
-			]
-		}
-	},
-	"docs": "https://developer.mozilla.org/en-US/docs/Web/API/Node/contains"
+    "aliases": [
+        "dom4"
+    ],
+    "browsers": {
+        "firefox": "* - 8",
+        "safari": "* - 2",
+        "ie": "9 - *",
+        "ie_mob": "10 - *",
+        "firefox_mob": "* - 8"
+    },
+    "variants": {
+        "document": {
+            "browsers": {
+                "ie": "* - 8"
+            },
+            "dependencies": [
+                "Element"
+            ]
+        }
+    },
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/API/Node/contains"
 }

--- a/polyfills/Object/assign/config.json
+++ b/polyfills/Object/assign/config.json
@@ -1,22 +1,23 @@
 {
-	"aliases": [
-		"es6",
-		"modernizr:es6object",
-		"default"
-	],
-	"browsers": {
-		"android": "*",
-		"bb": "*",
-		"chrome": "*",
-		"firefox": "1 - 33",
-		"ie": "*",
-		"ie_mob": "*",
-		"ios_chr": "*",
-		"ios_saf": "*",
-		"opera": "*",
-		"op_mob": "*",
-		"op_mini": "*",
-		"safari": "*"
-	},
-	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign"
+    "aliases": [
+        "es6",
+        "modernizr:es6object",
+        "default"
+    ],
+    "browsers": {
+        "android": "*",
+        "bb": "*",
+        "chrome": "*",
+        "firefox": "1 - 33",
+        "ie": "*",
+        "ie_mob": "*",
+        "ios_chr": "*",
+        "ios_saf": "*",
+        "opera": "*",
+        "op_mob": "*",
+        "op_mini": "*",
+        "safari": "*",
+        "firefox_mob": "1 - 33"
+    },
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign"
 }

--- a/polyfills/Object/create/config.json
+++ b/polyfills/Object/create/config.json
@@ -1,16 +1,17 @@
 {
-	"aliases": [
-		"es5",
-		"modernizr:es5object",
-		"default"
-	],
-	"browsers": {
-		"ie": "6 - 8",
-		"safari": "4",
-		"firefox": "<4"
-	},
-	"dependencies": [
-		"Object.defineProperties"
-	],
-	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create"
+    "aliases": [
+        "es5",
+        "modernizr:es5object",
+        "default"
+    ],
+    "browsers": {
+        "ie": "6 - 8",
+        "safari": "4",
+        "firefox": "<4",
+        "firefox_mob": "<4"
+    },
+    "dependencies": [
+        "Object.defineProperties"
+    ],
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create"
 }

--- a/polyfills/Object/defineProperties/config.json
+++ b/polyfills/Object/defineProperties/config.json
@@ -1,16 +1,17 @@
 {
-	"aliases": [
-		"es5",
-		"modernizr:es5object",
-		"default"
-	],
-	"browsers": {
-		"ie": "6 - 8",
-		"safari": "4 - 4.1",
-		"firefox": "<4"
-	},
-	"dependencies": [
-		"Object.defineProperty"
-	],
-	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperties"
+    "aliases": [
+        "es5",
+        "modernizr:es5object",
+        "default"
+    ],
+    "browsers": {
+        "ie": "6 - 8",
+        "safari": "4 - 4.1",
+        "firefox": "<4",
+        "firefox_mob": "<4"
+    },
+    "dependencies": [
+        "Object.defineProperty"
+    ],
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperties"
 }

--- a/polyfills/Object/defineProperty/config.json
+++ b/polyfills/Object/defineProperty/config.json
@@ -1,25 +1,26 @@
 {
-	"aliases": [
-		"es5",
-		"modernizr:es5object",
-		"default"
-	],
-	"browsers": {
-		"firefox": "3.6",
-		"safari": "4 - 4.1",
-		"ios_saf": "4.3"
-	},
-	"variants": {
-		"ie7": {
-			"browsers": {
-				"ie": "6 - 7"
-			}
-		},
-		"ie8": {
-			"browsers": {
-				"ie": "8"
-			}
-		}
-	},
-	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty"
+    "aliases": [
+        "es5",
+        "modernizr:es5object",
+        "default"
+    ],
+    "browsers": {
+        "firefox": "3.6",
+        "safari": "4 - 4.1",
+        "ios_saf": "4.3",
+        "firefox_mob": "3.6"
+    },
+    "variants": {
+        "ie7": {
+            "browsers": {
+                "ie": "6 - 7"
+            }
+        },
+        "ie8": {
+            "browsers": {
+                "ie": "8"
+            }
+        }
+    },
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty"
 }

--- a/polyfills/Object/getOwnPropertyNames/config.json
+++ b/polyfills/Object/getOwnPropertyNames/config.json
@@ -1,13 +1,14 @@
 {
-	"aliases": [
-		"es5",
-		"modernizr:es5object",
-		"default"
-	],
-	"browsers": {
-		"firefox": "3.6",
-		"safari": "4",
-		"ie": "6 - 8"
-	},
-	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyNames"
+    "aliases": [
+        "es5",
+        "modernizr:es5object",
+        "default"
+    ],
+    "browsers": {
+        "firefox": "3.6",
+        "safari": "4",
+        "ie": "6 - 8",
+        "firefox_mob": "3.6"
+    },
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyNames"
 }

--- a/polyfills/Object/getPrototypeOf/config.json
+++ b/polyfills/Object/getPrototypeOf/config.json
@@ -1,13 +1,14 @@
 {
-	"aliases": [
-		"es5",
-		"modernizr:es5object",
-		"default"
-	],
-	"browsers": {
-		"ie": "6 - 8",
-		"firefox": "3.6",
-		"safari": "4"
-	},
-	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getPrototypeOf"
+    "aliases": [
+        "es5",
+        "modernizr:es5object",
+        "default"
+    ],
+    "browsers": {
+        "ie": "6 - 8",
+        "firefox": "3.6",
+        "safari": "4",
+        "firefox_mob": "3.6"
+    },
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getPrototypeOf"
 }

--- a/polyfills/Object/is/config.json
+++ b/polyfills/Object/is/config.json
@@ -1,20 +1,21 @@
 {
-	"aliases": [
-		"es6",
-		"modernizr:es6object"
-	],
-	"browsers": {
-		"android": "*",
-		"bb": "*",
-		"chrome": "1 - 29",
-		"firefox": "3.6 - 21",
-		"ie": "*",
-		"ie_mob": "10 - *",
-		"opera": "*",
-		"op_mini": "*",
-		"op_mob": "*",
-		"safari": "*",
-		"ios_saf": "*"
-	},
-	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is"
+    "aliases": [
+        "es6",
+        "modernizr:es6object"
+    ],
+    "browsers": {
+        "android": "*",
+        "bb": "*",
+        "chrome": "1 - 29",
+        "firefox": "3.6 - 21",
+        "ie": "*",
+        "ie_mob": "10 - *",
+        "opera": "*",
+        "op_mini": "*",
+        "op_mob": "*",
+        "safari": "*",
+        "ios_saf": "*",
+        "firefox_mob": "3.6 - 21"
+    },
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is"
 }

--- a/polyfills/Object/keys/config.json
+++ b/polyfills/Object/keys/config.json
@@ -1,17 +1,18 @@
 {
-	"aliases": [
-		"es5",
-		"modernizr:es5object",
-		"default"
-	],
-	"browsers": {
-		"ie": "6 - 8",
-		"safari": "4",
-		"chrome": "<5",
-		"opera": "<12",
-		"firefox": "<4"
-	},
-	"author": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys",
-	"license": "CC0",
-	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys"
+    "aliases": [
+        "es5",
+        "modernizr:es5object",
+        "default"
+    ],
+    "browsers": {
+        "ie": "6 - 8",
+        "safari": "4",
+        "chrome": "<5",
+        "opera": "<12",
+        "firefox": "<4",
+        "firefox_mob": "<4"
+    },
+    "author": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys",
+    "license": "CC0",
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys"
 }

--- a/polyfills/Promise/config.json
+++ b/polyfills/Promise/config.json
@@ -1,28 +1,29 @@
 {
-	"aliases": [
-		"modernizr:promises",
-		"caniuse:promises"
-	],
-	"browsers": {
-		"android": "* - 4.4",
-		"bb": "* - 10",
-		"chrome": "* - 31",
-		"firefox": "6 - 28",
-		"ie": "8 - *",
-		"ie_mob": "*",
-		"ios_saf": "* - 7.1",
-		"op_mini": "*",
-		"opera": "* - 19",
-		"safari": "* - 7"
-	},
-	"dependencies": [
-		"_enqueueMicrotask",
-		"Array.isArray"
-	],
-	"notes": [
-		"In IE8, the `catch` method cannot be invoked directly since it is a reserved word.  Instead, use `[\"catch\"]` if intend to run your code in IE8"
-	],
-	"license": "MIT",
-	"docs": "https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Promise",
-	"repo": "https://github.com/Octane/Promise"
+    "aliases": [
+        "modernizr:promises",
+        "caniuse:promises"
+    ],
+    "browsers": {
+        "android": "* - 4.4",
+        "bb": "* - 10",
+        "chrome": "* - 31",
+        "firefox": "6 - 28",
+        "ie": "8 - *",
+        "ie_mob": "*",
+        "ios_saf": "* - 7.1",
+        "op_mini": "*",
+        "opera": "* - 19",
+        "safari": "* - 7",
+        "firefox_mob": "6 - 28"
+    },
+    "dependencies": [
+        "_enqueueMicrotask",
+        "Array.isArray"
+    ],
+    "notes": [
+        "In IE8, the `catch` method cannot be invoked directly since it is a reserved word.  Instead, use `[\"catch\"]` if intend to run your code in IE8"
+    ],
+    "license": "MIT",
+    "docs": "https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Promise",
+    "repo": "https://github.com/Octane/Promise"
 }

--- a/polyfills/String/prototype/contains/config.json
+++ b/polyfills/String/prototype/contains/config.json
@@ -1,17 +1,18 @@
 {
-	"browsers": {
-		"android": "*",
-		"bb": "*",
-		"chrome": "*",
-		"firefox": "3.6 - 17",
-		"opera": "10 - 18",
-		"safari": "*",
-		"ie": "6 - *",
-		"ie_mob": "10 - *",
-		"ios_saf": "*"
-	},
-	"dependencies": [
-		"String.prototype.includes"
-	],
-	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes#String.prototype.contains"
+    "browsers": {
+        "android": "*",
+        "bb": "*",
+        "chrome": "*",
+        "firefox": "3.6 - 17",
+        "opera": "10 - 18",
+        "safari": "*",
+        "ie": "6 - *",
+        "ie_mob": "10 - *",
+        "ios_saf": "*",
+        "firefox_mob": "3.6 - 17"
+    },
+    "dependencies": [
+        "String.prototype.includes"
+    ],
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes#String.prototype.contains"
 }

--- a/polyfills/String/prototype/endsWith/config.json
+++ b/polyfills/String/prototype/endsWith/config.json
@@ -1,18 +1,19 @@
 {
-	"aliases": [
-		"es6",
-		"modernizr:es6string"
-	],
-	"browsers": {
-		"android": "*",
-		"bb": "*",
-		"chrome": "<=40",
-		"firefox": "3.6 - 17",
-		"opera": "10 - 18",
-		"safari": "*",
-		"ie": "6 - *",
-		"ie_mob": "10 - *",
-		"ios_saf": "*"
-	},
-	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith"
+    "aliases": [
+        "es6",
+        "modernizr:es6string"
+    ],
+    "browsers": {
+        "android": "*",
+        "bb": "*",
+        "chrome": "<=40",
+        "firefox": "3.6 - 17",
+        "opera": "10 - 18",
+        "safari": "*",
+        "ie": "6 - *",
+        "ie_mob": "10 - *",
+        "ios_saf": "*",
+        "firefox_mob": "3.6 - 17"
+    },
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith"
 }

--- a/polyfills/String/prototype/includes/config.json
+++ b/polyfills/String/prototype/includes/config.json
@@ -1,19 +1,20 @@
 {
-	"aliases": [
-		"default",
-		"es6",
-		"modernizr:es6string"
-	],
-	"browsers": {
-		"android": "*",
-		"bb": "*",
-		"chrome": "*",
-		"firefox": "*",
-		"opera": "10 - 18",
-		"safari": "*",
-		"ie": "6 - *",
-		"ie_mob": "10 - *",
-		"ios_saf": "*"
-	},
-	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes"
+    "aliases": [
+        "default",
+        "es6",
+        "modernizr:es6string"
+    ],
+    "browsers": {
+        "android": "*",
+        "bb": "*",
+        "chrome": "*",
+        "firefox": "*",
+        "opera": "10 - 18",
+        "safari": "*",
+        "ie": "6 - *",
+        "ie_mob": "10 - *",
+        "ios_saf": "*",
+        "firefox_mob": "*"
+    },
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes"
 }

--- a/polyfills/String/prototype/repeat/config.json
+++ b/polyfills/String/prototype/repeat/config.json
@@ -1,18 +1,19 @@
 {
-	"aliases": [
-		"es6",
-		"modernizr:es6string"
-	],
-	"browsers": {
-		"android": "*",
-		"bb": "*",
-		"chrome": "*",
-		"firefox": "3.6 - 17",
-		"opera": "10 - 18",
-		"safari": "*",
-		"ie": "6 - *",
-		"ie_mob": "10 - *",
-		"ios_saf": "*"
-	},
-	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/repeat"
+    "aliases": [
+        "es6",
+        "modernizr:es6string"
+    ],
+    "browsers": {
+        "android": "*",
+        "bb": "*",
+        "chrome": "*",
+        "firefox": "3.6 - 17",
+        "opera": "10 - 18",
+        "safari": "*",
+        "ie": "6 - *",
+        "ie_mob": "10 - *",
+        "ios_saf": "*",
+        "firefox_mob": "3.6 - 17"
+    },
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/repeat"
 }

--- a/polyfills/String/prototype/startsWith/config.json
+++ b/polyfills/String/prototype/startsWith/config.json
@@ -1,18 +1,19 @@
 {
-	"aliases": [
-		"es6",
-		"modernizr:es6string"
-	],
-	"browsers": {
-		"android": "*",
-		"bb": "*",
-		"chrome": "*",
-		"firefox": "3.6 - 17",
-		"opera": "10 - 18",
-		"safari": "*",
-		"ie": "6 - *",
-		"ie_mob": "10 - *",
-		"ios_saf": "*"
-	},
-	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith"
+    "aliases": [
+        "es6",
+        "modernizr:es6string"
+    ],
+    "browsers": {
+        "android": "*",
+        "bb": "*",
+        "chrome": "*",
+        "firefox": "3.6 - 17",
+        "opera": "10 - 18",
+        "safari": "*",
+        "ie": "6 - *",
+        "ie_mob": "10 - *",
+        "ios_saf": "*",
+        "firefox_mob": "3.6 - 17"
+    },
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith"
 }

--- a/polyfills/URL/config.json
+++ b/polyfills/URL/config.json
@@ -1,19 +1,18 @@
 {
-	"browsers": {
-		"chrome" : "5 - *",
-		"firefox": "4 - 29",
-		"ie"     : ">=8",
-		"ie_mob" : ">=10",
-		"opera"  : "11.60 - *",
-		"safari" : "5.1 - *"
-	},
-
-	"dependencies": [
-		"Object.defineProperties",
-		"Array.prototype.forEach"
-	],
-
-	"license": "CC0",
-	"repo" : "https://github.com/inexorabletash/polyfill",
-	"docs": "https://developer.mozilla.org/en-US/docs/Web/API/URL"
+    "browsers": {
+        "chrome": "5 - *",
+        "firefox": "4 - 29",
+        "ie": ">=8",
+        "ie_mob": ">=10",
+        "opera": "11.60 - *",
+        "safari": "5.1 - *",
+        "firefox_mob": "4 - 29"
+    },
+    "dependencies": [
+        "Object.defineProperties",
+        "Array.prototype.forEach"
+    ],
+    "license": "CC0",
+    "repo": "https://github.com/inexorabletash/polyfill",
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/API/URL"
 }

--- a/polyfills/WeakMap/config.json
+++ b/polyfills/WeakMap/config.json
@@ -1,21 +1,22 @@
 {
-	"aliases": [
-		"es6"
-	],
-	"browsers": {
-		"ie": "7 - 11",
-		"ie_mob": "10 - 11",
-		"safari": "*",
-		"chrome": "<38",
-		"firefox": "<36",
-		"ios_saf": "*",
-		"opera": "<25"
-	},
-	"dependencies": [
-		"Object.defineProperty",
-		"Array.prototype.forEach",
-		"Date.now"
-	],
-	"license": "https://github.com/webcomponents/webcomponentsjs/blob/master/LICENSE.md",
-	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap"
+    "aliases": [
+        "es6"
+    ],
+    "browsers": {
+        "ie": "7 - 11",
+        "ie_mob": "10 - 11",
+        "safari": "*",
+        "chrome": "<38",
+        "firefox": "<36",
+        "ios_saf": "*",
+        "opera": "<25",
+        "firefox_mob": "<36"
+    },
+    "dependencies": [
+        "Object.defineProperty",
+        "Array.prototype.forEach",
+        "Date.now"
+    ],
+    "license": "https://github.com/webcomponents/webcomponentsjs/blob/master/LICENSE.md",
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap"
 }

--- a/polyfills/WeakSet/config.json
+++ b/polyfills/WeakSet/config.json
@@ -1,22 +1,23 @@
 {
-	"aliases": [
-		"es6"
-	],
-	"browsers": {
-		"ie": "7 - *",
-		"ie_mob": "10 - *",
-		"safari": "*",
-		"chrome": "<38",
-		"firefox": "<34",
-		"ios_saf": "*",
-		"opera": "<25"
-	},
-	"dependencies": [
-		"Object.defineProperty",
-		"Array.prototype.forEach",
-		"Date.now"
-	],
-	"repo": "https://github.com/webcomponents/webcomponentsjs",
-	"license": "https://github.com/webcomponents/webcomponentsjs/blob/master/LICENSE.md",
-	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakSet"
+    "aliases": [
+        "es6"
+    ],
+    "browsers": {
+        "ie": "7 - *",
+        "ie_mob": "10 - *",
+        "safari": "*",
+        "chrome": "<38",
+        "firefox": "<34",
+        "ios_saf": "*",
+        "opera": "<25",
+        "firefox_mob": "<34"
+    },
+    "dependencies": [
+        "Object.defineProperty",
+        "Array.prototype.forEach",
+        "Date.now"
+    ],
+    "repo": "https://github.com/webcomponents/webcomponentsjs",
+    "license": "https://github.com/webcomponents/webcomponentsjs/blob/master/LICENSE.md",
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakSet"
 }

--- a/polyfills/_enqueueMicrotask/config.json
+++ b/polyfills/_enqueueMicrotask/config.json
@@ -1,29 +1,29 @@
-
 {
-	"aliases": [
-		"modernizr:promises",
-		"caniuse:promises"
-	],
-	"browsers": {
-		"android": "*",
-		"chrome": "*",
-		"firefox": "*",
-		"ie": "9 - *",
-		"ie_mob": "*",
-		"ios_saf": "*",
-		"opera": "*",
-		"op_mob": "*",
-		"op_mini": "*",
-		"bb": "*",
-		"safari": "*"
-	},
-	"variants": {
-		"ie8": {
-			"browsers": {
-				"ie": "* - 8"
-			}
-		}
-	},
-	"license": "MIT",
-	"repo": "https://github.com/Octane/setImmediate"
+    "aliases": [
+        "modernizr:promises",
+        "caniuse:promises"
+    ],
+    "browsers": {
+        "android": "*",
+        "chrome": "*",
+        "firefox": "*",
+        "ie": "9 - *",
+        "ie_mob": "*",
+        "ios_saf": "*",
+        "opera": "*",
+        "op_mob": "*",
+        "op_mini": "*",
+        "bb": "*",
+        "safari": "*",
+        "firefox_mob": "*"
+    },
+    "variants": {
+        "ie8": {
+            "browsers": {
+                "ie": "* - 8"
+            }
+        }
+    },
+    "license": "MIT",
+    "repo": "https://github.com/Octane/setImmediate"
 }

--- a/polyfills/_mutation/config.json
+++ b/polyfills/_mutation/config.json
@@ -1,20 +1,21 @@
 {
-	"browsers": {
-		"android": "*",
-		"bb": "*",
-		"chrome": "*",
-		"firefox": "*",
-		"ios_chr": "*",
-		"ios_saf": "*",
-		"ie": "*",
-		"ie_mob": "10 - *",
-		"opera": "*",
-		"op_mini": "*",
-		"safari": "*"
-	},
-	"dependencies": [
-		"Document",
-		"Element",
-		"Text"
-	]
+    "browsers": {
+        "android": "*",
+        "bb": "*",
+        "chrome": "*",
+        "firefox": "*",
+        "ios_chr": "*",
+        "ios_saf": "*",
+        "ie": "*",
+        "ie_mob": "10 - *",
+        "opera": "*",
+        "op_mini": "*",
+        "safari": "*",
+        "firefox_mob": "*"
+    },
+    "dependencies": [
+        "Document",
+        "Element",
+        "Text"
+    ]
 }

--- a/polyfills/fetch/config.json
+++ b/polyfills/fetch/config.json
@@ -1,24 +1,25 @@
 {
-	"browsers": {
-		"ie": "*",
-		"ie_mob": "10 - *",
-		"firefox": "* - 38",
-		"opera": "* - 28",
-		"safari": "*",
-		"chrome": "* - 41",
-		"ios_saf": "*"
-	},
-	"dependencies": [
-		"Array.prototype.forEach",
-		"Object.getOwnPropertyNames",
-		"Promise",
-		"XMLHttpRequest"
-	],
-	"license": "MIT",
-	"spec": "https://fetch.spec.whatwg.org/",
-	"repo": "https://github.com/github/fetch",
-	"notes": [
-		"Makes use of FormData, FileReader and Blob if they exist"
-	],
-	"docs": "https://developer.mozilla.org/en-US/docs/Web/API/GlobalFetch/fetch"
+    "browsers": {
+        "ie": "*",
+        "ie_mob": "10 - *",
+        "firefox": "* - 38",
+        "opera": "* - 28",
+        "safari": "*",
+        "chrome": "* - 41",
+        "ios_saf": "*",
+        "firefox_mob": "* - 38"
+    },
+    "dependencies": [
+        "Array.prototype.forEach",
+        "Object.getOwnPropertyNames",
+        "Promise",
+        "XMLHttpRequest"
+    ],
+    "license": "MIT",
+    "spec": "https://fetch.spec.whatwg.org/",
+    "repo": "https://github.com/github/fetch",
+    "notes": [
+        "Makes use of FormData, FileReader and Blob if they exist"
+    ],
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/API/GlobalFetch/fetch"
 }

--- a/polyfills/location/origin/config.json
+++ b/polyfills/location/origin/config.json
@@ -5,7 +5,8 @@
         "firefox": "<=20",
         "safari": "<=6",
         "ios_saf": "<=6",
-        "chrome": "<=29"
+        "chrome": "<=29",
+        "firefox_mob": "<=20"
     },
     "dependencies": [
         "Object.defineProperties"

--- a/polyfills/performance/now/config.json
+++ b/polyfills/performance/now/config.json
@@ -1,16 +1,17 @@
 {
-	"browsers": {
-		"bb": "<10",
-		"chrome": "<24",
-		"ie": "<10",
-		"ios_saf": "<8 || 8.1",
-		"firefox": "<15",
-		"opera": "<15",
-		"op_mob": "<24",
-		"safari": "<8"
-	},
-	"dependencies": [
-		"Date.now"
-	],
-	"docs": "https://developer.mozilla.org/en-US/docs/Web/API/Performance/now"
+    "browsers": {
+        "bb": "<10",
+        "chrome": "<24",
+        "ie": "<10",
+        "ios_saf": "<8 || 8.1",
+        "firefox": "<15",
+        "opera": "<15",
+        "op_mob": "<24",
+        "safari": "<8",
+        "firefox_mob": "<15"
+    },
+    "dependencies": [
+        "Date.now"
+    ],
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/API/Performance/now"
 }

--- a/polyfills/requestAnimationFrame/config.json
+++ b/polyfills/requestAnimationFrame/config.json
@@ -1,44 +1,45 @@
 {
-	"aliases": [
-		"default",
-		"caniuse:requestanimationframe",
-		"modernizr:requestanimationframe"
-	],
-	"browsers": {
-		"bb": "7",
-		"chrome": "1 - 9",
-		"ie": "6 - 9",
-		"ios_saf": "3.2 - 5.1",
-		"firefox": "3.6",
-		"opera": "9 - 12.1",
-		"op_mini": "5 - 7",
-		"op_mob": "10 - 12.1",
-		"safari": "3.1 - 5.1"
-	},
-	"variants": {
-		"moz": {
-			"browsers": {
-				"firefox": "4 - 22"
-			},
-			"dependencies": [
-				"performance.now"
-			]
-		},
-		"webkit": {
-			"browsers": {
-				"chrome": "10 - 23",
-				"safari": "6",
-				"ios_saf": "6.1"
-			},
-			"dependencies": [
-				"performance.now"
-			]
-		}
-	},
-	"dependencies": [
-		"Date.now",
-		"performance.now"
-	],
-	"license": "MIT",
-	"docs": "https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame"
+    "aliases": [
+        "default",
+        "caniuse:requestanimationframe",
+        "modernizr:requestanimationframe"
+    ],
+    "browsers": {
+        "bb": "7",
+        "chrome": "1 - 9",
+        "ie": "6 - 9",
+        "ios_saf": "3.2 - 5.1",
+        "firefox": "3.6",
+        "opera": "9 - 12.1",
+        "op_mini": "5 - 7",
+        "op_mob": "10 - 12.1",
+        "safari": "3.1 - 5.1",
+        "firefox_mob": "3.6"
+    },
+    "variants": {
+        "moz": {
+            "browsers": {
+                "firefox": "4 - 22"
+            },
+            "dependencies": [
+                "performance.now"
+            ]
+        },
+        "webkit": {
+            "browsers": {
+                "chrome": "10 - 23",
+                "safari": "6",
+                "ios_saf": "6.1"
+            },
+            "dependencies": [
+                "performance.now"
+            ]
+        }
+    },
+    "dependencies": [
+        "Date.now",
+        "performance.now"
+    ],
+    "license": "MIT",
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame"
 }

--- a/polyfills/screen/orientation/config.json
+++ b/polyfills/screen/orientation/config.json
@@ -1,22 +1,23 @@
 {
-	"browsers": {
-		"ie": "9 - *",
-		"ie_mob": "*",
-		"firefox": "*",
-		"chrome": "* - 37",
-		"safari": "*",
-		"ios_saf": "*",
-		"opera": "* - 24",
-		"op_mob": "*",
-		"android": "*",
-		"bb": "*"
-	},
-	"dependencies": [
-		"Object.defineProperty"
-	],
-	"notes": [
-		"In IE <= 8 window.screen is read-only, so the orientation property is not definable"
-	],
-	"spec": "http://www.w3.org/TR/screen-orientation/",
-	"docs": "https://developer.mozilla.org/en-US/docs/Web/API/Screen/orientation"
+    "browsers": {
+        "ie": "9 - *",
+        "ie_mob": "*",
+        "firefox": "*",
+        "chrome": "* - 37",
+        "safari": "*",
+        "ios_saf": "*",
+        "opera": "* - 24",
+        "op_mob": "*",
+        "android": "*",
+        "bb": "*",
+        "firefox_mob": "*"
+    },
+    "dependencies": [
+        "Object.defineProperty"
+    ],
+    "notes": [
+        "In IE <= 8 window.screen is read-only, so the orientation property is not definable"
+    ],
+    "spec": "http://www.w3.org/TR/screen-orientation/",
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/API/Screen/orientation"
 }

--- a/polyfills/setImmediate/config.json
+++ b/polyfills/setImmediate/config.json
@@ -1,18 +1,19 @@
 {
-	"browsers": {
-		"chrome": "*",
-		"firefox": "*",
-		"opera": "*",
-		"safari": "*",
-		"ie": "* - 9",
-		"ios_saf": "*",
-		"ios_chr": "*",
-		"android": "*",
-		"op_mob": "*",
-		"ie_mob": "*"
-	},
-	"dependencies": [
-		"_enqueueMicrotask"
-	],
-	"docs": "https://developer.mozilla.org/en-US/docs/Web/API/Window/setImmediate"
+    "browsers": {
+        "chrome": "*",
+        "firefox": "*",
+        "opera": "*",
+        "safari": "*",
+        "ie": "* - 9",
+        "ios_saf": "*",
+        "ios_chr": "*",
+        "android": "*",
+        "op_mob": "*",
+        "ie_mob": "*",
+        "firefox_mob": "*"
+    },
+    "dependencies": [
+        "_enqueueMicrotask"
+    ],
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/API/Window/setImmediate"
 }


### PR DESCRIPTION
Adds `firefox_mob` support and update config accordingly.  In most places the config is identical to Firefox with some exceptions - notably `Intl`.

Closes #477 

(The config update was automated using this hacky script, if you're interested: https://gist.github.com/samgiles/496399d0da51f03e308e)
