### PR TITLE
IE11 doesn't support Event constructor - adding to required browsers

### DIFF
--- a/polyfills/Event/config.json
+++ b/polyfills/Event/config.json
@@ -4,7 +4,7 @@
 	],
 	"browsers": {
 		"firefox": "6 - 10",
-		"ie": "9 - 10",
+		"ie": "9 - 11",
 		"ie_mob": "10",
 		"opera": "10 - 11.5",
 		"safari": "4 - 7"


### PR DESCRIPTION
This is a fix for `Event` support in IE11. The config was saying that it should polyfill up to IE10, but as can be seen from these tests, IE11 requires the `Event` polyfill as well.

[Throws in IE11](http://annez.github.io/event-test/)
[Works in IE11 with Event polyfill forced](http://annez.github.io/event-test/fix.html)
## Changes
- Updated `config.json` file to reflect this and polyfilling IE11

This should fix #479 
