### PR TITLE
Make window.hasOwnProperty work in IE8.

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "polyfill-service",
-  "version": "2.0.0",
+  "version": "2.1.0-beta.1",
   "dependencies": {
     "babel-core": {
       "version": "4.7.16",

--- a/package.json
+++ b/package.json
@@ -74,5 +74,5 @@
     "sauce-tunnel": "^2.2.3",
     "wd": "^0.3.8"
   },
-  "version": "2.0.0"
+  "version": "2.1.0-beta.1"
 }

--- a/polyfills/Object/getOwnPropertyNames/polyfill.js
+++ b/polyfills/Object/getOwnPropertyNames/polyfill.js
@@ -14,7 +14,7 @@ Object.getOwnPropertyNames = function getOwnPropertyNames(object) {
 
 	// Enumerable properties only
 	for (key in object) {
-		if (object.hasOwnProperty(key)) {
+		if (Object.prototype.hasOwnProperty.call(object, key)) {
 			buffer.push(key);
 		}
 	}

--- a/polyfills/Object/getOwnPropertyNames/tests.js
+++ b/polyfills/Object/getOwnPropertyNames/tests.js
@@ -4,6 +4,12 @@ it('returns properties of a simple object', function () {
 	expect(Object.getOwnPropertyNames({foo:42})).to.eql(["foo"]);
 });
 
+it('does not throw an exception when used on window object', function () {
+	expect(function () {
+		Object.getOwnPropertyNames(window);
+	}).not.to.throwException();
+});
+
 it('does not include properties inherited from a prototype', function () {
 	var A = function() { this.foo = true; };
 	A.prototype = {bar: true};
@@ -32,4 +38,3 @@ it.skip('splits a string into an array', function() {
 	// In Chrome the length property is returned at the end, in FF at the beginning.  Our polyfill adds it to the end
 	expect(Object.getOwnPropertyNames('foo')).to.eql(['0', '1', '2', 'length']);
 });
-


### PR DESCRIPTION
This fixes hasOwnProperty IE8 error if you try to query window object. window.hasOwnProperty is undefined otherwise.. 

Uses the same fix used in for Object.assign (929ce80270c2ed886b09a1b25242551b3ff2f461)

Relates with: #433
