### PR TITLE
Update HTML5 Shiv to latest version (3.7.3)

### DIFF
--- a/polyfills/~html5-elements/polyfill.js
+++ b/polyfills/~html5-elements/polyfill.js
@@ -1,10 +1,10 @@
 /**
-* @preserve HTML5 Shiv 3.7.2 | @afarkas @jdalton @jon_neal @rem | MIT/GPL2 Licensed
+* @preserve HTML5 Shiv 3.7.3 | @afarkas @jdalton @jon_neal @rem | MIT/GPL2 Licensed
 */
 ;(function(window, document) {
 /*jshint evil:true */
   /** version */
-  var version = '3.7.2';
+  var version = '3.7.3';
 
   /** Preset options */
   var options = window.html5 || {};
@@ -121,7 +121,7 @@
    * returns a shived element for the given nodeName and document
    * @memberOf html5
    * @param {String} nodeName name of the element
-   * @param {Document} ownerDocument The context document.
+   * @param {Document|DocumentFragment} ownerDocument The context document.
    * @returns {Object} The shived element.
    */
   function createElement(nodeName, ownerDocument, data){
@@ -319,4 +319,8 @@
   // shiv the document
   shivDocument(document);
 
-}(this, document));
+  if(typeof module == 'object' && module.exports){
+    module.exports = html5;
+  }
+
+}(typeof window !== "undefined" ? window : this, document));


### PR DESCRIPTION
Update HTML5 Shiv to latest version (3.7.3)

From: https://github.com/aFarkas/html5shiv/blob/master/dist/html5shiv.js
