### PR TITLE
Add response.ok property to fetch polyfill

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "polyfill-service",
-  "version": "2.0.0",
+  "version": "2.1.0-beta.1",
   "dependencies": {
     "babel-core": {
       "version": "4.7.16",

--- a/package.json
+++ b/package.json
@@ -74,5 +74,5 @@
     "sauce-tunnel": "^2.2.3",
     "wd": "^0.3.8"
   },
-  "version": "2.0.0"
+  "version": "2.1.0-beta.1"
 }

--- a/polyfills/fetch/polyfill.js
+++ b/polyfills/fetch/polyfill.js
@@ -264,6 +264,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     this.url = null
     this.status = options.status
     this.statusText = options.statusText
+    this.ok = this.status >= 200 && this.status < 300
     this.headers = options.headers
     this.url = options.url || ''
   }


### PR DESCRIPTION
From the MDN docs: The `ok` read-only property of the `Response`
interface contains a boolean stating whether the response was successful
(status in the range 200-299) or not.

See:
- https://developer.mozilla.org/en-US/docs/Web/API/Response/ok
- https://github.com/github/fetch/blob/e0a48518734aac116f49962c825522ab99da8338/fetch.js#L278
