### PR TITLE
Enable `localStorage` polyfill in Opera Mini

### DIFF
--- a/polyfills/localStorage/config.json
+++ b/polyfills/localStorage/config.json
@@ -4,7 +4,8 @@
 		"modernizr:localstorage"
 	],
 	"browsers": {
-		"ie": "6 - 7"
+		"ie": "6 - 7",
+		"op_mini": "*"
 	},
 	"dependencies": [
 		"Window"


### PR DESCRIPTION
#498.
