### PR TITLE
Add simple memory cache around the latest polyfill collection

### DIFF
--- a/lib/sources.js
+++ b/lib/sources.js
@@ -33,6 +33,7 @@ try {
 
 function Collection(version) {
 	this.version = version || 'latest';
+	this.cache = {};
 	if (this.version !== 'latest') {
 		this.version = semver.maxSatisfying(semverVersions, version);
 	}
@@ -51,9 +52,16 @@ Collection.prototype.getPolyfill = function(featureName) {
 
 	// TODO: Should this reject if the polyfill doesn't exist?  Makes the main module logic a bit more complex
 	if (features[this.version].indexOf(featureName) !== -1) {
+		if (this.version === 'latest' && this.cache[featureName]) {
+			return Promise.resolve(this.cache[featureName]);
+		}
 		return readFile(path.join(polyfillsPath, this.version, featureName+'.json'), 'utf-8').then(function(str) {
-			return JSON.parse(str);
-		});
+			var feature = JSON.parse(str);
+			if (this.version === 'latest') {
+				this.cache[featureName] = feature;
+			}
+			return feature;
+		}.bind(this));
 	} else {
 		return Promise.resolve(null);
 	}


### PR DESCRIPTION
Hopefully to reduce the amount of time we spend blocked on IO, though it's hard to tell why async IO functions are causing such long event loop delay.
