### PR TITLE
RequestAnimationFrame webkit polyfill ios_saf 6

### DIFF
--- a/polyfills/requestAnimationFrame/config.json
+++ b/polyfills/requestAnimationFrame/config.json
@@ -29,7 +29,7 @@
 			"browsers": {
 				"chrome": "10 - 23",
 				"safari": "6",
-				"ios_saf": "6.1"
+				"ios_saf": "6"
 			},
 			"dependencies": [
 				"performance.now"


### PR DESCRIPTION
Allow webkit polyfill for requestAnimationFrame on all iOS6 safari browsers, as opposed to just versions greater than 6.1
