### PR TITLE
Array.prototype.includes updated browser support for firefox 43

### DIFF
--- a/polyfills/Array/prototype/includes/config.json
+++ b/polyfills/Array/prototype/includes/config.json
@@ -5,7 +5,7 @@
 	],
 	"browsers": {
 		"chrome": "*",
-		"firefox": "*",
+		"firefox": "<=42",
 		"ie": "*",
 		"opera": "*",
 		"safari": "*",


### PR DESCRIPTION
According to [Release Notes](https://developer.mozilla.org/en-US/Firefox/Releases/43#New_APIs) Array.prototype.includes is available in firefox since version 43
