### PR TITLE
String.prototype.includes browser support for chrome 41 and firefox 40

### DIFF
--- a/polyfills/String/prototype/includes/config.json
+++ b/polyfills/String/prototype/includes/config.json
@@ -7,8 +7,8 @@
 	"browsers": {
 		"android": "*",
 		"bb": "*",
-		"chrome": "*",
-		"firefox": "*",
+		"chrome": "<=40",
+		"firefox": "<=39",
 		"opera": "10 - 18",
 		"safari": "*",
 		"ie": "6 - *",


### PR DESCRIPTION
According to [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes) String.prototype.includes is available in chrome since version 41 and in firefox since version 40
