### PR TITLE
Array.prototype.find updated browser support for chrome 45

### DIFF
--- a/polyfills/Array/prototype/find/config.json
+++ b/polyfills/Array/prototype/find/config.json
@@ -5,7 +5,7 @@
 	],
 	"browsers": {
 		"bb": "*",
-		"chrome": "*",
+		"chrome": "<=44",
 		"firefox": "3.6 - 24",
 		"ie": "*",
 		"ie_mob": "10 - *",


### PR DESCRIPTION
According to [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find) Array.prototype.find is available in chrome since version 45
