### PR TITLE
Array.prototype.findIndex updated browser support for chrome 45

### DIFF
--- a/polyfills/Array/prototype/findIndex/config.json
+++ b/polyfills/Array/prototype/findIndex/config.json
@@ -4,7 +4,7 @@
 		"modernizr:es6array"
 	],
 	"browsers": {
-		"chrome": "*",
+		"chrome": "<=45",
 		"firefox": "3.6 - 24",
 		"ie": "*",
 		"ie_mob": "10 - *",


### PR DESCRIPTION
According to [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex) Array.prototype.findIndex is available in chrome since version 45
