### PR TITLE
Array.from updated browser support for firefox 32

### DIFF
--- a/polyfills/Array/from/config.json
+++ b/polyfills/Array/from/config.json
@@ -5,7 +5,7 @@
 	],
 	"browsers": {
 		"chrome": "<45",
-		"firefox": "4 - *",
+		"firefox": "4 - 31",
 		"ie": "6 - *",
 		"ie_mob": "10 - *",
 		"opera": "*",


### PR DESCRIPTION
According to [MDN](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Array/from) Array.from is available in firefox since version 32
