### PR TITLE
Array.of updated browser support for chrome 45

### DIFF
--- a/polyfills/Array/of/config.json
+++ b/polyfills/Array/of/config.json
@@ -4,7 +4,7 @@
 		"modernizr:es6array"
 	],
 	"browsers": {
-		"chrome": "*",
+		"chrome": "<=44",
 		"firefox": "* - 24",
 		"ie": "*",
 		"ie_mob": "10 - *",


### PR DESCRIPTION
According to [MDN](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Array/of) Array.of is available in chrome since version 45
