### PR TITLE
Add polyfill for console

### DIFF
--- a/polyfills/console/assert/config.json
+++ b/polyfills/console/assert/config.json
@@ -1,0 +1,14 @@
+{
+	"aliases": [
+		"caniuse:console-basic"
+	],
+	"browsers": {
+		"ie": "6 - 11",
+		"firefox": "1 - 4"
+	},
+	"dependencies": [
+		"Window"
+	],
+	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
+}

--- a/polyfills/console/assert/detect.js
+++ b/polyfills/console/assert/detect.js
@@ -1,0 +1,1 @@
+'console' in this && 'assert' in this.console

--- a/polyfills/console/assert/polyfill.js
+++ b/polyfills/console/assert/polyfill.js
@@ -1,0 +1,13 @@
+(function(global) {
+
+	var console = global.console || (global.console = {});
+
+	if (typeof console.assert === 'function') {
+		return;
+	}
+
+	console.assert = function assert() {
+		// noop
+	};
+
+})(this);

--- a/polyfills/console/assert/tests.js
+++ b/polyfills/console/assert/tests.js
@@ -1,0 +1,10 @@
+describe('console', function () {
+
+	it('assert()', function () {
+		expect(console).to.be.ok;
+		expect(function () {
+			console.assert();
+		}).not.to.throwException();
+	});
+
+});

--- a/polyfills/console/cd/config.json
+++ b/polyfills/console/cd/config.json
@@ -1,0 +1,14 @@
+{
+	"aliases": [
+		"caniuse:console-basic"
+	],
+	"browsers": {
+		"ie": "6 - 11",
+		"firefox": "1 - 4"
+	},
+	"dependencies": [
+		"Window"
+	],
+	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
+}

--- a/polyfills/console/cd/detect.js
+++ b/polyfills/console/cd/detect.js
@@ -1,0 +1,1 @@
+'console' in this && 'cd' in this.console

--- a/polyfills/console/cd/polyfill.js
+++ b/polyfills/console/cd/polyfill.js
@@ -1,0 +1,13 @@
+(function(global) {
+
+	var console = global.console || (global.console = {});
+
+	if (typeof console.cd === 'function') {
+		return;
+	}
+
+	console.cd = function cd() {
+		// noop
+	};
+
+})(this);

--- a/polyfills/console/cd/tests.js
+++ b/polyfills/console/cd/tests.js
@@ -1,0 +1,10 @@
+describe('console', function () {
+
+	it('cd()', function () {
+		expect(console).to.be.ok;
+		expect(function () {
+			console.cd();
+		}).not.to.throwException();
+	});
+
+});

--- a/polyfills/console/clear/config.json
+++ b/polyfills/console/clear/config.json
@@ -1,0 +1,14 @@
+{
+	"aliases": [
+		"caniuse:console-basic"
+	],
+	"browsers": {
+		"ie": "6 - 11",
+		"firefox": "1 - 4"
+	},
+	"dependencies": [
+		"Window"
+	],
+	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
+}

--- a/polyfills/console/clear/detect.js
+++ b/polyfills/console/clear/detect.js
@@ -1,0 +1,1 @@
+'console' in this && 'clear' in this.console

--- a/polyfills/console/clear/polyfill.js
+++ b/polyfills/console/clear/polyfill.js
@@ -1,0 +1,13 @@
+(function(global) {
+
+	var console = global.console || (global.console = {});
+
+	if (typeof console.clear === 'function') {
+		return;
+	}
+
+	console.clear = function clear() {
+		// noop
+	};
+
+})(this);

--- a/polyfills/console/clear/tests.js
+++ b/polyfills/console/clear/tests.js
@@ -1,0 +1,10 @@
+describe('console', function () {
+
+	it('clear()', function () {
+		expect(console).to.be.ok;
+		expect(function () {
+			console.clear();
+		}).not.to.throwException();
+	});
+
+});

--- a/polyfills/console/count/config.json
+++ b/polyfills/console/count/config.json
@@ -1,0 +1,14 @@
+{
+	"aliases": [
+		"caniuse:console-basic"
+	],
+	"browsers": {
+		"ie": "6 - 11",
+		"firefox": "1 - 4"
+	},
+	"dependencies": [
+		"Window"
+	],
+	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
+}

--- a/polyfills/console/count/detect.js
+++ b/polyfills/console/count/detect.js
@@ -1,0 +1,1 @@
+'console' in this && 'count' in this.console

--- a/polyfills/console/count/polyfill.js
+++ b/polyfills/console/count/polyfill.js
@@ -1,0 +1,13 @@
+(function(global) {
+
+	var console = global.console || (global.console = {});
+
+	if (typeof console.count === 'function') {
+		return;
+	}
+
+	console.count = function count() {
+		// noop
+	};
+
+})(this);

--- a/polyfills/console/count/tests.js
+++ b/polyfills/console/count/tests.js
@@ -1,0 +1,10 @@
+describe('console', function () {
+
+	it('count()', function () {
+		expect(console).to.be.ok;
+		expect(function () {
+			console.count();
+		}).not.to.throwException();
+	});
+
+});

--- a/polyfills/console/debug/config.json
+++ b/polyfills/console/debug/config.json
@@ -1,0 +1,14 @@
+{
+	"aliases": [
+		"caniuse:console-basic"
+	],
+	"browsers": {
+		"ie": "6 - 11",
+		"firefox": "1 - 4"
+	},
+	"dependencies": [
+		"Window"
+	],
+	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
+}

--- a/polyfills/console/debug/detect.js
+++ b/polyfills/console/debug/detect.js
@@ -1,0 +1,1 @@
+'console' in this && 'debug' in this.console

--- a/polyfills/console/debug/polyfill.js
+++ b/polyfills/console/debug/polyfill.js
@@ -1,0 +1,30 @@
+(function(global) {
+
+	var console = global.console || (global.console = {});
+
+	if (typeof console.debug === 'function') {
+		return;
+	}
+
+	console.debug = function debug() {
+
+		var fn = console.log;
+		var hasApply = false;
+
+		try {
+			hasApply = !!fn.apply;
+		} catch (e) { /* do nothing */ }
+
+		if (hasApply) {
+			return function () {
+				fn.apply(console, arguments);
+			};
+		}
+
+		return function (arg1, arg2, arg3) {
+			fn(arg1, arg2, arg3);
+		};
+
+	};
+
+})(this);

--- a/polyfills/console/debug/tests.js
+++ b/polyfills/console/debug/tests.js
@@ -1,0 +1,10 @@
+describe('console', function () {
+
+	it('debug()', function () {
+		expect(console).to.be.ok;
+		expect(function () {
+			console.debug();
+		}).not.to.throwException();
+	});
+
+});

--- a/polyfills/console/dir/config.json
+++ b/polyfills/console/dir/config.json
@@ -1,0 +1,14 @@
+{
+	"aliases": [
+		"caniuse:console-basic"
+	],
+	"browsers": {
+		"ie": "6 - 11",
+		"firefox": "1 - 4"
+	},
+	"dependencies": [
+		"Window"
+	],
+	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
+}

--- a/polyfills/console/dir/detect.js
+++ b/polyfills/console/dir/detect.js
@@ -1,0 +1,1 @@
+'console' in this && 'dir' in this.console

--- a/polyfills/console/dir/polyfill.js
+++ b/polyfills/console/dir/polyfill.js
@@ -1,0 +1,13 @@
+(function(global) {
+
+	var console = global.console || (global.console = {});
+
+	if (typeof console.dir === 'function') {
+		return;
+	}
+
+	console.dir = function dir() {
+		// noop
+	};
+
+})(this);

--- a/polyfills/console/dir/tests.js
+++ b/polyfills/console/dir/tests.js
@@ -1,0 +1,10 @@
+describe('console', function () {
+
+	it('dir()', function () {
+		expect(console).to.be.ok;
+		expect(function () {
+			console.dir();
+		}).not.to.throwException();
+	});
+
+});

--- a/polyfills/console/dirxml/config.json
+++ b/polyfills/console/dirxml/config.json
@@ -1,0 +1,14 @@
+{
+	"aliases": [
+		"caniuse:console-basic"
+	],
+	"browsers": {
+		"ie": "6 - 11",
+		"firefox": "1 - 4"
+	},
+	"dependencies": [
+		"Window"
+	],
+	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
+}

--- a/polyfills/console/dirxml/detect.js
+++ b/polyfills/console/dirxml/detect.js
@@ -1,0 +1,1 @@
+'console' in this && 'dirxml' in this.console

--- a/polyfills/console/dirxml/polyfill.js
+++ b/polyfills/console/dirxml/polyfill.js
@@ -1,0 +1,13 @@
+(function(global) {
+
+	var console = global.console || (global.console = {});
+
+	if (typeof console.dirxml === 'function') {
+		return;
+	}
+
+	console.dirxml = function dirxml() {
+		// noop
+	};
+
+})(this);

--- a/polyfills/console/dirxml/tests.js
+++ b/polyfills/console/dirxml/tests.js
@@ -1,0 +1,10 @@
+describe('console', function () {
+
+	it('dirxml()', function () {
+		expect(console).to.be.ok;
+		expect(function () {
+			console.dirxml(document.body); // argument requied for IE11
+		}).not.to.throwException();
+	});
+
+});

--- a/polyfills/console/error/config.json
+++ b/polyfills/console/error/config.json
@@ -1,0 +1,14 @@
+{
+	"aliases": [
+		"caniuse:console-basic"
+	],
+	"browsers": {
+		"ie": "6 - 11",
+		"firefox": "1 - 4"
+	},
+	"dependencies": [
+		"Window"
+	],
+	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
+}

--- a/polyfills/console/error/detect.js
+++ b/polyfills/console/error/detect.js
@@ -1,0 +1,1 @@
+'console' in this && 'error' in this.console

--- a/polyfills/console/error/polyfill.js
+++ b/polyfills/console/error/polyfill.js
@@ -1,0 +1,30 @@
+(function(global) {
+
+	var console = global.console || (global.console = {});
+
+	if (typeof console.error === 'function') {
+		return;
+	}
+
+	console.error = function error() {
+
+		var fn = console.log;
+		var hasApply = false;
+
+		try {
+			hasApply = !!fn.apply;
+		} catch (e) { /* do nothing */ }
+
+		if (hasApply) {
+			return function () {
+				fn.apply(console, arguments);
+			};
+		}
+
+		return function (arg1, arg2, arg3) {
+			fn(arg1, arg2, arg3);
+		};
+
+	};
+
+})(this);

--- a/polyfills/console/error/tests.js
+++ b/polyfills/console/error/tests.js
@@ -1,0 +1,10 @@
+describe('console', function () {
+
+	it('error()', function () {
+		expect(console).to.be.ok;
+		expect(function () {
+			console.error();
+		}).not.to.throwException();
+	});
+
+});

--- a/polyfills/console/exception/config.json
+++ b/polyfills/console/exception/config.json
@@ -1,0 +1,14 @@
+{
+	"aliases": [
+		"caniuse:console-basic"
+	],
+	"browsers": {
+		"ie": "6 - 11",
+		"firefox": "1 - 4"
+	},
+	"dependencies": [
+		"Window"
+	],
+	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
+}

--- a/polyfills/console/exception/detect.js
+++ b/polyfills/console/exception/detect.js
@@ -1,0 +1,1 @@
+'console' in this && 'exception' in this.console

--- a/polyfills/console/exception/polyfill.js
+++ b/polyfills/console/exception/polyfill.js
@@ -1,0 +1,13 @@
+(function(global) {
+
+	var console = global.console || (global.console = {});
+
+	if (typeof console.exception === 'function') {
+		return;
+	}
+
+	console.exception = function exception() {
+		// noop
+	};
+
+})(this);

--- a/polyfills/console/exception/tests.js
+++ b/polyfills/console/exception/tests.js
@@ -1,0 +1,10 @@
+describe('console', function () {
+
+	it('exception()', function () {
+		expect(console).to.be.ok;
+		expect(function () {
+			console.exception();
+		}).not.to.throwException();
+	});
+
+});

--- a/polyfills/console/group/config.json
+++ b/polyfills/console/group/config.json
@@ -1,0 +1,14 @@
+{
+	"aliases": [
+		"caniuse:console-basic"
+	],
+	"browsers": {
+		"ie": "6 - 11",
+		"firefox": "1 - 4"
+	},
+	"dependencies": [
+		"Window"
+	],
+	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
+}

--- a/polyfills/console/group/detect.js
+++ b/polyfills/console/group/detect.js
@@ -1,0 +1,1 @@
+'console' in this && 'group' in this.console

--- a/polyfills/console/group/polyfill.js
+++ b/polyfills/console/group/polyfill.js
@@ -1,0 +1,13 @@
+(function(global) {
+
+	var console = global.console || (global.console = {});
+
+	if (typeof console.group === 'function') {
+		return;
+	}
+
+	console.group = function group() {
+		// noop
+	};
+
+})(this);

--- a/polyfills/console/group/tests.js
+++ b/polyfills/console/group/tests.js
@@ -1,0 +1,10 @@
+describe('console', function () {
+
+	it('group()', function () {
+		expect(console).to.be.ok;
+		expect(function () {
+			console.group();
+		}).not.to.throwException();
+	});
+
+});

--- a/polyfills/console/groupCollapsed/config.json
+++ b/polyfills/console/groupCollapsed/config.json
@@ -1,0 +1,14 @@
+{
+	"aliases": [
+		"caniuse:console-basic"
+	],
+	"browsers": {
+		"ie": "6 - 11",
+		"firefox": "1 - 4"
+	},
+	"dependencies": [
+		"Window"
+	],
+	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
+}

--- a/polyfills/console/groupCollapsed/detect.js
+++ b/polyfills/console/groupCollapsed/detect.js
@@ -1,0 +1,1 @@
+'console' in this && 'groupCollapsed' in this.console

--- a/polyfills/console/groupCollapsed/polyfill.js
+++ b/polyfills/console/groupCollapsed/polyfill.js
@@ -1,0 +1,13 @@
+(function(global) {
+
+	var console = global.console || (global.console = {});
+
+	if (typeof console.groupCollapsed === 'function') {
+		return;
+	}
+
+	console.groupCollapsed = function groupCollapsed() {
+		// noop
+	};
+
+})(this);

--- a/polyfills/console/groupCollapsed/tests.js
+++ b/polyfills/console/groupCollapsed/tests.js
@@ -1,0 +1,10 @@
+describe('console', function () {
+
+	it('groupCollapsed()', function () {
+		expect(console).to.be.ok;
+		expect(function () {
+			console.groupCollapsed();
+		}).not.to.throwException();
+	});
+
+});

--- a/polyfills/console/groupEnd/config.json
+++ b/polyfills/console/groupEnd/config.json
@@ -1,0 +1,14 @@
+{
+	"aliases": [
+		"caniuse:console-basic"
+	],
+	"browsers": {
+		"ie": "6 - 11",
+		"firefox": "1 - 4"
+	},
+	"dependencies": [
+		"Window"
+	],
+	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
+}

--- a/polyfills/console/groupEnd/detect.js
+++ b/polyfills/console/groupEnd/detect.js
@@ -1,0 +1,1 @@
+'console' in this && 'groupEnd' in this.console

--- a/polyfills/console/groupEnd/polyfill.js
+++ b/polyfills/console/groupEnd/polyfill.js
@@ -1,0 +1,13 @@
+(function(global) {
+
+	var console = global.console || (global.console = {});
+
+	if (typeof console.groupEnd === 'function') {
+		return;
+	}
+
+	console.groupEnd = function groupEnd() {
+		// noop
+	};
+
+})(this);

--- a/polyfills/console/groupEnd/tests.js
+++ b/polyfills/console/groupEnd/tests.js
@@ -1,0 +1,10 @@
+describe('console', function () {
+
+	it('groupEnd()', function () {
+		expect(console).to.be.ok;
+		expect(function () {
+			console.groupEnd();
+		}).not.to.throwException();
+	});
+
+});

--- a/polyfills/console/info/config.json
+++ b/polyfills/console/info/config.json
@@ -1,0 +1,14 @@
+{
+	"aliases": [
+		"caniuse:console-basic"
+	],
+	"browsers": {
+		"ie": "6 - 11",
+		"firefox": "1 - 4"
+	},
+	"dependencies": [
+		"Window"
+	],
+	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
+}

--- a/polyfills/console/info/detect.js
+++ b/polyfills/console/info/detect.js
@@ -1,0 +1,1 @@
+'console' in this && 'info' in this.console

--- a/polyfills/console/info/polyfill.js
+++ b/polyfills/console/info/polyfill.js
@@ -1,0 +1,30 @@
+(function(global) {
+
+	var console = global.console || (global.console = {});
+
+	if (typeof console.info === 'function') {
+		return;
+	}
+
+	console.info = function info() {
+
+		var fn = console.log;
+		var hasApply = false;
+
+		try {
+			hasApply = !!fn.apply;
+		} catch (e) { /* do nothing */ }
+
+		if (hasApply) {
+			return function () {
+				fn.apply(console, arguments);
+			};
+		}
+
+		return function (arg1, arg2, arg3) {
+			fn(arg1, arg2, arg3);
+		};
+
+	};
+
+})(this);

--- a/polyfills/console/info/tests.js
+++ b/polyfills/console/info/tests.js
@@ -1,0 +1,10 @@
+describe('console', function () {
+
+	it('info()', function () {
+		expect(console).to.be.ok;
+		expect(function () {
+			console.info();
+		}).not.to.throwException();
+	});
+
+});

--- a/polyfills/console/log/config.json
+++ b/polyfills/console/log/config.json
@@ -1,0 +1,14 @@
+{
+	"aliases": [
+		"caniuse:console-basic"
+	],
+	"browsers": {
+		"ie": "6 - 11",
+		"firefox": "1 - 4"
+	},
+	"dependencies": [
+		"Window"
+	],
+	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
+}

--- a/polyfills/console/log/detect.js
+++ b/polyfills/console/log/detect.js
@@ -1,0 +1,1 @@
+'console' in this && 'log' in this.console

--- a/polyfills/console/log/polyfill.js
+++ b/polyfills/console/log/polyfill.js
@@ -1,0 +1,9 @@
+(function(global) {
+
+	var console = global.console || (global.console = {});
+
+	console.log = console.log || (console.log = function log() {
+		// noop
+	});
+
+})(this);

--- a/polyfills/console/log/tests.js
+++ b/polyfills/console/log/tests.js
@@ -1,0 +1,10 @@
+describe('console', function () {
+
+	it('log()', function () {
+		expect(console).to.be.ok;
+		expect(function () {
+			console.log();
+		}).not.to.throwException();
+	});
+
+});

--- a/polyfills/console/markTimeline/config.json
+++ b/polyfills/console/markTimeline/config.json
@@ -1,0 +1,14 @@
+{
+	"aliases": [
+		"caniuse:console-basic"
+	],
+	"browsers": {
+		"ie": "6 - 11",
+		"firefox": "1 - 4"
+	},
+	"dependencies": [
+		"Window"
+	],
+	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
+}

--- a/polyfills/console/markTimeline/detect.js
+++ b/polyfills/console/markTimeline/detect.js
@@ -1,0 +1,1 @@
+'console' in this && 'markTimeline' in this.console

--- a/polyfills/console/markTimeline/polyfill.js
+++ b/polyfills/console/markTimeline/polyfill.js
@@ -1,0 +1,13 @@
+(function(global) {
+
+	var console = global.console || (global.console = {});
+
+	if (typeof console.markTimeline === 'function') {
+		return;
+	}
+
+	console.markTimeline = function markTimeline() {
+		// noop
+	};
+
+})(this);

--- a/polyfills/console/markTimeline/tests.js
+++ b/polyfills/console/markTimeline/tests.js
@@ -1,0 +1,10 @@
+describe('console', function () {
+
+	it('markTimeline()', function () {
+		expect(console).to.be.ok;
+		expect(function () {
+			console.markTimeline();
+		}).not.to.throwException();
+	});
+
+});

--- a/polyfills/console/memory/config.json
+++ b/polyfills/console/memory/config.json
@@ -1,0 +1,14 @@
+{
+	"aliases": [
+		"caniuse:console-basic"
+	],
+	"browsers": {
+		"ie": "6 - 11",
+		"firefox": "1 - 4"
+	},
+	"dependencies": [
+		"Window"
+	],
+	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
+}

--- a/polyfills/console/memory/detect.js
+++ b/polyfills/console/memory/detect.js
@@ -1,0 +1,1 @@
+'console' in this && 'memory' in this.console

--- a/polyfills/console/memory/polyfill.js
+++ b/polyfills/console/memory/polyfill.js
@@ -1,0 +1,6 @@
+(function(global) {
+
+	global.console = global.console || {};
+	global.console.memory = global.console.memory || {};
+
+})(this);

--- a/polyfills/console/memory/tests.js
+++ b/polyfills/console/memory/tests.js
@@ -1,0 +1,8 @@
+describe('console', function () {
+
+	it('memory', function () {
+		expect(console).to.be.ok;
+		expect(console.memory).to.be.ok;
+	});
+
+});

--- a/polyfills/console/profile/config.json
+++ b/polyfills/console/profile/config.json
@@ -1,0 +1,14 @@
+{
+	"aliases": [
+		"caniuse:console-basic"
+	],
+	"browsers": {
+		"ie": "6 - 11",
+		"firefox": "1 - 4"
+	},
+	"dependencies": [
+		"Window"
+	],
+	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
+}

--- a/polyfills/console/profile/detect.js
+++ b/polyfills/console/profile/detect.js
@@ -1,0 +1,1 @@
+'console' in this && 'profile' in this.console

--- a/polyfills/console/profile/polyfill.js
+++ b/polyfills/console/profile/polyfill.js
@@ -1,0 +1,13 @@
+(function(global) {
+
+	var console = global.console || (global.console = {});
+
+	if (typeof console.profile === 'function') {
+		return;
+	}
+
+	console.profile = function profile() {
+		// noop
+	};
+
+})(this);

--- a/polyfills/console/profile/tests.js
+++ b/polyfills/console/profile/tests.js
@@ -1,0 +1,10 @@
+describe('console', function () {
+
+	it('profile()', function () {
+		expect(console).to.be.ok;
+		expect(function () {
+			console.profile();
+		}).not.to.throwException();
+	});
+
+});

--- a/polyfills/console/profileEnd/config.json
+++ b/polyfills/console/profileEnd/config.json
@@ -1,0 +1,14 @@
+{
+	"aliases": [
+		"caniuse:console-basic"
+	],
+	"browsers": {
+		"ie": "6 - 11",
+		"firefox": "1 - 4"
+	},
+	"dependencies": [
+		"Window"
+	],
+	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
+}

--- a/polyfills/console/profileEnd/detect.js
+++ b/polyfills/console/profileEnd/detect.js
@@ -1,0 +1,1 @@
+'console' in this && 'profileEnd' in this.console

--- a/polyfills/console/profileEnd/polyfill.js
+++ b/polyfills/console/profileEnd/polyfill.js
@@ -1,0 +1,13 @@
+(function(global) {
+
+	var console = global.console || (global.console = {});
+
+	if (typeof console.profileEnd === 'function') {
+		return;
+	}
+
+	console.profileEnd = function profileEnd() {
+		// noop
+	};
+
+})(this);

--- a/polyfills/console/profileEnd/tests.js
+++ b/polyfills/console/profileEnd/tests.js
@@ -1,0 +1,10 @@
+describe('console', function () {
+
+	it('profileEnd()', function () {
+		expect(console).to.be.ok;
+		expect(function () {
+			console.profileEnd();
+		}).not.to.throwException();
+	});
+
+});

--- a/polyfills/console/profiles/config.json
+++ b/polyfills/console/profiles/config.json
@@ -1,0 +1,14 @@
+{
+	"aliases": [
+		"caniuse:console-basic"
+	],
+	"browsers": {
+		"ie": "6 - 11",
+		"firefox": "1 - 4"
+	},
+	"dependencies": [
+		"Window"
+	],
+	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
+}

--- a/polyfills/console/profiles/detect.js
+++ b/polyfills/console/profiles/detect.js
@@ -1,0 +1,1 @@
+'console' in this && 'profiles' in this.console

--- a/polyfills/console/profiles/polyfill.js
+++ b/polyfills/console/profiles/polyfill.js
@@ -1,0 +1,13 @@
+(function(global) {
+
+	var console = global.console || (global.console = {});
+
+	if (typeof console.profiles === 'function') {
+		return;
+	}
+
+	console.profiles = function profiles() {
+		// noop
+	};
+
+})(this);

--- a/polyfills/console/profiles/tests.js
+++ b/polyfills/console/profiles/tests.js
@@ -1,0 +1,10 @@
+describe('console', function () {
+
+	it('profiles()', function () {
+		expect(console).to.be.ok;
+		expect(function () {
+			console.profiles();
+		}).not.to.throwException();
+	});
+
+});

--- a/polyfills/console/show/config.json
+++ b/polyfills/console/show/config.json
@@ -1,0 +1,14 @@
+{
+	"aliases": [
+		"caniuse:console-basic"
+	],
+	"browsers": {
+		"ie": "6 - 11",
+		"firefox": "1 - 4"
+	},
+	"dependencies": [
+		"Window"
+	],
+	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
+}

--- a/polyfills/console/show/detect.js
+++ b/polyfills/console/show/detect.js
@@ -1,0 +1,1 @@
+'console' in this && 'show' in this.console

--- a/polyfills/console/show/polyfill.js
+++ b/polyfills/console/show/polyfill.js
@@ -1,0 +1,13 @@
+(function(global) {
+
+	var console = global.console || (global.console = {});
+
+	if (typeof console.show === 'function') {
+		return;
+	}
+
+	console.show = function show() {
+		// noop
+	};
+
+})(this);

--- a/polyfills/console/show/tests.js
+++ b/polyfills/console/show/tests.js
@@ -1,0 +1,10 @@
+describe('console', function () {
+
+	it('show()', function () {
+		expect(console).to.be.ok;
+		expect(function () {
+			console.show();
+		}).not.to.throwException();
+	});
+
+});

--- a/polyfills/console/table/config.json
+++ b/polyfills/console/table/config.json
@@ -1,0 +1,14 @@
+{
+	"aliases": [
+		"caniuse:console-basic"
+	],
+	"browsers": {
+		"ie": "6 - 11",
+		"firefox": "1 - 4"
+	},
+	"dependencies": [
+		"Window"
+	],
+	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
+}

--- a/polyfills/console/table/detect.js
+++ b/polyfills/console/table/detect.js
@@ -1,0 +1,1 @@
+'console' in this && 'table' in this.console

--- a/polyfills/console/table/polyfill.js
+++ b/polyfills/console/table/polyfill.js
@@ -1,0 +1,13 @@
+(function(global) {
+
+	var console = global.console || (global.console = {});
+
+	if (typeof console.table === 'function') {
+		return;
+	}
+
+	console.table = function table() {
+		// noop
+	};
+
+})(this);

--- a/polyfills/console/table/tests.js
+++ b/polyfills/console/table/tests.js
@@ -1,0 +1,10 @@
+describe('console', function () {
+
+	it('table()', function () {
+		expect(console).to.be.ok;
+		expect(function () {
+			console.table();
+		}).not.to.throwException();
+	});
+
+});

--- a/polyfills/console/time/config.json
+++ b/polyfills/console/time/config.json
@@ -1,0 +1,14 @@
+{
+	"aliases": [
+		"caniuse:console-basic"
+	],
+	"browsers": {
+		"ie": "6 - 11",
+		"firefox": "1 - 4"
+	},
+	"dependencies": [
+		"Window"
+	],
+	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
+}

--- a/polyfills/console/time/detect.js
+++ b/polyfills/console/time/detect.js
@@ -1,0 +1,1 @@
+'console' in this && 'time' in this.console

--- a/polyfills/console/time/polyfill.js
+++ b/polyfills/console/time/polyfill.js
@@ -1,0 +1,13 @@
+(function(global) {
+
+	var console = global.console || (global.console = {});
+
+	if (typeof console.time === 'function') {
+		return;
+	}
+
+	console.time = function time() {
+		// noop
+	};
+
+})(this);

--- a/polyfills/console/time/tests.js
+++ b/polyfills/console/time/tests.js
@@ -1,0 +1,10 @@
+describe('console', function () {
+
+	it('time()', function () {
+		expect(console).to.be.ok;
+		expect(function () {
+			console.time();
+		}).not.to.throwException();
+	});
+
+});

--- a/polyfills/console/timeEnd/config.json
+++ b/polyfills/console/timeEnd/config.json
@@ -1,0 +1,14 @@
+{
+	"aliases": [
+		"caniuse:console-basic"
+	],
+	"browsers": {
+		"ie": "6 - 11",
+		"firefox": "1 - 4"
+	},
+	"dependencies": [
+		"Window"
+	],
+	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
+}

--- a/polyfills/console/timeEnd/detect.js
+++ b/polyfills/console/timeEnd/detect.js
@@ -1,0 +1,1 @@
+'console' in this && 'timeEnd' in this.console

--- a/polyfills/console/timeEnd/polyfill.js
+++ b/polyfills/console/timeEnd/polyfill.js
@@ -1,0 +1,13 @@
+(function(global) {
+
+	var console = global.console || (global.console = {});
+
+	if (typeof console.timeEnd === 'function') {
+		return;
+	}
+
+	console.timeEnd = function timeEnd() {
+		// noop
+	};
+
+})(this);

--- a/polyfills/console/timeEnd/tests.js
+++ b/polyfills/console/timeEnd/tests.js
@@ -1,0 +1,10 @@
+describe('console', function () {
+
+	it('timeEnd()', function () {
+		expect(console).to.be.ok;
+		expect(function () {
+			console.timeEnd();
+		}).not.to.throwException();
+	});
+
+});

--- a/polyfills/console/timeStamp/config.json
+++ b/polyfills/console/timeStamp/config.json
@@ -1,0 +1,14 @@
+{
+	"aliases": [
+		"caniuse:console-basic"
+	],
+	"browsers": {
+		"ie": "6 - 11",
+		"firefox": "1 - 4"
+	},
+	"dependencies": [
+		"Window"
+	],
+	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
+}

--- a/polyfills/console/timeStamp/detect.js
+++ b/polyfills/console/timeStamp/detect.js
@@ -1,0 +1,1 @@
+'console' in this && 'timeStamp' in this.console

--- a/polyfills/console/timeStamp/polyfill.js
+++ b/polyfills/console/timeStamp/polyfill.js
@@ -1,0 +1,13 @@
+(function(global) {
+
+	var console = global.console || (global.console = {});
+
+	if (typeof console.timeStamp === 'function') {
+		return;
+	}
+
+	console.timeStamp = function timeStamp() {
+		// noop
+	};
+
+})(this);

--- a/polyfills/console/timeStamp/tests.js
+++ b/polyfills/console/timeStamp/tests.js
@@ -1,0 +1,10 @@
+describe('console', function () {
+
+	it('timeStamp()', function () {
+		expect(console).to.be.ok;
+		expect(function () {
+			console.timeStamp();
+		}).not.to.throwException();
+	});
+
+});

--- a/polyfills/console/timeline/config.json
+++ b/polyfills/console/timeline/config.json
@@ -1,0 +1,14 @@
+{
+	"aliases": [
+		"caniuse:console-basic"
+	],
+	"browsers": {
+		"ie": "6 - 11",
+		"firefox": "1 - 4"
+	},
+	"dependencies": [
+		"Window"
+	],
+	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
+}

--- a/polyfills/console/timeline/detect.js
+++ b/polyfills/console/timeline/detect.js
@@ -1,0 +1,1 @@
+'console' in this && 'timeline' in this.console

--- a/polyfills/console/timeline/polyfill.js
+++ b/polyfills/console/timeline/polyfill.js
@@ -1,0 +1,13 @@
+(function(global) {
+
+	var console = global.console || (global.console = {});
+
+	if (typeof console.timeline === 'function') {
+		return;
+	}
+
+	console.timeline = function timeline() {
+		// noop
+	};
+
+})(this);

--- a/polyfills/console/timeline/tests.js
+++ b/polyfills/console/timeline/tests.js
@@ -1,0 +1,10 @@
+describe('console', function () {
+
+	it('timeline()', function () {
+		expect(console).to.be.ok;
+		expect(function () {
+			console.timeline();
+		}).not.to.throwException();
+	});
+
+});

--- a/polyfills/console/timelineEnd/config.json
+++ b/polyfills/console/timelineEnd/config.json
@@ -1,0 +1,14 @@
+{
+	"aliases": [
+		"caniuse:console-basic"
+	],
+	"browsers": {
+		"ie": "6 - 11",
+		"firefox": "1 - 4"
+	},
+	"dependencies": [
+		"Window"
+	],
+	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
+}

--- a/polyfills/console/timelineEnd/detect.js
+++ b/polyfills/console/timelineEnd/detect.js
@@ -1,0 +1,1 @@
+'console' in this && 'timelineEnd' in this.console

--- a/polyfills/console/timelineEnd/polyfill.js
+++ b/polyfills/console/timelineEnd/polyfill.js
@@ -1,0 +1,13 @@
+(function(global) {
+
+	var console = global.console || (global.console = {});
+
+	if (typeof console.timelineEnd === 'function') {
+		return;
+	}
+
+	console.timelineEnd = function timelineEnd() {
+		// noop
+	};
+
+})(this);

--- a/polyfills/console/timelineEnd/tests.js
+++ b/polyfills/console/timelineEnd/tests.js
@@ -1,0 +1,10 @@
+describe('console', function () {
+
+	it('timelineEnd()', function () {
+		expect(console).to.be.ok;
+		expect(function () {
+			console.timelineEnd();
+		}).not.to.throwException();
+	});
+
+});

--- a/polyfills/console/trace/config.json
+++ b/polyfills/console/trace/config.json
@@ -1,0 +1,14 @@
+{
+	"aliases": [
+		"caniuse:console-basic"
+	],
+	"browsers": {
+		"ie": "6 - 11",
+		"firefox": "1 - 4"
+	},
+	"dependencies": [
+		"Window"
+	],
+	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
+}

--- a/polyfills/console/trace/detect.js
+++ b/polyfills/console/trace/detect.js
@@ -1,0 +1,1 @@
+'console' in this && 'trace' in this.console

--- a/polyfills/console/trace/polyfill.js
+++ b/polyfills/console/trace/polyfill.js
@@ -1,0 +1,13 @@
+(function(global) {
+
+	var console = global.console || (global.console = {});
+
+	if (typeof console.trace === 'function') {
+		return;
+	}
+
+	console.trace = function trace() {
+		// noop
+	};
+
+})(this);

--- a/polyfills/console/trace/tests.js
+++ b/polyfills/console/trace/tests.js
@@ -1,0 +1,10 @@
+describe('console', function () {
+
+	it('trace()', function () {
+		expect(console.memory).to.be.ok;
+		expect(function () {
+			console.trace();
+		}).not.to.throwException();
+	});
+
+});

--- a/polyfills/console/warn/config.json
+++ b/polyfills/console/warn/config.json
@@ -1,0 +1,14 @@
+{
+	"aliases": [
+		"caniuse:console-basic"
+	],
+	"browsers": {
+		"ie": "6 - 11",
+		"firefox": "1 - 4"
+	},
+	"dependencies": [
+		"Window"
+	],
+	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
+}

--- a/polyfills/console/warn/detect.js
+++ b/polyfills/console/warn/detect.js
@@ -1,0 +1,1 @@
+'console' in this && 'warn' in this.console

--- a/polyfills/console/warn/polyfill.js
+++ b/polyfills/console/warn/polyfill.js
@@ -1,0 +1,30 @@
+(function(global) {
+
+	var console = global.console || (global.console = {});
+
+	if (typeof console.warn === 'function') {
+		return;
+	}
+
+	console.warn = function warn() {
+
+		var fn = console.log;
+		var hasApply = false;
+
+		try {
+			hasApply = !!fn.apply;
+		} catch (e) { /* do nothing */ }
+
+		if (hasApply) {
+			return function () {
+				fn.apply(console, arguments);
+			};
+		}
+
+		return function (arg1, arg2, arg3) {
+			fn(arg1, arg2, arg3);
+		};
+
+	};
+
+})(this);

--- a/polyfills/console/warn/tests.js
+++ b/polyfills/console/warn/tests.js
@@ -1,0 +1,10 @@
+describe('console', function () {
+
+	it('warn()', function () {
+		expect(console.memory).to.be.ok;
+		expect(function () {
+			console.warn();
+		}).not.to.throwException();
+	});
+
+});


### PR DESCRIPTION
This PR adds a poly fill for `console` and its various methods. RE: #440 

Whilst putting the polyfill together I was unable to come up with a definite list of methods that each browsers support and in which version they support which method :cry:

Also, I'm not entirely sure how we detect each missing method. Would splitting each method into its own folder similar to [Array](https://github.com/Financial-Times/polyfill-service/tree/master/polyfills/Array) work better? 
