### PR TITLE
Fix old markdown link

### DIFF
--- a/docs/api.html
+++ b/docs/api.html
@@ -39,7 +39,7 @@
 					<td><code>features</code></td>
 					<td>Querystring</td>
 					<td>
-						<p>List of browser features to polyfill. Accepts a comma-separated list of feature names.  Available feature names are shown on the <a href='/v{{apiversion}}/docs/features/'>Browsers and Features</a> page, though group aliases such as 'es5' and 'es6' are also accepted (these are defined in the polyfills' config.json files - [here's an example](https://github.com/Financial-Times/polyfill-service/blob/master/polyfills/Array.from/config.json)).</p>
+						<p>List of browser features to polyfill. Accepts a comma-separated list of feature names.  Available feature names are shown on the <a href='/v{{apiversion}}/docs/features/'>Browsers and Features</a> page, though group aliases such as 'es5' and 'es6' are also accepted (these are defined in the polyfills' config.json files - <a href="https://github.com/Financial-Times/polyfill-service/blob/master/polyfills/Array/from/config.json">here's an example</a>).</p>
 						<p>Each feature name may optionally be appended with zero or more of the following flags:</p>
 						<dl>
 							<dt><code>|always</code></dt>


### PR DESCRIPTION
Changes markdown to HTML and fixes the link.
