### PR TITLE
grunt task buildsources -  fix for missing subdirectories

### DIFF
--- a/tasks/buildsources.js
+++ b/tasks/buildsources.js
@@ -107,8 +107,17 @@ module.exports = function(grunt) {
 				config.rawSource = '\n// '+featureName + '\n' + config.rawSource;
 
 				var featurePath = path.join(destFolder, featureName+'.json');
+        var featureDir = path.dirname(featurePath);
+        mkdir(featureDir, function(err) {
+          if (!err) {
+            fs.writeFileSync(featurePath, JSON.stringify(config));
+          }
+          else {
+            grunt.log.writenln("Can't create directory " + featureDir + "due to the following error: " + err);
+          }    
+        });                    
 				fs.writeFileSync(featurePath, JSON.stringify(config));
-				grunt.log.writeln('+ '+featureName);
+				grunt.log.writeln('+ '+featurePath);
 
 				// Store alias names in a map for efficient lookup, mapping aliases to
 				// featureNames.  An alias can map to many polyfill names. So a group

--- a/tasks/buildsources.js
+++ b/tasks/buildsources.js
@@ -107,17 +107,17 @@ module.exports = function(grunt) {
 				config.rawSource = '\n// '+featureName + '\n' + config.rawSource;
 
 				var featurePath = path.join(destFolder, featureName+'.json');
-        var featureDir = path.dirname(featurePath);
-        mkdir(featureDir, function(err) {
-          if (!err) {
-            fs.writeFileSync(featurePath, JSON.stringify(config));
-          }
-          else {
-            grunt.log.writenln("Can't create directory " + featureDir + "due to the following error: " + err);
-          }    
-        });                    
+                var featureDir = path.dirname(featurePath);
+                mkdir(featureDir, function(err) {
+                if (!err) {
+                    fs.writeFileSync(featurePath, JSON.stringify(config));
+                }
+                else {
+                    grunt.log.writenln("Can't create directory " + featureDir + "due to the following error: " + err);
+                }    
+                });                    
 				fs.writeFileSync(featurePath, JSON.stringify(config));
-				grunt.log.writeln('+ '+featurePath);
+				grunt.log.writeln('+ '+featureName);
 
 				// Store alias names in a map for efficient lookup, mapping aliases to
 				// featureNames.  An alias can map to many polyfill names. So a group

--- a/tasks/buildsources.js
+++ b/tasks/buildsources.js
@@ -168,6 +168,15 @@ module.exports = function(grunt) {
 					});
 
 					var featurePath = path.join(destFolder, featureName+'.json');
+                    var featureDir = path.dirname(featurePath);
+                    mkdir(featureDir, function(err) {
+                        if (!err) {
+                            fs.writeFileSync(featurePath, JSON.stringify(config));
+                        }
+                        else {
+                            grunt.log.writenln("Can't create directory " + featureDir + "due to the following error: " + err);
+                        }    
+                    });                    
 					fs.writeFileSync(featurePath, JSON.stringify(config));
 					grunt.log.writeln('+ '+featurePath);
 

--- a/tasks/buildsources.js
+++ b/tasks/buildsources.js
@@ -107,15 +107,15 @@ module.exports = function(grunt) {
 				config.rawSource = '\n// '+featureName + '\n' + config.rawSource;
 
 				var featurePath = path.join(destFolder, featureName+'.json');
-                var featureDir = path.dirname(featurePath);
-                mkdir(featureDir, function(err) {
-                if (!err) {
-                    fs.writeFileSync(featurePath, JSON.stringify(config));
-                }
-                else {
-                    grunt.log.writenln("Can't create directory " + featureDir + "due to the following error: " + err);
-                }    
-                });                    
+				var featureDir = path.dirname(featurePath);
+				mkdir(featureDir, function(err) {
+					if (!err) {
+						fs.writeFileSync(featurePath, JSON.stringify(config));
+					}
+					else {
+						grunt.log.writenln("Can't create directory " + featureDir + "due to the following error: " + err);
+					}    
+				});                    
 				fs.writeFileSync(featurePath, JSON.stringify(config));
 				grunt.log.writeln('+ '+featureName);
 


### PR DESCRIPTION
Link to issue https://github.com/Financial-Times/polyfill-service/issues/547

Create polyfill subdirectories prior to create polyfill json file.
