### PR TITLE
Element.prototype.placeholder not displaying - fixes #566

### DIFF
--- a/polyfills/Element/prototype/placeholder/polyfill.js
+++ b/polyfills/Element/prototype/placeholder/polyfill.js
@@ -1,6 +1,7 @@
 Object.defineProperty(Element.prototype, 'placeholder', {
-	get:function(){
-		return this.getAttribute('placeholder') ;},
+	get: function() {
+		return this.getAttribute('placeholder');
+	},
 
 	set: function (value) {
 		if (!value || !/^(input|textarea)$/i.test(this.nodeName) || !/^(email|number|password|search|tel|text|url|)$/i.test(this.getAttribute('type'))) {

--- a/polyfills/Element/prototype/placeholder/polyfill.js
+++ b/polyfills/Element/prototype/placeholder/polyfill.js
@@ -1,4 +1,7 @@
 Object.defineProperty(Element.prototype, 'placeholder', {
+	get:function(){
+		return this.getAttribute('placeholder') ;},
+
 	set: function (value) {
 		if (!value || !/^(input|textarea)$/i.test(this.nodeName) || !/^(email|number|password|search|tel|text|url|)$/i.test(this.getAttribute('type'))) {
 			return;
@@ -6,8 +9,8 @@ Object.defineProperty(Element.prototype, 'placeholder', {
 
 		var
 		element = this,
-		xInput = document.createElement('-ms-input'),
-		xPlaceholder = xInput.appendChild(document.createElement('-ms-placeholder')),
+		xInput = document.createElement('ms-input'),
+		xPlaceholder = xInput.appendChild(document.createElement('ms-placeholder')),
 		xInputRuntimeStyle = xInput.runtimeStyle,
 		xPlaceholderRuntimeStyle = xPlaceholder.runtimeStyle,
 		elementCurrentStyle = element.currentStyle;


### PR DESCRIPTION
- document.createElement was failing due to the '-' at the start of the identifier.
- missing getter.

**todo:** the styles aren't applying as they should.
