### PR TITLE
Return before trying to cast property to string

### DIFF
--- a/polyfills/Object/defineProperty/polyfill.js
+++ b/polyfills/Object/defineProperty/polyfill.js
@@ -6,6 +6,11 @@
 
 	Object.defineProperty = function defineProperty(object, property, descriptor) {
 
+		// Where native support exists, assume it
+		if (nativeDefineProperty && (object === window || object === document || object === Element.prototype || object instanceof Element)) {
+			return nativeDefineProperty(object, property, descriptor);
+		}
+
 		var propertyString = String(property);
 		var hasValueOrWritable = 'value' in descriptor || 'writable' in descriptor;
 		var getterType = 'get' in descriptor && typeof descriptor.get;
@@ -17,11 +22,6 @@
 
 		if (!(descriptor instanceof Object)) {
 			throw new TypeError('Descriptor must be an object (Object.defineProperty polyfill)');
-		}
-
-		// Where native support exists, assume it
-		if (nativeDefineProperty && (object === window || object === document || object === Element.prototype || object instanceof Element)) {
-			return nativeDefineProperty(object, propertyString, descriptor);
 		}
 
 		// handle descriptor.get


### PR DESCRIPTION
I'm using the polyfill service with Babel on a Samsung Tablet rocking Chrome 38.

Babel is providing a `Symbol` which doesn't like being cast to a string, however, the browser does support `defineProperty` but is being pulled in as a dependency of `Promise`.

The actual fix for me is to remove `Promise|always`, but polyfills should always exit with the native option first anyway which would avoid the casting issue?
