### PR TITLE
Update browser compatibility for Array.from

### DIFF
--- a/polyfills/Array/from/config.json
+++ b/polyfills/Array/from/config.json
@@ -7,11 +7,12 @@
 	"browsers": {
 		"chrome": "<45",
 		"firefox": "4 - 31",
-		"ie": "6 - *",
+		"ie": "6 - 11",
 		"ie_mob": "10 - *",
 		"opera": "*",
-		"safari": "7 - *",
-		"firefox_mob": "4 - *"
+		"safari": "<9",
+		"firefox_mob": "4 - *",
+		"ios_saf": "3 - 8"
 	},
 	"dependencies": [
 		"Object.defineProperty"


### PR DESCRIPTION
There were some gaps in browser support coverage for `Array.from`.
