### PR TITLE
Fixing Windows build (#610)

### DIFF
--- a/bin/polyfill-service.cmd
+++ b/bin/polyfill-service.cmd
@@ -1,0 +1,7 @@
+@IF EXIST "%~dp0\node.exe" (
+  "%~dp0\node.exe"  "%~dp0\polyfill-service" %*
+) ELSE (
+  @SETLOCAL
+  @SET PATHEXT=%PATHEXT:;.JS;=;%
+  node  "%~dp0\polyfill-service" %*
+)

--- a/tasks/buildsources.js
+++ b/tasks/buildsources.js
@@ -47,7 +47,7 @@ module.exports = function(grunt) {
 			var configPath = path.join(polyfillPath, 'config.json');
 			var detectPath = path.join(polyfillPath, 'detect.js');
 			var polyfillSourcePath = path.join(polyfillPath, 'polyfill.js');
-			var featureName = polyfillPath.substr(polyfillSourceFolder.length+1).replace(/\//g, '.');
+			var featureName = polyfillPath.substr(polyfillSourceFolder.length+1).replace(/(\/|\\)/g, '.');
 
 			try {
 


### PR DESCRIPTION
This PR deals with issue #610, which is related to making a Windows build. Currently when built under Windows 7, the `polyfills/__dist` folder would appear as a tree instead of being a flat directory. The commit 209041e fixes that by using both `/` (POSIX platforms) and `\` (Windows platforms) in generating the files.

Bundled together is another commit 24922ea, which adds `polyfill-service.cmd` to `bin/`. This mimics the behavior that Node/NPM on Windows would make a *.cmd to each executable installed by `npm i`.

I have tested on my Windows box (Windows 7 x64), but frankly Windows is not my prior development platform, so I really love to know if there are anything that I should note as well. Thanks!
