### PR TITLE
pass absolute path to grunt-clean

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,12 +1,13 @@
 'use strict';
 
 require('dotenv').config({silent: true});
+const path = require('path');
 
 module.exports = function(grunt) {
 
 	grunt.initConfig({
 		"clean": {
-			dist: ['polyfills/__dist']
+			dist: [path.resolve(__dirname, '/polyfills/__dist')]
 		},
 		"simplemocha": {
 			options: {


### PR DESCRIPTION
After cloning a fresh install and running `npm install` I received this error:

> Running "clean:dist" (clean) task
> Warning: Cannot delete files outside the current working directory. Use --force to continue.
> 
> Aborted due to warnings.

After adding my patch this error was resolved.
