### PR TITLE
Polyfill custom event for all android

### DIFF
--- a/polyfills/CustomEvent/config.json
+++ b/polyfills/CustomEvent/config.json
@@ -10,7 +10,7 @@
 		"opera": "10 - 11.5",
 		"safari": "4 - 7",
 		"chrome": "1 - 14",
-		"android": "<=4.3",
+		"android": "<=5",
 		"firefox_mob": "6 - 10"
 	},
 	"dependencies": [

--- a/polyfills/CustomEvent/config.json
+++ b/polyfills/CustomEvent/config.json
@@ -10,7 +10,7 @@
 		"opera": "10 - 11.5",
 		"safari": "4 - 7",
 		"chrome": "1 - 14",
-		"android": "<=5",
+		"android": "<5",
 		"firefox_mob": "6 - 10"
 	},
 	"dependencies": [


### PR DESCRIPTION
I've just found that CustomEvent is missing in samsung stock browser on android 4.4.2 so, to paraphrase Donald Trump, I think we should lock this down until we can figure out what the hell is going on
