### PR TITLE
Add Map polyfill

### DIFF
--- a/polyfills/Map/config.json
+++ b/polyfills/Map/config.json
@@ -12,6 +12,7 @@
 	},
 	"dependencies": [
 		"Array.prototype.indexOf",
+		"Symbol",
 		"Symbol.iterator",
 		"Symbol.species",
 		"Object.defineProperty",

--- a/polyfills/Map/config.json
+++ b/polyfills/Map/config.json
@@ -1,0 +1,16 @@
+{
+	"aliases": [
+		"default"
+	],
+	"browsers": {
+		"ie": "<11",
+		"firefox": "<29",
+		"safari": "<8",
+		"ios_saf": "<7.1",
+		"chrome": "<38",
+		"firefox_mob": "<29"
+	},
+	"dependencies": [
+		"Symbol"
+	]
+}

--- a/polyfills/Map/config.json
+++ b/polyfills/Map/config.json
@@ -3,7 +3,7 @@
 		"default"
 	],
 	"browsers": {
-		"ie": "<11",
+		"ie": "<12",
 		"firefox": "<29",
 		"safari": "<8",
 		"ios_saf": "<7.1",

--- a/polyfills/Map/config.json
+++ b/polyfills/Map/config.json
@@ -16,5 +16,8 @@
 		"Symbol.species",
 		"Object.defineProperty",
 		"Number.isNaN"
+	],
+	"notes": [
+		"For compatibility with very old engines, `Map.prototype.delete` must be accessed using square bracket notation because 'delete' is a reserved word. `myMap.delete()` is an error in IE8. Use `myMap['delete']()` instead."
 	]
 }

--- a/polyfills/Map/config.json
+++ b/polyfills/Map/config.json
@@ -18,6 +18,7 @@
 		"Number.isNaN"
 	],
 	"notes": [
-		"For compatibility with very old engines, `Map.prototype.delete` must be accessed using square bracket notation because 'delete' is a reserved word. `myMap.delete()` is an error in IE8. Use `myMap['delete']()` instead."
+		"For compatibility with very old engines, `Map.prototype.delete` must be accessed using square bracket notation because 'delete' is a reserved word. `myMap.delete()` is an error in IE8. Use `myMap['delete']()` instead.",
+		"The test suite for this polyfill is derived from work of Andrea Giammarchi which is [published under an MIT licence](https://github.com/WebReflection/es6-collections)"
 	]
 }

--- a/polyfills/Map/config.json
+++ b/polyfills/Map/config.json
@@ -11,6 +11,10 @@
 		"firefox_mob": "<29"
 	},
 	"dependencies": [
-		"Symbol"
+		"Array.prototype.indexOf",
+		"Symbol.iterator",
+		"Symbol.species",
+		"Object.defineProperty",
+		"Number.isNaN"
 	]
 }

--- a/polyfills/Map/detect.js
+++ b/polyfills/Map/detect.js
@@ -1,0 +1,1 @@
+'Map' in this

--- a/polyfills/Map/detect.js
+++ b/polyfills/Map/detect.js
@@ -1,1 +1,3 @@
-'Map' in this
+'Map' in this && (function() {
+	return (new Map([[1,1], [2,2]])).size === 2;
+}())

--- a/polyfills/Map/polyfill.js
+++ b/polyfills/Map/polyfill.js
@@ -1,64 +1,122 @@
 (function(global) {
 
+
+	// Deleted map items mess with iterator pointers, so rather than removing them mark them as deleted. Can't use undefined or null since those both valid keys so use a private symbol.
+	var undefMarker = {};
+
+	// NaN cannot be found in an array using indexOf, so we encode NaNs using a private symbol.
+	var NaNMarker = {};
+
+	function encodeKey(key) {
+		return Number.isNaN(key) ? NaNMarker : key;
+	}
+	function decodeKey(encodedKey) {
+		return (encodedKey === NaNMarker) ? NaN : encodedKey;
+	}
+
+	function makeIterator(mapInst, getter) {
+		var nextIdx = 0;
+		var done = false;
+		return {
+			next: function() {
+				if (nextIdx === mapInst._keys.length) done = true;
+				if (!done) {
+					while (mapInst._keys[nextIdx] === undefMarker) nextIdx++;
+					return {value: getter.call(mapInst, nextIdx++), done: false};
+				} else {
+					return {done:true};
+				}
+			}
+		}
+	}
+
+	function calcSize(mapInst) {
+		var size = 0;
+		for (var i=0, s=mapInst._keys.length; i<s; i++) {
+			if (mapInst._keys[i] !== undefMarker) size++;
+		}
+		return size;
+	}
+
+	var ACCESSOR_SUPPORT = true;
+
 	var Map = function(data) {
-		var keys, values;
+		this._keys = [];
+		this._values = [];
 
 		// If `data` is iterable (indicated by presence of a forEach method), pre-populate the map
 		data && data.forEach && data.forEach(function (item) {
 			this.set.apply(this, item);
 		}, this);
+
+		if (!ACCESSOR_SUPPORT) this.size = calcSize(this);
 	};
+	Map.prototype = {};
 
-	Object.assign(Map.prototype, {
-		"get": function(key) {
-			var idx = this.keys.indexOf(key);
-			return (idx !== -1) ? this.values[idx] : undefined;
-		},
-		"set": function(key, value) {
-			if (typeof key !== 'object' && typeof key !== 'function')
-				throw new TypeError('Invalid value used as weak map key');
+	// Some old engines do not support ES5 getters/setters.  Since Map only requires these for the size property, we can fall back to setting the size property statically easch time the size of the map changes.
+	try {
+		Object.defineProperty(Map.prototype, 'size', {
+			get: function() {
+				return calcSize(this);
+			}
+		});
+	} catch(e) {
+		ACCESSOR_SUPPORT = false;
+	}
 
-			var entry = key[this.name];
-			if (entry && entry[0] === key)
-				entry[1] = value;
-			else
-				defineProperty(key, this.name, {value: [key, value], writable: true});
-			return this;
-		},
-		"has": function(key) {
-			return (this.keys.indexOf(key) !== -1);
-		},
-		"delete": function(key) {
-			var idx = this.keys.indexOf(key);
-			if (idx === -1) return false;
-			this.keys.splice(idx);
-			this.values.splice(idx);
-			return true;
-		},
-		"clear": function() {
-			this.keys = this.values = [];
-		},
-		get "size": function() {
-			return this.keys.length;
-		},
-		"values": function() {
-
-		},
-		"keys": function() {
-
-		},
-		"entries": function() {
-			// TODO
-		},
-		"forEach": function() {
-
-		},
-		"constructor": Map
-	});
+	Map.prototype['get'] = function(key) {
+		var idx = this._keys.indexOf(encodeKey(key));
+		return (idx !== -1) ? this._values[idx] : undefined;
+	};
+	Map.prototype['set'] = function(key, value) {
+		var idx = this._keys.indexOf(encodeKey(key));
+		if (idx !== -1) {
+			this._values[idx] = value;
+		} else {
+			this._keys.push(encodeKey(key));
+			this._values.push(value);
+			if (!ACCESSOR_SUPPORT) this.size = calcSize(this);
+		}
+		return this;
+	};
+	Map.prototype['has'] = function(key) {
+		return (this._keys.indexOf(encodeKey(key)) !== -1);
+	};
+	Map.prototype['delete'] = function(key) {
+		var idx = this._keys.indexOf(encodeKey(key));
+		if (idx === -1) return false;
+		this._keys[idx] = undefMarker;
+		this._values[idx] = undefMarker;
+		if (!ACCESSOR_SUPPORT) this.size = calcSize(this);
+		return true;
+	};
+	Map.prototype['clear'] = function() {
+		this._keys = this._values = [];
+		if (!ACCESSOR_SUPPORT) this.size = 0;
+	};
+	Map.prototype['values'] = function() {
+		return makeIterator(this, function(i) { return this._values[i]; });
+	};
+	Map.prototype['keys'] = function() {
+		return makeIterator(this, function(i) { return decodeKey(this._keys[i]); });
+	};
+	Map.prototype['entries'] =
+	Map.prototype[Symbol.iterator] = function() {
+		return makeIterator(this, function(i) { return [decodeKey(this._keys[i]), this._values[i]]; });
+	};
+	Map.prototype['forEach'] = function(callbackFn, thisArg) {
+		thisArg = thisArg || global;
+		var iterator = this.entries();
+		result = iterator.next();
+		while (result.done === false) {
+			callbackFn.call(thisArg, result.value[1], result.value[0], this);
+			result = iterator.next();
+		}
+	};
+	Map.prototype['constructor'] =
+	Map.prototype[Symbol.species] = Map;
 
 	Map.length = 0;
-
-	// TODO: get Map[@@species]
 
 	// Export the object
 	this.Map = Map;

--- a/polyfills/Map/polyfill.js
+++ b/polyfills/Map/polyfill.js
@@ -2,10 +2,10 @@
 
 
 	// Deleted map items mess with iterator pointers, so rather than removing them mark them as deleted. Can't use undefined or null since those both valid keys so use a private symbol.
-	var undefMarker = {};
+	var undefMarker = Symbol('undef');
 
 	// NaN cannot be found in an array using indexOf, so we encode NaNs using a private symbol.
-	var NaNMarker = {};
+	var NaNMarker = Symbol('NaN');
 
 	function encodeKey(key) {
 		return Number.isNaN(key) ? NaNMarker : key;

--- a/polyfills/Map/polyfill.js
+++ b/polyfills/Map/polyfill.js
@@ -1,0 +1,57 @@
+(function(global) {
+
+	var Map = function(data) {
+		var keys, values;
+
+		// If `data` is iterable (indicated by presence of a forEach method), pre-populate the map
+		data && data.forEach && data.forEach(function (item) {
+			this.set.apply(this, item);
+		}, this);
+	};
+
+	Object.assign(Map.prototype, {
+		"get": function(key) {
+			var idx = this.keys.indexOf(key);
+			return (idx !== -1) ? this.values[idx] : undefined;
+		},
+		"set": function(key, value) {
+			if (typeof key !== 'object' && typeof key !== 'function')
+				throw new TypeError('Invalid value used as weak map key');
+
+			var entry = key[this.name];
+			if (entry && entry[0] === key)
+				entry[1] = value;
+			else
+				defineProperty(key, this.name, {value: [key, value], writable: true});
+			return this;
+		},
+		"has": function(key) {
+			return (this.keys.indexOf(key) !== -1);
+		},
+		"delete": function(key) {
+			var idx = this.keys.indexOf(key);
+			if (idx === -1) return false;
+			this.keys.splice(idx);
+			this.values.splice(idx);
+			return true;
+		},
+		"clear": function() {
+			this.keys = this.values = [];
+		},
+		get "size": function() {
+			return this.keys.length;
+		},
+		"entries": function() {
+			// TODO
+		},
+		"constructor": Map
+	});
+
+	Map.length = 0;
+
+	// TODO: get Map[@@species]
+
+	// Export the object
+	this.Map = Map;
+
+})(this);

--- a/polyfills/Map/polyfill.js
+++ b/polyfills/Map/polyfill.js
@@ -41,8 +41,17 @@
 		get "size": function() {
 			return this.keys.length;
 		},
+		"values": function() {
+
+		},
+		"keys": function() {
+
+		},
 		"entries": function() {
 			// TODO
+		},
+		"forEach": function() {
+
 		},
 		"constructor": Map
 	});

--- a/polyfills/Map/polyfill.js
+++ b/polyfills/Map/polyfill.js
@@ -53,7 +53,7 @@
 	};
 	Map.prototype = {};
 
-	// Some old engines do not support ES5 getters/setters.  Since Map only requires these for the size property, we can fall back to setting the size property statically easch time the size of the map changes.
+	// Some old engines do not support ES5 getters/setters.  Since Map only requires these for the size property, we can fall back to setting the size property statically each time the size of the map changes.
 	try {
 		Object.defineProperty(Map.prototype, 'size', {
 			get: function() {

--- a/polyfills/Map/polyfill.js
+++ b/polyfills/Map/polyfill.js
@@ -45,7 +45,7 @@
 		this._values = [];
 
 		// If `data` is iterable (indicated by presence of a forEach method), pre-populate the map
-		data && data.forEach && data.forEach(function (item) {
+		data && (typeof data.forEach === 'function') && data.forEach(function (item) {
 			this.set.apply(this, item);
 		}, this);
 

--- a/polyfills/Map/tests.js
+++ b/polyfills/Map/tests.js
@@ -1,0 +1,180 @@
+var o, generic, callback;
+
+beforeEach(function() {
+	if ('Map' in window) o = new Map();
+	generic = {};
+	callback = function () {};
+})
+
+it("has valid constructor", function () {
+	expect(new Map).to.be.a(Map);
+	expect(new Map()).to.be.a(Map);
+	var a = 1;
+	var b = {};
+	var c = new Map();
+	var m = new Map([[1,1], [b,2], [c, 3]]);
+	expect(m.has(a)).to.be(true);
+	expect(m.has(b)).to.be(true);
+	expect(m.has(c)).to.be(true);
+	expect(m.size).to.equal(3);
+	if ("__proto__" in {}) {
+		expect((new Map).__proto__.isPrototypeOf(new Map())).to.be(true);
+		expect((new Map).__proto__ === Map.prototype).to.be(true);
+	}
+});
+
+it("implements .size()", function () {
+	expect(o.size).to.be(0);
+	o.set("a", "a");
+	expect(o.size).to.be(1);
+	o["delete"]("a"); // Use square-bracket syntax to avoid a reserved word in old browsers
+	expect(o.size).to.be(0);
+});
+
+it("implements .has()", function () {
+	expect(o.has(callback)).to.be(false);
+	o.set(callback, generic);
+	expect(o.has(callback)).to.be(true);
+});
+
+it("implements .get()", function () {
+	o.set(callback, generic);
+	expect(o.get(callback, 123)).to.be(generic);
+	expect(o.get(callback)).to.be(generic);
+});
+
+it("implements .set()", function () {
+	o.set(callback, generic);
+	expect(o.get(callback)).to.be(generic);
+	o.set(callback, callback);
+	expect(o.get(callback)).to.be(callback);
+	o.set(callback, o);
+	expect(o.get(callback)).to.be(o);
+	o.set(o, callback);
+	expect(o.get(o)).to.be(callback);
+	o.set(NaN, generic);
+	expect(o.has(NaN));
+	expect(o.get(NaN)).to.be(generic);
+	o.set("key", undefined);
+	expect(o.has("key"));
+	expect(o.get("key")).to.be(undefined);
+
+	expect(!o.has(-0));
+	expect(!o.has(0));
+	o.set(-0, callback);
+	expect(o.has(-0));
+	expect(o.has(0));
+	expect(o.get(-0)).to.be(callback);
+	expect(o.get(0)).to.be(callback);
+	o.set(0, generic);
+	expect(o.has(-0));
+	expect(o.has(0));
+	expect(o.get(-0)).to.be(generic);
+	expect(o.get(0)).to.be(generic);
+});
+
+it("implements .delete()", function () {
+	o.set(callback, generic);
+	o.set(generic, callback);
+	o.set(o, callback);
+	expect(o.has(callback) && o.has(generic) && o.has(o)).to.be(true);
+	o["delete"](callback);
+	o["delete"](generic);
+	o["delete"](o);
+	expect(!o.has(callback) && !o.has(generic) && !o.has(o)).to.be(true);
+	expect(o["delete"](o) === false);
+	o.set(o, callback);
+	expect(o["delete"](o));
+});
+
+it("does not throw an error when a non-object key is used", function () {
+	expect(function() {
+		o.set("key", o);
+	}).to.not.throwError();
+});
+
+it("exhibits correct iterator behaviour", function () {
+	// test that things get returned in insertion order as per the specs
+	o = new Map([["1", 1], ["2", 2], ["3", 3]]);
+	var keys = o.keys();
+	var values = o.values();
+	var k = keys.next()
+	var v = values.next();
+	expect(k.value).to.be("1");
+	expect(v.value).to.be(1);
+	o.delete("2");
+	k = keys.next();
+	v = values.next();
+	expect(k.value).to.be("3");
+	expect(v.value).to.be(3);
+	// insertion of previously-removed item goes to the end
+	o.set("2", 2);
+	k = keys.next()
+	v = values.next();
+	expect(k.value).to.be("2");
+	expect(v.value).to.be(2);
+	// when called again, new iterator starts from beginning
+	var entriesagain = o.entries();
+	expect(entriesagain.next().value[0]).to.be("1");
+	expect(entriesagain.next().value[0]).to.be("3");
+	expect(entriesagain.next().value[0]).to.be("2");
+	// after a iterator is finished, don't return any more elements
+	k = keys.next();
+	v = values.next();
+	expect(k.done).to.be(true);
+	expect(v.done).to.be(true);
+	k = keys.next();
+	v = values.next();
+	expect(k.done).to.be(true);
+	expect(v.done).to.be(true);
+	o.set("4", 4);
+	k = keys.next();
+	v = values.next();
+	expect(k.done).to.be(true);
+	expect(v.done).to.be(true);
+	// new element shows up in iterators that didn't yet finish
+	expect(entriesagain.next().value[0]).to.be("4");
+	expect(entriesagain.next().done).to.be(true);
+});
+
+it("implements .forEach()", function () {
+	var o = new Map(), i;
+	o.set("key 0", 0);
+	o.set("key 1", 1);
+	if ("forEach" in o) {
+		o.forEach(function (value, key, obj) {
+			expect(key).to.be("key " + value);
+			expect(obj).to.be(o);
+			// even if dropped, keeps looping
+			o["delete"](key);
+		});
+		expect(o.size).to.be(0);
+	}
+});
+
+it("supports mutations during forEach loops", function () {
+	var o = new Map([["0", 0], ["1", 1], ["2", 2]]), seen = [];
+	o.forEach(function (value, key, obj) {
+		seen.push(value);
+		expect(obj).to.be(o);
+		expect(""+value).to.be(key);
+		// mutations work as expected
+		if (value === 1) {
+			o.delete("0"); // remove from before current index
+			o.delete("2"); // remove from after current index
+			o.set("3", 3); // insertion
+		} else if (value === 3) {
+			o.set("0", 0); // insertion at the end
+		}
+	});
+	expect(JSON.stringify(seen)).to.be(JSON.stringify([0, 1, 3, 0]));
+});
+
+it("implements .clear()", function(){
+	var o = new Map();
+	o.set(1, '1');
+	o.set(2, '2');
+	o.set(3, '3');
+	o.clear();
+	expect(o.size).to.be(0);
+});

--- a/polyfills/Map/tests.js
+++ b/polyfills/Map/tests.js
@@ -105,7 +105,7 @@ it("exhibits correct iterator behaviour", function () {
 	var v = values.next();
 	expect(k.value).to.be("1");
 	expect(v.value).to.be(1);
-	o.delete("2");
+	o['delete']("2");
 	k = keys.next();
 	v = values.next();
 	expect(k.value).to.be("3");
@@ -158,19 +158,19 @@ it("implements .forEach()", function () {
 it("supports mutations during forEach loops", function () {
 	var o = new Map([["0", 0], ["1", 1], ["2", 2]]), seen = [];
 	o.forEach(function (value, key, obj) {
-		seen.push(value);
+		seen += ','+value;
 		expect(obj).to.be(o);
 		expect(""+value).to.be(key);
 		// mutations work as expected
 		if (value === 1) {
-			o.delete("0"); // remove from before current index
-			o.delete("2"); // remove from after current index
+			o['delete']("0"); // remove from before current index
+			o['delete']("2"); // remove from after current index
 			o.set("3", 3); // insertion
 		} else if (value === 3) {
 			o.set("0", 0); // insertion at the end
 		}
 	});
-	expect(JSON.stringify(seen)).to.be(JSON.stringify([0, 1, 3, 0]));
+	expect(seen).to.be(",0,1,3,0");
 });
 
 it("implements .clear()", function(){

--- a/polyfills/Map/tests.js
+++ b/polyfills/Map/tests.js
@@ -144,15 +144,13 @@ it("implements .forEach()", function () {
 	var o = new Map(), i;
 	o.set("key 0", 0);
 	o.set("key 1", 1);
-	if ("forEach" in o) {
-		o.forEach(function (value, key, obj) {
-			expect(key).to.be("key " + value);
-			expect(obj).to.be(o);
-			// even if dropped, keeps looping
-			o["delete"](key);
-		});
-		expect(o.size).to.be(0);
-	}
+	o.forEach(function (value, key, obj) {
+		expect(key).to.be("key " + value);
+		expect(obj).to.be(o);
+		// even if dropped, keeps looping
+		o["delete"](key);
+	});
+	expect(o.size).to.be(0);
 });
 
 it("supports mutations during forEach loops", function () {

--- a/polyfills/Map/tests.js
+++ b/polyfills/Map/tests.js
@@ -9,6 +9,13 @@ beforeEach(function() {
 it("has valid constructor", function () {
 	expect(new Map).to.be.a(Map);
 	expect(new Map()).to.be.a(Map);
+	if ("__proto__" in {}) {
+		expect((new Map).__proto__.isPrototypeOf(new Map())).to.be(true);
+		expect((new Map).__proto__ === Map.prototype).to.be(true);
+	}
+});
+
+it ("can be pre-populated", function() {
 	var a = 1;
 	var b = {};
 	var c = new Map();
@@ -17,10 +24,6 @@ it("has valid constructor", function () {
 	expect(m.has(b)).to.be(true);
 	expect(m.has(c)).to.be(true);
 	expect(m.size).to.equal(3);
-	if ("__proto__" in {}) {
-		expect((new Map).__proto__.isPrototypeOf(new Map())).to.be(true);
-		expect((new Map).__proto__ === Map.prototype).to.be(true);
-	}
 });
 
 it("implements .size()", function () {
@@ -65,7 +68,7 @@ it("implements .set()", function () {
 	expect(o.has(-0));
 	expect(o.has(0));
 	expect(o.get(-0)).to.be(callback);
-	expect(o.get(0)).to.be(callback);
+	expect(o.get(0)).to.be(callback); // Native impl fails in IE11
 	o.set(0, generic);
 	expect(o.has(-0));
 	expect(o.has(0));


### PR DESCRIPTION
This PR adds a polyfill for Map.  Notable:
- I'm using private pseudo-symbol-objects as reliable markers for undefined and NaN since those values are problematic.  Open to better ways of doing this.
- Not using `Object.defineProperty` for all these - could do but I think the current arch is clearer
- The rules on how the iterators and forEach method behave when mutations occur during enumeration are a bit weird to me, but I think I implemented them correctly.  Both my polyfill and the native impl pass my tests.
