### PR TITLE
Exclude option, closes #435

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Returns a promise of a polyfill bundle string.  Options is an object with the fo
 * `minify`: Boolean, optional. Whether to minify the bundle
 * `features`: Object, optional. An object with the features that are to be considered for polyfill inclusion. If not supplied, no features will be considered and the output will be blank. To load the default feature set, set features to `{default:{}}`.  Each feature must be an entry in the features object with the key corresponding to the name of the feature and the value an object with the following properties:
 	* `flags`: Array, optional. Array of flags to apply to this feature (see below)
+* `excludes`: Array, optional. Array of features to exclude from the final bundle.
 * `unknown`: String, optional. What to do when the user agent is not recognised.  Set to `polyfill` to return polyfills for all qualifying features, `ignore` to return nothing.  Defaults to `ignore`.
 
 Flags that may be applied to polyfills are:
@@ -204,6 +205,7 @@ Options is an object with the following keys:
 * `uaString`: String, required. The user agent to evaluate for features that should be included conditionally
 * `features`: Object, optional. An object with the features that are to be considered for polyfill inclusion. If not supplied, all default features will be considered. Each feature must be an entry in the features object with the key corresponding to the name of the feature and the value an object with the following properties:
 	* `flags`: Array, optional. Array of flags to apply to this feature (see below)
+* `excludes`: Array, optional. Array of features to exclude from the final bundle.
 
 Example:
 

--- a/docs/api.html
+++ b/docs/api.html
@@ -50,6 +50,13 @@
 						<p>Omitting or setting to an empty string is equivalent to the value "default", which is an alias for a curated list of the most popular polyfills.  Setting the value "all" will select every feature in the library (this is an extremely bad idea)</p>
 					</td>
 				</tr><tr>
+					<td><code>excludes</code></td>
+					<td>Querystring</td>
+					<td>
+						<p>List of browser features to exclude from output. Accepts a comma-separated list of feature names.  Available feature names are shown on the <a href='/v{{apiversion}}/docs/features/'>Browsers and Features</a> page.  Aliases and flags are not accepted. Omitting or setting to an empty string will exclude no polyfills.</p>
+						<p>The main use case for this is where you want a polyfill but you don't want one or more of its dependencies.  Note that it doesn't make any sense to list the same feature in both the <code>features</code> and the <code>excludes</code> list.
+					</td>
+				</tr><tr>
 					<td><code>flags</code></td>
 					<td>Querystring</td>
 					<td><p>Comma separated list of flags to apply to <strong>all</strong> features.  For available options see the list in the <code>features</code> parameter documented above.  Equivalent to adding <code>|<em>flagname</em></code> to every feature in the <code>features</code> argument.</p><p>For example, <code>&amp;flags=always,gated</code> will apply both the <code>always</code> and the <code>gated</code> flag to all features requested in the <code>features</code> parameter.</td>

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,6 +25,7 @@ function getOptions(opts) {
 		minify: true,
 		unknown: 'ignore',
 		features: {},
+		excludes: []
 	}, opts);
 }
 
@@ -51,7 +52,10 @@ function getPolyfills(options) {
 	const resolveDependencies = createAliasResolver(
 		function aliasDependencies(featureName) {
 			return sourceslib.getPolyfill(featureName).then(function(polyfill) {
-				return ((polyfill && polyfill.dependencies) || []).concat(featureName);
+				return (polyfill && polyfill.dependencies || [])
+					.filter(depName => options.excludes.indexOf(depName) === -1)
+					.concat(featureName)
+				;
 			});
 		}
 	);
@@ -77,11 +81,21 @@ function getPolyfills(options) {
 		});
 	};
 
+	const filterForExcludes = function(features) {
+		Object.keys(features).forEach(featureName => {
+			if (options.excludes.indexOf(featureName) !== -1) {
+				delete features[featureName];
+			}
+		});
+		return features;
+	}
+
 	return Promise.resolve(options.features)
 		.then(resolveAliases)
 		.then(filterForUATargeting)
 		.then(resolveDependencies)
 		.then(filterForUATargeting)
+		.then(filterForExcludes)
 	;
 }
 

--- a/service/index.js
+++ b/service/index.js
@@ -157,6 +157,7 @@ app.get(/^\/v2\/polyfill(\.\w+)(\.\w+)?/, (req, res) => {
 
 	const params = {
 		features: polyfills.get(),
+		excludes: (req.query.excludes && req.query.excludes.split(',')) || [],
 		minify: minified
 	};
 	if (req.query.unknown) {

--- a/test/node/lib/test_index.js
+++ b/test/node/lib/test_index.js
@@ -104,6 +104,35 @@ describe("polyfillio", function() {
 				assert(Object.keys(polyfillSet).length > 0);
 			});
 		});
+
+		it("should respect the excludes option", function() {
+			return Promise.all([
+				polyfillio.getPolyfills({
+					features: {
+						'fetch': { flags:[] }
+					},
+					uaString: 'chrome/30'
+				}).then(function(polyfillSet) {
+					assert.deepEqual(polyfillSet, {
+						fetch: { flags: [] },
+						Promise: { flags: [], aliasOf: [ 'fetch' ] },
+						setImmediate: { flags: [], aliasOf: [ 'Promise', 'fetch' ] }
+					});
+				}),
+				polyfillio.getPolyfills({
+					features: {
+						'fetch': { flags:[] }
+					},
+					excludes: ["Promise", "non-existent-feature"],
+					uaString: 'chrome/30'
+				}).then(function(polyfillSet) {
+					console.log(polyfillSet, 2);
+					assert.deepEqual(polyfillSet, {
+						fetch: { flags: [] }
+					});
+				})
+			]);
+		});
 	});
 
 	/*


### PR DESCRIPTION
Adds the option to use `excludes` as both a library argument and an API param, so that automatically included dependencies can be selectively excluded.

@callumlocke 
