### PR TITLE
Daily stats

### DIFF
--- a/docs/assets/js/ui.js
+++ b/docs/assets/js/ui.js
@@ -19,10 +19,9 @@ function charts() {
 	drawCharts = function() {
 		chart1.draw(data1, {
 			chartArea:{left:0,top:0,width:'100%',height:'90%'},
-			hAxis: {title: 'Time (by hour, last 7 days)'},
-			vAxis: {textPosition: 'in'},
-			legend: {position: 'none'},
-			bar: {groupWidth: '90%'}
+			hAxis: {title: 'Time (by day)'},
+			vAxis: {textPosition: 'in', minValue:0},
+			legend: {position: 'none'}
 		});
 		chart2.draw(data2, {
 			pieHole: 0.6,
@@ -49,7 +48,7 @@ function charts() {
 						});
 					})
 				);
-				chart1 = new google.visualization.ColumnChart(chartel);
+				chart1 = new google.visualization.LineChart(chartel);
 
 				chartel = document.getElementById('chart-hitratio');
 				data2 = google.visualization.arrayToDataTable(

--- a/docs/usage.html
+++ b/docs/usage.html
@@ -12,7 +12,7 @@
 
 		<h3>Traffic volume</h3>
 
-		<p>This shows the number of requests we have served per day, over the last 90 days, measured by <strong>Fastly</strong>:</p>
+		<p>This shows the number of requests we have served per day, over the last 180 days, measured by <strong>Fastly</strong>:</p>
 
 		<div id="chart-requests" class='o-techdocs-content'>
 			<table class='chart-data o-techdocs-table'>

--- a/docs/usage.html
+++ b/docs/usage.html
@@ -12,7 +12,7 @@
 
 		<h3>Traffic volume</h3>
 
-		<p>This shows the number of requests we have served per hour, over the last 7 days, measured by <strong>Fastly</strong>:</p>
+		<p>This shows the number of requests we have served per day, over the last 90 days, measured by <strong>Fastly</strong>:</p>
 
 		<div id="chart-requests" class='o-techdocs-content'>
 			<table class='chart-data o-techdocs-table'>

--- a/service/docs.js
+++ b/service/docs.js
@@ -61,11 +61,14 @@ function getData(type) {
 	const handlers = {
 		fastly: () => {
 			if (!process.env.FASTLY_SERVICE_ID) return Promise.reject("Fastly environment vars not set");
+			const endTime = moment().startOf('day');
+			const startTime = moment(endTime).subtract(180, 'days');
 			return request({
-				url: 'https://api.fastly.com/stats/service/' + process.env.FASTLY_SERVICE_ID + '?from=90 days ago&to=1 day ago&by=day',
+				url: 'https://api.fastly.com/stats/service/' + process.env.FASTLY_SERVICE_ID + '?from='+startTime.unix()+'&to='+endTime.unix()+'&by=day',
 				headers: { 'fastly-key': process.env.FASTLY_API_KEY },
 				json: true
 			}).then(data => {
+				console.log(data);
 				const rollup = {requests:0, hits:0, miss:0, bandwidth:0};
 				const byday = data.data.map(function(result) {
 					rollup.requests += result.requests;

--- a/service/docs.js
+++ b/service/docs.js
@@ -62,19 +62,19 @@ function getData(type) {
 		fastly: () => {
 			if (!process.env.FASTLY_SERVICE_ID) return Promise.reject("Fastly environment vars not set");
 			return request({
-				url: 'https://api.fastly.com/stats/service/' + process.env.FASTLY_SERVICE_ID + '?from=7 days ago&to=2 hours ago&by=hour',
+				url: 'https://api.fastly.com/stats/service/' + process.env.FASTLY_SERVICE_ID + '?from=90 days ago&to=1 day ago&by=day',
 				headers: { 'fastly-key': process.env.FASTLY_API_KEY },
 				json: true
 			}).then(data => {
 				const rollup = {requests:0, hits:0, miss:0, bandwidth:0};
-				const byhour = data.data.map(function(result) {
+				const byday = data.data.map(function(result) {
 					rollup.requests += result.requests;
 					rollup.hits += result.hits;
 					rollup.miss += result.miss;
 					rollup.bandwidth += result.bandwidth;
 					return {date: result.start_time, requests:result.requests, hits:result.hits, miss:result.miss};
 				});
-				return {byhour:byhour, rollup:rollup};
+				return {byday:byday, rollup:rollup};
 			});
 		},
 		respTimes: () => {
@@ -258,7 +258,7 @@ function route(req, res, next) {
 				return Promise.all([getData('fastly'), getData('outages'), getData('respTimes')])
 					.then(spread((fastly, outages, respTimes) => {
 						return Object.assign(locals, {
-							requestsData: fastly.byhour,
+							requestsData: fastly.byday,
 							downtime: outages,
 							respTimes: respTimes,
 							hitCount: fastly.rollup.hits,

--- a/test/browser/director.html.handlebars
+++ b/test/browser/director.html.handlebars
@@ -55,9 +55,9 @@
 		}
 
         function postResult(featureName, result) {
-            if (parent && 'receiveTestResult' in parent) {
+            if (window.top !== this && parent && 'receiveTestResult' in parent) {
                 parent.receiveTestResult(featureName, result, '{{{mode}}}');
-            } else if (parent && 'postMessage' in parent) {
+            } else if (window.top !== this && parent && 'postMessage' in parent && 'JSON' in window) {
                 parent.postMessage(JSON.stringify({featureName:featureName, result:result, mode:'{{{mode}}}'}), '*');
             }
         }


### PR DESCRIPTION
Improve the display of our traffic growth by:
- using a line chart rather than columns
- grouping by day to avoid daily cycle effects (still get weekly cycle effects)
- increase time range from 7 to 180 days

![image](https://cloud.githubusercontent.com/assets/1735391/14980654/3c94f322-112a-11e6-8ea0-4f42f5f0b44d.png)
