### PR TITLE
Use Node 6 to handle HTTP clientError scenarios correctly, fixes #567

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Requirements
 
 Running Origami Build Service requires a few tools:
   * [Git]: For downloading the source code
-  * [Node.js] 5.x and [npm] 3.x: For installing the dependencies and running the application (npm is installed with Node.js)
+  * [Node.js] 6.x and [npm] 3.x: For installing the dependencies and running the application (npm is installed with Node.js)
   * [Grunt] 0.1.x: Used for automating tasks such as testing
 
 Running Locally

--- a/bin/polyfill-service
+++ b/bin/polyfill-service
@@ -18,6 +18,10 @@ var startService = require('../service');
 var argv = minimist(process.argv.slice(2));
 var port = argv.port || Number(process.env.PORT) || 3000;
 
+process.on('uncaughtException', (err) => {
+  console.log('uncaught exception', err.stack || err);
+});
+
 startService(port, function(err, app){
 	if (err) {
 		console.error('Error while starting service:', err);

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   node:
-    version: 5.8.0
+    version: 6.0.0
 dependencies:
   override:
     - npm install -g grunt-cli

--- a/service/index.js
+++ b/service/index.js
@@ -212,7 +212,8 @@ function startService(port, callback) {
 			callback(err);
 		})
 		.on('clientError', function (ex, sock) {
-			console.log('HTTP clientError: ', ex.code, sock);
+			socket.end('HTTP/1.1 400 Bad Request\r\n\r\n');
+			socket.destroy();
 		})
 	;
 }

--- a/service/index.js
+++ b/service/index.js
@@ -212,8 +212,8 @@ function startService(port, callback) {
 			callback(err);
 		})
 		.on('clientError', function (ex, sock) {
-			socket.end('HTTP/1.1 400 Bad Request\r\n\r\n');
-			socket.destroy();
+			sock.end('HTTP/1.1 400 Bad Request\r\n\r\n');
+			sock.destroy();
 		})
 	;
 }


### PR DESCRIPTION
Before:

![image](https://cloud.githubusercontent.com/assets/1735391/14982227/ce0a2ce4-112c-11e6-8463-550823a5dccd.png)

After:

![image](https://cloud.githubusercontent.com/assets/1735391/14982218/b91f7ec4-112c-11e6-9fe5-00c8c130623e.png)
