### PR TITLE
Raise baseline to exclude IE6, Safari 3, Android 2.  Fixes #456

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -152,7 +152,6 @@ const browsers = {
 		'ie/9',
 		'ie/8',
 		'ie/7',
-		'ie/6',
 		'safari/9',
 		'safari/8',
 		'android/4.4'
@@ -177,7 +176,6 @@ const browsers = {
 		'ie/9',
 		'ie/8',
 		'ie/7',
-		'ie/6',
 		'safari/9',
 		'safari/8',
 		'safari/5.1',

--- a/lib/UA.js
+++ b/lib/UA.js
@@ -19,15 +19,15 @@ const cache = require('lru-cache')({
 });
 
 const baseLineVersions = {
-	"ie": ">=6",
+	"ie": ">=7",
 	"ie_mob": ">=8",
 	"chrome": "*",
-	"safari": ">=3",
-	"ios_saf": ">=3",
+	"safari": ">=4",
+	"ios_saf": ">=4",
 	"ios_chr": ">=3",
 	"firefox": ">=3.6",
 	"firefox_mob": ">=4",
-	"android": ">=2.3",
+	"android": ">=3",
 	"opera": ">=11",
 	"op_mob": ">=10",
 	"op_mini": ">=5",


### PR DESCRIPTION
I think the majority of polyfill.io users are not testing IE6 and have no significant audience using it.  It would be better not to try and serve polyfills to it anymore.
