### PR TITLE
Add navigator.sendBeacon, closes #539

### DIFF
--- a/polyfills/navigator/sendBeacon/config.json
+++ b/polyfills/navigator/sendBeacon/config.json
@@ -1,13 +1,22 @@
 {
-	"aliases": [
-	],
+	"aliases": [],
 	"browsers": {
+		"chrome": "<39",
+		"firefox": "<31",
+		"ie": "*",
+		"opera": "<26",
+		"safari": "*",
+		"android": "*",
+		"firefox_mob": "<31",
+		"ie_mob": "*",
+		"op_mob": "*",
+		"ios_saf": "*"
 	},
 	"dependencies": [
 		"XMLHttpRequest"
 	],
-	"docs": "TODO",
-	"spec": "TODO",
+	"docs": "https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon",
+	"spec": "https://w3c.github.io/beacon/#sec-sendBeacon-method",
 	"repo": "https://github.com/miguelmota/Navigator.sendBeacon",
-	"license": "TODO"
+	"license": "MIT"
 }

--- a/polyfills/navigator/sendBeacon/config.json
+++ b/polyfills/navigator/sendBeacon/config.json
@@ -1,0 +1,13 @@
+{
+	"aliases": [
+	],
+	"browsers": {
+	},
+	"dependencies": [
+		"XMLHttpRequest"
+	],
+	"docs": "TODO",
+	"spec": "TODO",
+	"repo": "https://github.com/miguelmota/Navigator.sendBeacon",
+	"license": "TODO"
+}

--- a/polyfills/navigator/sendBeacon/detect.js
+++ b/polyfills/navigator/sendBeacon/detect.js
@@ -1,0 +1,1 @@
+'navigator' in this && 'sendBeacon' in navigator

--- a/polyfills/navigator/sendBeacon/polyfill.js
+++ b/polyfills/navigator/sendBeacon/polyfill.js
@@ -1,33 +1,15 @@
-(function(root) {
-
-	function sendBeacon(url, data) {
-		var xhr = ('XMLHttpRequest' in window) ? new XMLHttpRequest() : new ActiveXObject('Microsoft.XMLHTTP');
-		xhr.open('POST', url, false);
-		xhr.setRequestHeader('Accept', '*/*');
-		if (typeof data === 'string') {
-			xhr.setRequestHeader('Content-Type', 'text/plain;charset=UTF-8');
-			xhr.responseType = 'text/plain';
-		} else if (Object.prototype.toString.call(data) === '[object Blob]') {
-			if (data.type) {
-				xhr.setRequestHeader('Content-Type', data.type);
-			}
+this.navigator && this.navigator.sendBeacon = function sendBeacon(url, data) {
+	var xhr = ('XMLHttpRequest' in window) ? new XMLHttpRequest() : new ActiveXObject('Microsoft.XMLHTTP');
+	xhr.open('POST', url, false);
+	xhr.setRequestHeader('Accept', '*/*');
+	if (typeof data === 'string') {
+		xhr.setRequestHeader('Content-Type', 'text/plain;charset=UTF-8');
+		xhr.responseType = 'text/plain';
+	} else if (Object.prototype.toString.call(data) === '[object Blob]') {
+		if (data.type) {
+			xhr.setRequestHeader('Content-Type', data.type);
 		}
-		xhr.send(data);
-		return true;
 	}
-
-	if (!('sendBeacon' in navigator)) {
-		navigator.sendBeacon = sendBeacon;
-	}
-
-	if (typeof exports !== 'undefined') {
-		if (typeof module !== 'undefined' && module.exports) {
-			exports = module.exports = sendBeacon;
-		}
-		exports.sendBeacon = sendBeacon;
-	} else if (typeof define === 'function' && define.amd) {
-		define([], function() {
-			return sendBeacon;
-		});
-	}
-})(this);
+	xhr.send(data);
+	return true;
+}

--- a/polyfills/navigator/sendBeacon/polyfill.js
+++ b/polyfills/navigator/sendBeacon/polyfill.js
@@ -1,4 +1,5 @@
-this.navigator && this.navigator.sendBeacon = function sendBeacon(url, data) {
+if (!('navigator' in this)) this.navigator = {};
+this.navigator.sendBeacon = function sendBeacon(url, data) {
 	var xhr = ('XMLHttpRequest' in window) ? new XMLHttpRequest() : new ActiveXObject('Microsoft.XMLHTTP');
 	xhr.open('POST', url, false);
 	xhr.setRequestHeader('Accept', '*/*');
@@ -12,4 +13,4 @@ this.navigator && this.navigator.sendBeacon = function sendBeacon(url, data) {
 	}
 	xhr.send(data);
 	return true;
-}
+};

--- a/polyfills/navigator/sendBeacon/polyfill.js
+++ b/polyfills/navigator/sendBeacon/polyfill.js
@@ -1,0 +1,33 @@
+(function(root) {
+
+	function sendBeacon(url, data) {
+		var xhr = ('XMLHttpRequest' in window) ? new XMLHttpRequest() : new ActiveXObject('Microsoft.XMLHTTP');
+		xhr.open('POST', url, false);
+		xhr.setRequestHeader('Accept', '*/*');
+		if (typeof data === 'string') {
+			xhr.setRequestHeader('Content-Type', 'text/plain;charset=UTF-8');
+			xhr.responseType = 'text/plain';
+		} else if (Object.prototype.toString.call(data) === '[object Blob]') {
+			if (data.type) {
+				xhr.setRequestHeader('Content-Type', data.type);
+			}
+		}
+		xhr.send(data);
+		return true;
+	}
+
+	if (!('sendBeacon' in navigator)) {
+		navigator.sendBeacon = sendBeacon;
+	}
+
+	if (typeof exports !== 'undefined') {
+		if (typeof module !== 'undefined' && module.exports) {
+			exports = module.exports = sendBeacon;
+		}
+		exports.sendBeacon = sendBeacon;
+	} else if (typeof define === 'function' && define.amd) {
+		define([], function() {
+			return sendBeacon;
+		});
+	}
+})(this);


### PR DESCRIPTION
Adds a sendBeacon polyfill.  Some caveats:
- I can't find any tests for sendBeacon.  There aren't any in the polyfill repo, and sendBeacon is only mentioned in web platform tests as part of CSP test suites.  Creating tests would be hard since the success criteria is that the request made it to the server.  A serviceworker could be used, I suppose, but then the tests will only run in browsers that support SW.  A detect will need to suffice for now.
- The polyfill source includes a UMD, which is fine, but it also references `navigator` without pulling it off the `root` object.  This is probably an oversight on the part of the author, so we should probably push that change upstream.
