### PR TITLE
adding facebook user agent to Intl

### DIFF
--- a/polyfills/Intl/config.json
+++ b/polyfills/Intl/config.json
@@ -7,7 +7,8 @@
 		"chrome": "<24",
 		"safari": "*",
 		"ios_saf": "*",
-		"firefox_mob": "*"
+		"firefox_mob": "*",
+		"facebook": "*"
 	},
 	"dependencies": [],
 	"build": {


### PR DESCRIPTION
When opening a page in the Facebook for iOS in-app browser the user agent is recognized as "facebook" instead of "safari", this doesn't happen in Android where the UA is correctly interpreted as Chrome, so aliasing might not be necessary (being aliasing "facebook" to "safari", or even correctly interpreting it in the first place)

I'm making this commit to correct this issue https://github.com/facebook/react/issues/6739
