### PR TITLE
Fixed Object.create polyfill issue when called through Babel's Object's create wrapper

### DIFF
--- a/polyfills/Symbol/polyfill.js
+++ b/polyfills/Symbol/polyfill.js
@@ -191,7 +191,7 @@
 	defineProperty(Object, GOPD, descriptor);
 
 	descriptor.value = function (proto, descriptors) {
-		return arguments.length === 1 ?
+		return arguments.length === 1 || typeof descriptors === "undefined" ?
 		create(proto) :
 		createWithSymbols(proto, descriptors);
 	};

--- a/polyfills/Symbol/tests.js
+++ b/polyfills/Symbol/tests.js
@@ -152,3 +152,15 @@ xit('should not allow implicit string coercion', function() {
 	}
 	expect(implicitStringCoercion).to.throwError();
 });
+
+it('should create Object without symbols', function () {
+	var Obj = function () {};
+	var obj = Object.create(Obj.prototype);
+	expect(obj instanceof Obj).to.be(true);
+});
+
+it('should create Object without symbols, second argument undefined', function () {
+	var Obj = function () {};
+	var obj = Object.create(Obj.prototype, undefined);
+	expect(obj instanceof Obj).to.be(true);
+});


### PR DESCRIPTION
arguments can be 2 even if descriptors is explicitly undefined, so it's good to check if it's not undefined. Tested, solves the issue.
