### PR TITLE
Reinstate the existing Event prototype, fixes #705

### DIFF
--- a/polyfills/Event/config.json
+++ b/polyfills/Event/config.json
@@ -13,7 +13,8 @@
 	"dependencies": [
 		"Window",
 		"Document",
-		"Element"
+		"Element",
+		"Object.defineProperty"
 	],
 	"docs": "https://developer.mozilla.org/en/docs/Web/API/Event",
 	"notes": [

--- a/polyfills/Event/detect.js
+++ b/polyfills/Event/detect.js
@@ -5,7 +5,7 @@
 
 	try {
 
-		// In IE 9 and 10, the Event object exists but cannot be instantiated
+		// In IE 9-11, the Event object exists but cannot be instantiated
 		new Event('click');
 		return true;
 	} catch(e) {

--- a/polyfills/Event/polyfill.js
+++ b/polyfills/Event/polyfill.js
@@ -57,7 +57,12 @@
 		return event;
 	};
 	if (existingProto) {
-		window.Event.prototype = existingProto;
+		Object.defineProperty(window.Event, 'prototype', {
+			configurable: false,
+			enumerable: false,
+			writable: true,
+			value: existingProto
+		});
 	}
 
 	if (!('createEvent' in document)) {

--- a/polyfills/Event/polyfill.js
+++ b/polyfills/Event/polyfill.js
@@ -31,6 +31,7 @@
 		return -1;
 	}
 
+	var existingProto = (window.Event && window.Event.prototype) || null;
 	window.Event = Window.prototype.Event = function Event(type, eventInitDict) {
 		if (!type) {
 			throw new Error('Not enough arguments');
@@ -55,6 +56,9 @@
 
 		return event;
 	};
+	if (existingProto) {
+		window.Event.prototype = existingProto;
+	}
 
 	if (!('createEvent' in document)) {
 		window.addEventListener = Window.prototype.addEventListener = Document.prototype.addEventListener = Element.prototype.addEventListener = function addEventListener() {

--- a/polyfills/Event/tests.js
+++ b/polyfills/Event/tests.js
@@ -147,3 +147,12 @@ it('should successfully call window.addEventListener or throw exception', functi
 		threwLast = threw;
 	}
 });
+
+it('subclasses should be instances of Event', function () {
+	const a = document.createElement('a');
+	a.addEventListener('click', function(ev) {
+		expect(ev).to.be.an(Event);
+	});
+	document.body.appendChild(a);
+	a.click();
+})

--- a/polyfills/Event/tests.js
+++ b/polyfills/Event/tests.js
@@ -148,10 +148,14 @@ it('should successfully call window.addEventListener or throw exception', functi
 	}
 });
 
-it('subclasses should be instances of Event', function () {
-	const a = document.createElement('a');
+it('subclasses should be instances of Event if the UA implements DOM3', function () {
+	var a = document.createElement('a');
 	a.addEventListener('click', function(ev) {
-		expect(ev).to.be.an(Event);
+
+		// Supported in IE9+
+		if ('MouseEvent' in window) {
+			expect(ev).to.be.an(Event);
+		}
 	});
 	document.body.appendChild(a);
 	a.click();


### PR DESCRIPTION
My knowledge of JS prototypes is pretty sketchy, but I think this may fix the problem described in #705.  The issue is that redefinition of `Event` (in order to make it constructable in IE9-11) detaches it from the prototype chain for event instances.  This appears to be what's happening:

![image](https://cloud.githubusercontent.com/assets/1735391/15695304/bea3fcd8-27e0-11e6-9630-f8c7493d7407.png)
