### PR TITLE
Implement document.registerElement

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "babel-core": "^6.2.1",
     "babel-preset-es2015": "^6.1.18",
     "batch": "^0.5.1",
+    "document-register-element": "^0.5.4",
     "fastly": "Financial-Times/fastly#v2.5.0",
     "grunt": "~0.4.0",
     "grunt-cli": "~0.1.6",

--- a/polyfills/document.registerElement/config.json
+++ b/polyfills/document.registerElement/config.json
@@ -1,0 +1,22 @@
+{
+	"browsers": {
+		"ie": "9 - *",
+		"ie_mob": "10 - *",
+		"firefox": "14 - 31",
+		"opera": "15 - 25",
+		"safari": "*",
+		"chrome": "* - 35",
+		"ios_saf": "*",
+		"firefox_mob": "4 - 37",
+		"bb": "*",
+		"android": "* - 4.4.4"
+	},
+	"build": {
+		"commonjs": true
+	},
+	"dependencies": ["html5shiv"],
+	"license": "MIT",
+	"spec": "https://w3c.github.io/webcomponents/spec/custom/#extensions-to-document-interface-to-register",
+	"repo": "https://github.com/WebReflection/document-register-element",
+	"docs": "https://developer.mozilla.org/en-US/docs/Web/API/Document/registerElement"
+}

--- a/polyfills/document.registerElement/detect.js
+++ b/polyfills/document.registerElement/detect.js
@@ -1,0 +1,1 @@
+'document' in this && 'registerElement' in this.document

--- a/polyfills/document.registerElement/polyfill.js
+++ b/polyfills/document.registerElement/polyfill.js
@@ -1,0 +1,1 @@
+require('document-register-element');


### PR DESCRIPTION
Closes #429 - though without IE8 support (yet).

While researching this, I found that actually `document.registerElement()` was removed from the spec in favour of `window.customElements.define`, which could have bigger implications elsewhere (ref. https://github.com/w3c/webcomponents/commit/d95392f734895b2c72e1822f464dd70a22b322a4 and later https://github.com/w3c/webcomponents/commit/815910d197077523fb449dfb5a1e6fceab728019).

Does implementing this still make sense, since it is already in-use in some Origami components, or should we skip and go straight for `window.customElements.define`?  (As far as I can tell nothing has implemented the changes yet).

Lemme know if this is a question to raise elsewhere.
