### PR TITLE
Provide immutable default sets

### DIFF
--- a/docs/api.html
+++ b/docs/api.html
@@ -47,7 +47,7 @@
 							<dt><code>|gated</code></dt>
 							<dd>If the polyfill is included in the bundle, it will be accompanied by a feature detect, which will only execute the polyfill if the native API is not present.</dd>
 						</dl>
-						<p>Omitting or setting to an empty string is equivalent to the value "default", which is an alias for a curated list of the most popular polyfills.  Setting the value "all" will select every feature in the library (this is an extremely bad idea)</p>
+						<p>Omitting or setting to an empty string is equivalent to the value "default", which is an alias for <a href='/{{apiversion}}/docs/features/#default-sets'>a curated list of the most popular polyfills</a>.  Setting the value "all" will select every feature in the library (this is an extremely bad idea and will be removed in a future version)</p>
 					</td>
 				</tr><tr>
 					<td><code>excludes</code></td>

--- a/docs/features.html
+++ b/docs/features.html
@@ -104,6 +104,23 @@
 			</tbody>
 		</table>
 
+		<h2 id='default-sets'>Default sets</h2>
+
+		<p>The alias <code>default</code> includes a set of polyfills that comprise features with high demands, small polyfill sizes, good performance and at least one good native implementation in a stable browser.  The set evolves over time to include new features as they become a more stable part of the web platform.</p>
+
+		<p>Although you cannot request an immutable version of a polyfill, you can reduce the risk of future releases of the polyfill service breaking compatibility with your code by using an immutable default set.  Each time we make a release, if we have changed the features included in the default set we will issue a new immutable alias for the set, which won't change when the default set changes again.  The components of these sets are shown below:</p>
+
+		<table>
+			<thead>
+				<tr><th>Alias</th><th>Constituents</th></tr>
+			</thead>
+			<tbody>
+				<tr><td><code style='white-space: nowrap'>default-3.3</code></td><td>Array.isArray, Array.prototype.every, Array.prototype.filter, Array.prototype.forEach, Array.prototype.indexOf, Array.prototype.lastIndexOf, Array.prototype.map, Array.prototype.reduce, Array.prototype.reduceRight, Array.prototype.some, atob, CustomEvent, Date.now, Date.prototype.toISOString, Document, document.querySelector, document.visibilityState, DOMTokenList, Element, Element.prototype.classList, Element.prototype.cloneNode, Element.prototype.closest, Element.prototype.matches, Event, Event.DOMContentLoaded, Event.focusin, Event.hashchange, Function.prototype.bind, JSON, Object.assign, Object.create, Object.defineProperties, Object.defineProperty, Object.getOwnPropertyNames, Object.getPrototypeOf, Object.keys, requestAnimationFrame, String.prototype.includes, String.prototype.trim, Window, XMLHttpRequest, ~html5-elements</td></tr>
+				<tr><td><code style='white-space: nowrap'>default-3.4</code></td><td><strong>Added</strong> Array.from, Array.of, Array.prototype.fill, Element.prototype.after, Element.prototype.append, Element.prototype.before, Element.prototype.prepend, Element.prototype.remove, Element.prototype.replaceWith, Node.prototype.contains, Number.isNaN, Promise, String.prototype.endsWith, String.prototype.startsWith, URL, location.origin</td></tr>
+				<tr><td><code style='white-space: nowrap'>default-3.5</code></td><td><strong>Added</strong> Object.getOwnPropertyDescriptor</td></tr>
+				<tr><td><code style='white-space: nowrap'>default-3.6</code></td><td><strong>Added</strong> Map, Set</td></tr>
+			</tbody>
+		</table>
 	</div>
 
 {{>footer}}

--- a/polyfills/Array/from/config.json
+++ b/polyfills/Array/from/config.json
@@ -3,6 +3,9 @@
 		"es6",
 		"modernizr:es6array",
 		"blissfuljs",
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default"
 	],
 	"browsers": {

--- a/polyfills/Array/isArray/config.json
+++ b/polyfills/Array/isArray/config.json
@@ -1,5 +1,9 @@
 {
 	"aliases": [
+		"default-3.3",
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default",
 		"es5",
 		"modernizr:es5array",

--- a/polyfills/Array/of/config.json
+++ b/polyfills/Array/of/config.json
@@ -2,6 +2,9 @@
 	"aliases": [
 		"es6",
 		"modernizr:es6array",
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default"
 	],
 	"browsers": {

--- a/polyfills/Array/prototype/every/config.json
+++ b/polyfills/Array/prototype/every/config.json
@@ -1,5 +1,9 @@
 {
 	"aliases": [
+		"default-3.3",
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default",
 		"es5",
 		"modernizr:es5array"

--- a/polyfills/Array/prototype/fill/config.json
+++ b/polyfills/Array/prototype/fill/config.json
@@ -1,6 +1,9 @@
 {
 	"aliases": [
 		"es6",
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default"
 	],
 	"browsers": {

--- a/polyfills/Array/prototype/filter/config.json
+++ b/polyfills/Array/prototype/filter/config.json
@@ -1,5 +1,9 @@
 {
 	"aliases": [
+		"default-3.3",
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default",
 		"es5",
 		"modernizr:es5array",

--- a/polyfills/Array/prototype/forEach/config.json
+++ b/polyfills/Array/prototype/forEach/config.json
@@ -1,5 +1,9 @@
 {
 	"aliases": [
+		"default-3.3",
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default",
 		"es5",
 		"modernizr:es5array",

--- a/polyfills/Array/prototype/indexOf/config.json
+++ b/polyfills/Array/prototype/indexOf/config.json
@@ -1,5 +1,9 @@
 {
 	"aliases": [
+		"default-3.3",
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default",
 		"es5",
 		"modernizr:es5array",

--- a/polyfills/Array/prototype/lastIndexOf/config.json
+++ b/polyfills/Array/prototype/lastIndexOf/config.json
@@ -1,5 +1,9 @@
 {
 	"aliases": [
+		"default-3.3",
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default",
 		"es5",
 		"modernizr:es5array"

--- a/polyfills/Array/prototype/map/config.json
+++ b/polyfills/Array/prototype/map/config.json
@@ -1,5 +1,9 @@
 {
 	"aliases": [
+		"default-3.3",
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default",
 		"es5",
 		"modernizr:es5array",

--- a/polyfills/Array/prototype/reduce/config.json
+++ b/polyfills/Array/prototype/reduce/config.json
@@ -1,5 +1,9 @@
 {
 	"aliases": [
+		"default-3.3",
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default",
 		"es5",
 		"modernizr:es5array",

--- a/polyfills/Array/prototype/reduceRight/config.json
+++ b/polyfills/Array/prototype/reduceRight/config.json
@@ -1,5 +1,9 @@
 {
 	"aliases": [
+		"default-3.3",
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default",
 		"es5",
 		"modernizr:es5array"

--- a/polyfills/Array/prototype/some/config.json
+++ b/polyfills/Array/prototype/some/config.json
@@ -1,5 +1,9 @@
 {
 	"aliases": [
+		"default-3.3",
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default",
 		"es5",
 		"modernizr:es5array",

--- a/polyfills/CustomEvent/config.json
+++ b/polyfills/CustomEvent/config.json
@@ -1,5 +1,9 @@
 {
 	"aliases": [
+		"default-3.3",
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default",
 		"modernizr:customevent"
 	],

--- a/polyfills/DOMTokenList/config.json
+++ b/polyfills/DOMTokenList/config.json
@@ -1,5 +1,9 @@
 {
 	"aliases": [
+		"default-3.3",
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default"
 	],
 	"browsers": {

--- a/polyfills/Date/now/config.json
+++ b/polyfills/Date/now/config.json
@@ -1,5 +1,9 @@
 {
 	"aliases": [
+		"default-3.3",
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default",
 		"es5",
 		"modernizr:es5date"

--- a/polyfills/Date/prototype/toISOString/config.json
+++ b/polyfills/Date/prototype/toISOString/config.json
@@ -1,5 +1,9 @@
 {
 	"aliases": [
+		"default-3.3",
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default",
 		"es5",
 		"modernizr:es5date"

--- a/polyfills/Document/config.json
+++ b/polyfills/Document/config.json
@@ -1,5 +1,9 @@
 {
 	"aliases": [
+		"default-3.3",
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default"
 	],
 	"browsers": {

--- a/polyfills/Element/config.json
+++ b/polyfills/Element/config.json
@@ -1,5 +1,9 @@
 {
 	"aliases": [
+		"default-3.3",
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default"
 	],
 	"browsers": {

--- a/polyfills/Element/prototype/after/config.json
+++ b/polyfills/Element/prototype/after/config.json
@@ -1,5 +1,8 @@
 {
 	"aliases": [
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default"
 	],
 	"browsers": {

--- a/polyfills/Element/prototype/append/config.json
+++ b/polyfills/Element/prototype/append/config.json
@@ -1,5 +1,8 @@
 {
 	"aliases": [
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default"
 	],
 	"browsers": {

--- a/polyfills/Element/prototype/before/config.json
+++ b/polyfills/Element/prototype/before/config.json
@@ -1,5 +1,8 @@
 {
 	"aliases": [
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default"
 	],
 	"browsers": {

--- a/polyfills/Element/prototype/classList/config.json
+++ b/polyfills/Element/prototype/classList/config.json
@@ -1,5 +1,9 @@
 {
 	"aliases": [
+		"default-3.3",
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default",
 		"modernizr:classlist",
 		"blissfuljs"

--- a/polyfills/Element/prototype/cloneNode/config.json
+++ b/polyfills/Element/prototype/cloneNode/config.json
@@ -1,5 +1,9 @@
 {
 	"aliases": [
+		"default-3.3",
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default",
 		"blissfuljs"
 	],

--- a/polyfills/Element/prototype/closest/config.json
+++ b/polyfills/Element/prototype/closest/config.json
@@ -1,5 +1,9 @@
 {
 	"aliases": [
+		"default-3.3",
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default",
 		"blissfuljs"
 	],

--- a/polyfills/Element/prototype/matches/config.json
+++ b/polyfills/Element/prototype/matches/config.json
@@ -1,5 +1,9 @@
 {
 	"aliases": [
+		"default-3.3",
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default",
 		"caniuse:matchesselector",
 		"blissfuljs"

--- a/polyfills/Element/prototype/prepend/config.json
+++ b/polyfills/Element/prototype/prepend/config.json
@@ -1,5 +1,8 @@
 {
 	"aliases": [
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default"
 	],
 	"browsers": {

--- a/polyfills/Element/prototype/remove/config.json
+++ b/polyfills/Element/prototype/remove/config.json
@@ -1,5 +1,8 @@
 {
 	"aliases": [
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default"
 	],
 	"browsers": {

--- a/polyfills/Element/prototype/replaceWith/config.json
+++ b/polyfills/Element/prototype/replaceWith/config.json
@@ -1,5 +1,8 @@
 {
 	"aliases": [
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default"
 	],
 	"browsers": {

--- a/polyfills/Event/DOMContentLoaded/config.json
+++ b/polyfills/Event/DOMContentLoaded/config.json
@@ -1,6 +1,10 @@
 {
 	"aliases": [
 		"caniuse:domcontentloaded",
+		"default-3.3",
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default"
 	],
 	"browsers": {

--- a/polyfills/Event/config.json
+++ b/polyfills/Event/config.json
@@ -1,5 +1,9 @@
 {
 	"aliases": [
+		"default-3.3",
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default"
 	],
 	"browsers": {

--- a/polyfills/Event/focusin/config.json
+++ b/polyfills/Event/focusin/config.json
@@ -1,5 +1,9 @@
 {
 	"aliases": [
+		"default-3.3",
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default"
 	],
 	"browsers": {

--- a/polyfills/Event/hashchange/config.json
+++ b/polyfills/Event/hashchange/config.json
@@ -2,6 +2,10 @@
 	"aliases": [
 		"caniuse:hashchange",
 		"modernizr:hashchange",
+		"default-3.3",
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default"
 	],
 	"browsers": {

--- a/polyfills/Function/prototype/bind/config.json
+++ b/polyfills/Function/prototype/bind/config.json
@@ -1,5 +1,9 @@
 {
 	"aliases": [
+		"default-3.3",
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default",
 		"es5",
 		"modernizr:es5function",

--- a/polyfills/JSON/config.json
+++ b/polyfills/JSON/config.json
@@ -1,5 +1,9 @@
 {
 	"aliases": [
+		"default-3.3",
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default",
 		"caniuse:json",
 		"modernizr:json"

--- a/polyfills/Map/config.json
+++ b/polyfills/Map/config.json
@@ -1,5 +1,6 @@
 {
 	"aliases": [
+		"default-3.6",
 		"default"
 	],
 	"browsers": {

--- a/polyfills/Node/prototype/contains/config.json
+++ b/polyfills/Node/prototype/contains/config.json
@@ -1,6 +1,9 @@
 {
 	"aliases": [
 		"dom4",
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default"
 	],
 	"browsers": {

--- a/polyfills/Number/isNaN/config.json
+++ b/polyfills/Number/isNaN/config.json
@@ -1,5 +1,8 @@
 {
 	"aliases": [
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default"
 	],
 	"browsers": {

--- a/polyfills/Object/assign/config.json
+++ b/polyfills/Object/assign/config.json
@@ -2,6 +2,10 @@
 	"aliases": [
 		"es6",
 		"modernizr:es6object",
+		"default-3.3",
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default"
 	],
 	"browsers": {

--- a/polyfills/Object/create/config.json
+++ b/polyfills/Object/create/config.json
@@ -2,6 +2,10 @@
 	"aliases": [
 		"es5",
 		"modernizr:es5object",
+		"default-3.3",
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default",
 		"blissfuljs"
 	],

--- a/polyfills/Object/defineProperties/config.json
+++ b/polyfills/Object/defineProperties/config.json
@@ -2,6 +2,10 @@
 	"aliases": [
 		"es5",
 		"modernizr:es5object",
+		"default-3.3",
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default"
 	],
 	"browsers": {

--- a/polyfills/Object/defineProperty/config.json
+++ b/polyfills/Object/defineProperty/config.json
@@ -2,6 +2,10 @@
 	"aliases": [
 		"es5",
 		"modernizr:es5object",
+		"default-3.3",
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default",
 		"blissfuljs"
 	],

--- a/polyfills/Object/getOwnPropertyDescriptor/config.json
+++ b/polyfills/Object/getOwnPropertyDescriptor/config.json
@@ -2,6 +2,8 @@
 	"aliases": [
 		"es5",
 		"modernizr:es5object",
+		"default-3.5",
+		"default-3.6",
 		"default",
 		"blissfuljs"
 	],

--- a/polyfills/Object/getOwnPropertyNames/config.json
+++ b/polyfills/Object/getOwnPropertyNames/config.json
@@ -2,6 +2,10 @@
 	"aliases": [
 		"es5",
 		"modernizr:es5object",
+		"default-3.3",
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default"
 	],
 	"browsers": {

--- a/polyfills/Object/getPrototypeOf/config.json
+++ b/polyfills/Object/getPrototypeOf/config.json
@@ -2,6 +2,10 @@
 	"aliases": [
 		"es5",
 		"modernizr:es5object",
+		"default-3.3",
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default"
 	],
 	"browsers": {

--- a/polyfills/Object/keys/config.json
+++ b/polyfills/Object/keys/config.json
@@ -2,6 +2,10 @@
 	"aliases": [
 		"es5",
 		"modernizr:es5object",
+		"default-3.3",
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default",
 		"blissfuljs"
 	],

--- a/polyfills/Promise/config.json
+++ b/polyfills/Promise/config.json
@@ -3,6 +3,9 @@
 		"modernizr:promises",
 		"caniuse:promises",
 		"blissfuljs",
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default",
 		"es6"
 	],

--- a/polyfills/Set/config.json
+++ b/polyfills/Set/config.json
@@ -1,5 +1,6 @@
 {
 	"aliases": [
+		"default-3.6",
 		"default"
 	],
 	"browsers": {

--- a/polyfills/String/prototype/endsWith/config.json
+++ b/polyfills/String/prototype/endsWith/config.json
@@ -3,6 +3,9 @@
 		"es6",
 		"modernizr:es6string",
 		"blissfuljs",
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default"
 	],
 	"browsers": {

--- a/polyfills/String/prototype/includes/config.json
+++ b/polyfills/String/prototype/includes/config.json
@@ -1,5 +1,9 @@
 {
 	"aliases": [
+		"default-3.3",
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default",
 		"es6",
 		"modernizr:es6string"

--- a/polyfills/String/prototype/startsWith/config.json
+++ b/polyfills/String/prototype/startsWith/config.json
@@ -3,6 +3,9 @@
 		"es6",
 		"modernizr:es6string",
 		"blissfuljs",
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default"
 	],
 	"browsers": {

--- a/polyfills/String/prototype/trim/config.json
+++ b/polyfills/String/prototype/trim/config.json
@@ -1,5 +1,9 @@
 {
 	"aliases": [
+		"default-3.3",
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default",
 		"es5",
 		"modernizr:es5string",

--- a/polyfills/URL/config.json
+++ b/polyfills/URL/config.json
@@ -2,6 +2,9 @@
 	"aliases": [
 	  	"modernizr:urlparser",
 		"blissfuljs",
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default"
 	],
 	"browsers": {

--- a/polyfills/Window/config.json
+++ b/polyfills/Window/config.json
@@ -1,5 +1,9 @@
 {
 	"aliases": [
+		"default-3.3",
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default"
 	],
 	"browsers": {

--- a/polyfills/XMLHttpRequest/config.json
+++ b/polyfills/XMLHttpRequest/config.json
@@ -1,5 +1,9 @@
 {
 	"aliases": [
+		"default-3.3",
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default",
 		"blissfuljs"
 	],

--- a/polyfills/atob/config.json
+++ b/polyfills/atob/config.json
@@ -1,5 +1,9 @@
 {
 	"aliases": [
+		"default-3.3",
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default",
 		"caniuse:datauri"
 	],

--- a/polyfills/document.querySelector/config.json
+++ b/polyfills/document.querySelector/config.json
@@ -1,5 +1,9 @@
 {
 	"aliases": [
+		"default-3.3",
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default",
 		"blissfuljs"
 	],

--- a/polyfills/document.visibilityState/config.json
+++ b/polyfills/document.visibilityState/config.json
@@ -1,5 +1,9 @@
 {
 	"aliases": [
+		"default-3.3",
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default",
 		"caniuse:visib",
 		"caniuse:pagevisibility",

--- a/polyfills/location/origin/config.json
+++ b/polyfills/location/origin/config.json
@@ -1,5 +1,8 @@
 {
 	"aliases": [
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default"
 	],
 	"browsers": {

--- a/polyfills/requestAnimationFrame/config.json
+++ b/polyfills/requestAnimationFrame/config.json
@@ -1,5 +1,9 @@
 {
 	"aliases": [
+		"default-3.3",
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default",
 		"caniuse:requestanimationframe",
 		"modernizr:requestanimationframe"

--- a/polyfills/~html5-elements/config.json
+++ b/polyfills/~html5-elements/config.json
@@ -4,6 +4,10 @@
 		"safari": "4"
 	},
 	"aliases": [
+		"default-3.3",
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
 		"default",
 		"html5shiv"
 	],


### PR DESCRIPTION
This PR adds new aliases for the default set as it was in the last 4 public releases of the service.  See the change to docs/features.html for more detailed explanation of usage.  This is intended to address recent concerns over the release of v3.6 introducing a bug that broke IE11 even for users that were not requesting the Map and Set polyfills.
