### PR TITLE
Routes

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,7 +4,8 @@
 	},
 	"env": {
 		"es6": true,
-		"browser": false
+		"browser": false,
+		"node": true
 	},
 	"rules": {
 		"no-unused-vars": 2,

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -55,7 +55,7 @@ module.exports = function(grunt) {
 				spawn: false
 			},
 			js: {
-				files: ['bin/*', 'docs/*.html', 'service/*.js', 'lib/*.js'],
+				files: ['bin/*', 'docs/*.html', 'service/**/*.js', 'lib/*.js'],
 				tasks: ['service:polyfillservice:restart']
 			},
 			polyfills: {

--- a/docs/examples.html
+++ b/docs/examples.html
@@ -11,7 +11,7 @@
 
 			<h2 id='basic'>Basic case</h2>
 
-			<p>The simplest use: consider default polyfills, bundle, minfy and and return those which are required by the current browser:</p>
+			<p>The simplest use: consider default polyfills, bundle, minify and and return those which are required by the current browser:</p>
 			<div class='demo' data-src='/v{{apiversion}}/polyfill.min.js'></div>
 			<p>This example is minified by including <code>.min</code> in the URL.  All the other examples on this page are not minified, so you can see the metadata included at the top of the response, but any response can be minified by adding <code>.min</code> in the same way as shown above.</p>
 
@@ -38,7 +38,7 @@
 			<h2 id='flags'>Using flags</h2>
 
 			<p>It's often a good idea to use the <code>gated</code> flag to wrap polyfills in a feature-detect.  Some people prefer not to do this and instead just trust the browser targeting, but to guard against mistargeting, incorrect user agent interpretation, and conflicts with other polyfills that may be on the same page, you can apply feature-detect gating to all features in the bundle at once:</p>
-			<div class='demo' data-src='/v{{apiversion}}/polyfill.js?features=Element.prototype.classList,Array.from,Document&amp;gated=1'></div>
+			<div class='demo' data-src='/v{{apiversion}}/polyfill.js?features=Element.prototype.classList,Array.from,Document&amp;flags=gated'></div>
 
 			<p>Use the <code>always</code> flag to force a polyfill to be returned regardless of whether the user-agent requires it:</p>
 			<div class='demo' data-src='/v{{apiversion}}/polyfill.js?features=Element.prototype.classList|always,Array.from,Document|always&amp;ua=chrome/37'></div>

--- a/docs/nav.html
+++ b/docs/nav.html
@@ -19,14 +19,14 @@
 				<a href="/v{{apiversion}}/docs/contributing">Contributing</a>
 				{{#ifPrefix pageName "contributing"}}
 				<ul class="o-techdocs-nav o-techdocs-nav--sub">
-					<li{{sectionHighlight pageName "contributing/authoring-polyfills"}}>
-						<a href="/v{{apiversion}}/docs/contributing/authoring-polyfills">Authoring polyfills</a>
+					<li{{sectionHighlight ../pageName "contributing/authoring-polyfills"}}>
+						<a href="/v{{../apiversion}}/docs/contributing/authoring-polyfills">Authoring polyfills</a>
 					</li>
-					<li{{sectionHighlight pageName "contributing/testing"}}>
-						<a href="/v{{apiversion}}/docs/contributing/testing">Testing</a>
+					<li{{sectionHighlight ../pageName "contributing/testing"}}>
+						<a href="/v{{../apiversion}}/docs/contributing/testing">Testing</a>
 					</li>
-					<li{{sectionHighlight pageName "contributing/common-scenarios"}}>
-						<a href="/v{{apiversion}}/docs/contributing/common-scenarios">Common scenarios</a>
+					<li{{sectionHighlight ../pageName "contributing/common-scenarios"}}>
+						<a href="/v{{../apiversion}}/docs/contributing/common-scenarios">Common scenarios</a>
 					</li>
 				</ul>
 				{{/ifPrefix}}

--- a/lib/UA.js
+++ b/lib/UA.js
@@ -138,7 +138,7 @@ function UA(uaString) {
 
 			// Map to different family with per-version mapping
 			} else if (typeof aliases[this.ua.family] === 'object') {
-				for (let semverExpr in aliases[this.ua.family]) {
+				for (let semverExpr in aliases[this.ua.family]) {   // eslint-disable-line prefer-const
 					if (this.ua.satisfies(semverExpr) && Array.isArray(aliases[this.ua.family][semverExpr])) {
 						const a = aliases[this.ua.family][semverExpr];
 						this.ua = new useragent.Agent(a[0], a[1], (a[2] || 0), (a[3] || 0));

--- a/lib/index.js
+++ b/lib/index.js
@@ -91,7 +91,7 @@ function getPolyfills(options) {
 			}
 		});
 		return features;
-	}
+	};
 
 	return Promise.resolve(options.features)
 		.then(resolveAliases)
@@ -116,8 +116,9 @@ function getPolyfillString(options) {
 			if (options.minify) {
 				explainerComment.push('Rerun without minification (remove `.min` from URL path) for verbose metadata');
 			} else {
+				const versionStr = process.env.NODE_ENV === 'production' ? 'v'+appVersion : 'DEVELOPMENT MODE - for live use set NODE_ENV to \'production\'';
 				explainerComment.push(
-					'Polyfill service v' + appVersion,
+					'Polyfill service ' + versionStr,
 					'For detailed credits and licence information see http://github.com/financial-times/polyfill-service.',
 					'',
 					'UA detected: ' + uaDebugName,
@@ -222,7 +223,7 @@ function getPolyfillString(options) {
 				}
 
 				if ('all' in options.features) {
-					let warnText = 'Using the `all` alias with polyfill.io is a very bad idea. In a future version of the service, `all` will deliver the same behaviour as `default`, so we recommend using default instead.';
+					const warnText = 'Using the `all` alias with polyfill.io is a very bad idea. In a future version of the service, `all` will deliver the same behaviour as `default`, so we recommend using default instead.';
 					explainerComment.push('', warnText);
 					builtPolyfillString += "\nconsole.log('"+warnText+"');\n";
 				}

--- a/service/index.js
+++ b/service/index.js
@@ -1,39 +1,31 @@
 'use strict';
 
-const polyfillio = require('../lib');
 const express = require('express');
-const app = express().enable("strict routing");
-const PolyfillSet = require('./PolyfillSet');
 const path = require('path');
 const Raven = require('raven');
-const metrics = require('./metrics');
-const testing = require('./testing');
-const docs = require('./docs');
 const morgan = require('morgan');
 
+const app = express().enable("strict routing");
 const one_day = 60 * 60 * 24;
 const one_week = one_day * 7;
 const one_year = one_day * 365;
-const contentTypes = {".js": 'application/javascript', ".css": 'text/css'};
-
-const serviceInfo = Object.assign({}, require(path.join(__dirname, '../about.json')), {
-	appVersion: require(path.join(__dirname,'../package.json')).version,
-	hostname: require("os").hostname(),
-	dateDeployed: require('fs').statSync(path.join(__dirname,'../package.json')).mtime
-});
 
 let ravenClient;
-
 
 // Log requests
 if (process.env.ENABLE_ACCESS_LOG) {
 	app.use(morgan('method=:method path=":url" request_id=:req[X-Request-ID] status=:status service=:response-time bytes=:res[content-length]'));
 }
 
+process.on('uncaughtException', (err) => {
+  console.log('Caught exception', err);
+});
+
 // Set up Sentry (getsentry.com) to collect JS errors.
 if (process.env.SENTRY_DSN) {
+	const about = require(path.join(__dirname, '../about.json'));
 	ravenClient = new Raven.Client(process.env.SENTRY_DSN, {
-		release: serviceInfo.appVersion
+		release: about.appVersion || 'unknown'
 	});
 	ravenClient.patchGlobal();
 	app.use(Raven.middleware.express.requestHandler(ravenClient));
@@ -41,7 +33,7 @@ if (process.env.SENTRY_DSN) {
 
 // Default response headers
 app.use((req, res, next) => {
-	res.set('Strict-Transport-Security', `max-age=${one_year}`)
+	res.set('Strict-Transport-Security', `max-age=${one_year}`);
 	res.set('Cache-Control', 'public, max-age='+one_week+', stale-while-revalidate='+one_week+', stale-if-error='+one_week);
 	res.set('Timing-Allow-Origin', '*');
 	res.removeHeader("x-powered-by");
@@ -49,152 +41,15 @@ app.use((req, res, next) => {
 });
 
 
-/* Tests */
+/* Routes */
 
-app.use('/test/libs/mocha', express.static(path.join(__dirname, '/../node_modules/mocha')));
-app.use('/test/libs/expect', express.static(path.join(__dirname, '/../node_modules/expect.js/')));
+app.use(require('./routes/api.js'));
+app.use(require('./routes/meta.js'));
+app.use('/test', require('./routes/test.js'));
 
-app.get(/\/test\/director\/?$/, testing.createEndpoint('director', polyfillio));
-app.get(/\/test\/tests\/?$/, testing.createEndpoint('runner', polyfillio));
-
-
-/* Documentation and version routing */
-
-app.get(/^\/(?:v([12])(?:\/(?:docs\/?(?:(.+)\/?)?)?)?)?$/, docs.route);
+app.get(/^\/(?:v([12])(?:\/(?:docs\/?(?:(.+)\/?)?)?)?)?$/, require('./routes/docs'));
 app.use(/^\/v[12]\/assets/, express.static(__dirname + '/../docs/assets'));
 
-
-/* Endpoints for health, application metadata and availability status
- * compliant with FT Origami standard
- * http://origami.ft.com/docs/syntax/web-service-description/ */
-
-// Allow robots to index the site, including polyfill bundles as some sites need polyfills in order to be indexable!
-app.get('/robots.txt', (req, res) => {
-    res.type('text/plain');
-    res.send("User-agent: *\nDisallow:");
-});
-
-app.get(/^\/__about$/, (req, res) => {
-	res.type("application/json;charset=utf-8");
-	res.json(serviceInfo);
-});
-
-// "Good to go" endpoint
-app.get(/^\/__gtg$/, (req, res) => {
-	res.type("text/plain;charset=utf-8");
-	res.set("Cache-Control", "no-cache");
-	res.send("OK");
-});
-
-// Healthcheck
-app.get(/^\/__health$/, (req, res) => {
-	const info = {
-		"schemaVersion": 1,
-		"name": "polyfill-service",
-		"description": "Open API endpoint for retrieving Javascript polyfill libraries based on the user's user agent.  More at http://github.com/Financial-Times/polyfill-service.",
-		"checks": [
-			{
-				"name": "Server is up",
-				"ok": true,
-				"severity": 2,
-				"businessImpact": "Web page rendering may degrade for customers using certain browsers. Dynamic client side behaviour is likely to fail.",
-				"technicalSummary": "Tests that the Node JS process is up.",
-				"panicGuide": "This application consists of Node JS processes on any number of nodes in an environment.  The process must have read permissions on files within its deployment.",
-				"checkOutput": "None",
-				"lastUpdated": new Date().toISOString()
-			}
-		],
-	};
-
-	res.set('Cache-Control', 'no-cache');
-	res.type('application/json;charset=utf-8');
-	res.json(info);
-});
-
-
-/* API endpoints */
-
-app.get(/^\/v1\/(.*)/, (req, res) => {
-
-	const qs = Object.keys(req.query).reduce((out, key) => {
-		if (key !== 'libVersion' && key !== 'gated') {
-			out.push(key+'='+encodeURIComponent(req.query[key]));
-		}
-		return out;
-	}, []).join('&');
-	const redirPath = '/v2/' + req.params[0].replace(/[^\w\/\.\+\:]/g, '') + (qs.length ? '?'+qs : '');
-
-	res.status(301);
-	res.set('Location', redirPath);
-	res.set('Deprecation-Notice', 'API version 1 has been decommissioned - see the body of this response for more information.');
-	res.send('API version 1 has been decommissioned. Your request is being redirected to v2.  The `libVersion` and `gated` query string parameters are no longer supported and if present have been removed from your request.\n\nA deprecation period for v1 existed between August and December 2015, during which time v1 requests were honoured but a deprecation warning was added to output.');
-});
-
-app.get(/^\/v2\/polyfill(\.\w+)(\.\w+)?/, (req, res) => {
-	metrics.counter('hits').inc();
-	const respTimeTimer = metrics.timer('respTime').start();
-	const firstParameter = req.params[0].toLowerCase();
-	const minified = firstParameter === '.min';
-	const fileExtension = req.params[1] ? req.params[1].toLowerCase() : firstParameter;
-	const uaString = (typeof req.query.ua === 'string' && req.query.ua) || req.header('user-agent');
-	const flags = (typeof req.query.flags === 'string') ? req.query.flags.split(',') : [];
-	const warnings = [];
-
-	// Currently don't support CSS
-	if (fileExtension !== '.js') {
-		res.status(404);
-		res.set('Content-Type', 'text/plain;charset=utf-8');
-		res.send('/* Type not supported.  Only .js is supported at the moment */');
-		return;
-	}
-
-	const polyfills = PolyfillSet.fromQueryParam(req.query.features, flags);
-
-	// If inbound request did not specify UA on the query string, the cache key must use the HTTP header
-	if (!req.query.ua) {
-		res.set('Vary', 'User-Agent');
-	}
-
-	const params = {
-		features: polyfills.get(),
-		excludes: (req.query.excludes && req.query.excludes.split(',')) || [],
-		minify: minified
-	};
-	if (req.query.unknown) {
-		params.unknown = req.query.unknown;
-	}
-	if (uaString) {
-		params.uaString = uaString;
-		metrics.counter('useragentcount.'+polyfillio.normalizeUserAgent(uaString).replace(/^(.*?)\/(\d+)(\..*)?$/, '$1.$2')).inc();
-	}
-
-	polyfillio.getPolyfillString(params).then(op => {
-		if (warnings.length) {
-			op = '/* WARNINGS:\n\n- ' + warnings.join('\n- ') + '\n\n*/\n\n' + op;
-		}
-		if (req.query.callback && req.query.callback.match(/^[\w\.]+$/)) {
-			op += "\ntypeof "+req.query.callback+"==='function' && "+req.query.callback+"();";
-		}
-		res.set('Content-Type', contentTypes[fileExtension]+';charset=utf-8');
-		res.set('Access-Control-Allow-Origin', '*');
-		res.send(op);
-		respTimeTimer.end();
-	});
-
-});
-
-app.get("/v2/normalizeUa", (req, res) => {
-
-	if (req.query.ua) {
-		res.status(200);
-		res.set('Cache-Control', 'public, max-age='+one_year+', stale-if-error='+(one_year+one_week));
-		res.set('Normalized-User-Agent', encodeURIComponent(polyfillio.normalizeUserAgent(req.query.ua)));
-		res.send();
-	} else {
-		res.status(400);
-		res.send('ua query param required');
-	}
-});
 
 if (process.env.SENTRY_DSN) {
 	app.use(Raven.middleware.express.errorHandler(ravenClient));

--- a/service/routes/api.js
+++ b/service/routes/api.js
@@ -1,0 +1,98 @@
+/* Main endpoints for the Polyfill service public API */
+
+'use strict';
+
+const polyfillio = require('../../lib');
+const PolyfillSet = require('../PolyfillSet');
+const metrics = require('../metrics');
+const express = require('express');
+
+const router = express.Router();  // eslint-disable-line new-cap
+const contentTypes = {".js": 'application/javascript', ".css": 'text/css'};
+const one_day = 60 * 60 * 24;
+const one_week = one_day * 7;
+const one_year = one_day * 365;
+
+router.get(/^\/v1\/(.*)/, (req, res) => {
+
+	const qs = Object.keys(req.query).reduce((out, key) => {
+		if (key !== 'libVersion' && key !== 'gated') {
+			out.push(key+'='+encodeURIComponent(req.query[key]));
+		}
+		return out;
+	}, []).join('&');
+	const redirPath = '/v2/' + req.params[0].replace(/[^\w\/\.\+\:]/g, '') + (qs.length ? '?'+qs : '');
+
+	res.status(301);
+	res.set('Location', redirPath);
+	res.set('Deprecation-Notice', 'API version 1 has been decommissioned - see the body of this response for more information.');
+	res.send('API version 1 has been decommissioned. Your request is being redirected to v2.  The `libVersion` and `gated` query string parameters are no longer supported and if present have been removed from your request.\n\nA deprecation period for v1 existed between August and December 2015, during which time v1 requests were honoured but a deprecation warning was added to output.');
+});
+
+router.get(/^\/v2\/polyfill(\.\w+)(\.\w+)?/, (req, res) => {
+	metrics.counter('hits').inc();
+	const respTimeTimer = metrics.timer('respTime').start();
+	const firstParameter = req.params[0].toLowerCase();
+	const minified = firstParameter === '.min';
+	const fileExtension = req.params[1] ? req.params[1].toLowerCase() : firstParameter;
+	const uaString = (typeof req.query.ua === 'string' && req.query.ua) || req.header('user-agent');
+	const flags = (typeof req.query.flags === 'string') ? req.query.flags.split(',') : [];
+	const warnings = [];
+
+	// Currently don't support CSS
+	if (fileExtension !== '.js') {
+		res.status(404);
+		res.set('Content-Type', 'text/plain;charset=utf-8');
+		res.send('/* Type not supported.  Only .js is supported at the moment */');
+		return;
+	}
+
+	const polyfills = PolyfillSet.fromQueryParam(req.query.features, flags);
+
+	// If inbound request did not specify UA on the query string, the cache key must use the HTTP header
+	if (!req.query.ua) {
+		res.set('Vary', 'User-Agent');
+	}
+
+	const params = {
+		features: polyfills.get(),
+		excludes: (req.query.excludes && req.query.excludes.split(',')) || [],
+		minify: minified
+	};
+	if (req.query.unknown) {
+		params.unknown = req.query.unknown;
+	}
+	if (uaString) {
+		params.uaString = uaString;
+		metrics.counter('useragentcount.'+polyfillio.normalizeUserAgent(uaString).replace(/^(.*?)\/(\d+)(\..*)?$/, '$1.$2')).inc();
+	}
+
+	polyfillio.getPolyfillString(params).then(op => {
+		if (warnings.length) {
+			op = '/* WARNINGS:\n\n- ' + warnings.join('\n- ') + '\n\n*/\n\n' + op;
+		}
+		if (req.query.callback && req.query.callback.match(/^[\w\.]+$/)) {
+			op += "\ntypeof "+req.query.callback+"==='function' && "+req.query.callback+"();";
+		}
+		res.set('Content-Type', contentTypes[fileExtension]+';charset=utf-8');
+		res.set('Access-Control-Allow-Origin', '*');
+		res.send(op);
+		respTimeTimer.end();
+	});
+
+});
+
+router.get("/v2/normalizeUa", (req, res) => {
+
+	if (req.query.ua) {
+		res.status(200);
+		res.set('Cache-Control', 'public, max-age='+one_year+', stale-if-error='+(one_year+one_week));
+		res.set('Normalized-User-Agent', encodeURIComponent(polyfillio.normalizeUserAgent(req.query.ua)));
+		res.send();
+	} else {
+		res.status(400);
+		res.send('ua query param required');
+	}
+});
+
+module.exports = router;

--- a/service/routes/meta.js
+++ b/service/routes/meta.js
@@ -1,0 +1,61 @@
+/* Endpoints for health, application metadata and availability status */
+
+'use strict';
+
+const express = require('express');
+const path = require('path');
+
+const router = express.Router();  // eslint-disable-line new-cap
+
+const serviceInfo = Object.assign({}, require(path.join(__dirname, '../../about.json')), {
+	appVersion: require(path.join(__dirname,'../../package.json')).version,
+	hostname: require("os").hostname(),
+	dateDeployed: require('fs').statSync(path.join(__dirname,'../../package.json')).mtime
+});
+
+// Allow robots to index the site, including polyfill bundles,
+// as some sites need polyfills in order to be indexable!
+router.get('/robots.txt', (req, res) => {
+    res.type('text/plain');
+    res.send("User-agent: *\nDisallow:");
+});
+
+// Service description metadata
+router.get('/__about', (req, res) => {
+	res.type("application/json;charset=utf-8");
+	res.json(serviceInfo);
+});
+
+// "Good to go" endpoint
+router.get('/__gtg', (req, res) => {
+	res.type("text/plain;charset=utf-8");
+	res.set("Cache-Control", "no-cache");
+	res.send("OK");
+});
+
+// Healthcheck
+router.get('/__health', (req, res) => {
+	const info = {
+		"schemaVersion": 1,
+		"name": "polyfill-service",
+		"description": "Open API endpoint for retrieving Javascript polyfill libraries based on the user's user agent.  More at http://github.com/Financial-Times/polyfill-service.",
+		"checks": [
+			{
+				"name": "Server is up",
+				"ok": true,
+				"severity": 2,
+				"businessImpact": "Web page rendering may degrade for customers using certain browsers. Dynamic client side behaviour is likely to fail.",
+				"technicalSummary": "Tests that the Node JS process is up.",
+				"panicGuide": "This application consists of Node JS processes on any number of nodes in an environment.  The process must have read permissions on files within its deployment.",
+				"checkOutput": "None",
+				"lastUpdated": new Date().toISOString()
+			}
+		],
+	};
+
+	res.set('Cache-Control', 'no-cache');
+	res.type('application/json;charset=utf-8');
+	res.json(info);
+});
+
+module.exports = router;

--- a/service/routes/test.js
+++ b/service/routes/test.js
@@ -1,7 +1,13 @@
+/* Endpoints for running the test framework */
+
 'use strict';
 
+const polyfillio = require('../../lib');
+const express = require('express');
 const fs = require('fs');
 const path = require('path');
+
+const router = express.Router();  // eslint-disable-line new-cap
 
 /**
  * Modes:
@@ -11,7 +17,7 @@ const path = require('path');
  */
 
 function createEndpoint(type, polyfillio) {
-	const templateSrc = fs.readFileSync(path.join(__dirname, '/../test/browser/', type + '.html.handlebars'), {encoding: 'UTF-8'});
+	const templateSrc = fs.readFileSync(path.join(__dirname, '/../../test/browser/', type + '.html.handlebars'), {encoding: 'UTF-8'});
 	const template = require('handlebars').compile(templateSrc);
 
 	return (req, res) => {
@@ -41,7 +47,7 @@ function createEndpoint(type, polyfillio) {
 
 				// Eliminate those that are not testable or not public
 				const polyfilldata = Object.keys(polyfillSet).reduce((acc, featureName) => {
-					const baseDir = path.join(__dirname, '../polyfills');
+					const baseDir = path.join(__dirname, '../../polyfills');
 					const config = polyfillSet[featureName];
 					const detectFile = path.join(baseDir, config.baseDir, '/detect.js');
 					const testFile = path.join(baseDir, config.baseDir, '/tests.js');
@@ -77,6 +83,10 @@ function createEndpoint(type, polyfillio) {
 	};
 }
 
-module.exports = {
-	createEndpoint: createEndpoint
-};
+router.use('/libs/mocha', express.static(path.join(__dirname, '/../node_modules/mocha')));
+router.use('/libs/expect', express.static(path.join(__dirname, '/../node_modules/expect.js/')));
+
+router.get(/\/director\/?$/, createEndpoint('director', polyfillio));
+router.get(/\/tests?\/?$/, createEndpoint('runner', polyfillio));
+
+module.exports = router;

--- a/service/routes/test.js
+++ b/service/routes/test.js
@@ -82,7 +82,7 @@ function createEndpoint(type, polyfillio) {
 		;
 	};
 }
-console.log(require.resolve('mocha'));
+
 router.use('/libs/mocha', express.static(path.dirname(require.resolve('mocha'))));
 router.use('/libs/expect', express.static(path.dirname(require.resolve('expect.js'))));
 

--- a/service/routes/test.js
+++ b/service/routes/test.js
@@ -83,8 +83,8 @@ function createEndpoint(type, polyfillio) {
 	};
 }
 
-router.use('/libs/mocha', express.static(path.join(__dirname, '/../node_modules/mocha')));
-router.use('/libs/expect', express.static(path.join(__dirname, '/../node_modules/expect.js/')));
+router.use('/libs/mocha', express.static(path.join(__dirname, '/../../node_modules/mocha')));
+router.use('/libs/expect', express.static(path.join(__dirname, '/../../node_modules/expect.js/')));
 
 router.get(/\/director\/?$/, createEndpoint('director', polyfillio));
 router.get(/\/tests?\/?$/, createEndpoint('runner', polyfillio));

--- a/service/routes/test.js
+++ b/service/routes/test.js
@@ -82,9 +82,9 @@ function createEndpoint(type, polyfillio) {
 		;
 	};
 }
-
-router.use('/libs/mocha', express.static(path.join(__dirname, '/../../node_modules/mocha')));
-router.use('/libs/expect', express.static(path.join(__dirname, '/../../node_modules/expect.js/')));
+console.log(require.resolve('mocha'));
+router.use('/libs/mocha', express.static(path.dirname(require.resolve('mocha'))));
+router.use('/libs/expect', express.static(path.dirname(require.resolve('expect.js'))));
 
 router.get(/\/director\/?$/, createEndpoint('director', polyfillio));
 router.get(/\/tests?\/?$/, createEndpoint('runner', polyfillio));

--- a/tasks/deployvcl.js
+++ b/tasks/deployvcl.js
@@ -37,16 +37,14 @@ module.exports = function(grunt) {
 		const fastly = require('fastly')(process.env.FASTLY_API_KEY, encodeURIComponent(options.serviceId));
 		let newVersion;
 
-		let deploy =
-			fastly.getServices()
+		fastly.getServices()
 			.then(services => {
 				grunt.log.writeln('Loading Fastly service list');
-				var service = services.filter(svc => svc.id === options.serviceId);
-				if (!service.length) throw new Error('Service not found.  Check options.service matches a valid service on Fastly that is accessible by your FASTLY_API_KEY');
-				service = service[0];
+				const service = services.find(svc => svc.id === options.serviceId);
+				if (!service) throw new Error('Service not found.  Check options.service matches a valid service on Fastly that is accessible by your FASTLY_API_KEY');
 				grunt.log.writeln('Cloning active version %s of %s', service.version, service.name);
 				return fastly.cloneVersion(service.version).then(res => {
-					newVersion = res.number
+					newVersion = res.number;
 					grunt.log.writeln("Created version %d", newVersion);
 				});
 			})
@@ -54,7 +52,7 @@ module.exports = function(grunt) {
 			.then(() => fastly.getVcl(newVersion))
 			.then(vclsList => {
 				grunt.log.writeln('Deleting existing VCLs');
-				return Promise.all(vclsList.map(vcl => fastly.deleteVcl(newVersion, vcl.name)))
+				return Promise.all(vclsList.map(vcl => fastly.deleteVcl(newVersion, vcl.name)));
 			})
 
 			.then(() => {
@@ -67,7 +65,7 @@ module.exports = function(grunt) {
 
 			.then(() => {
 				grunt.log.writeln('Setting the VCL as main');
-				return fastly.setVclAsMain(newVersion, options.vclName)
+				return fastly.setVclAsMain(newVersion, options.vclName);
 			})
 
 			// Validate the VCL

--- a/tasks/service.js
+++ b/tasks/service.js
@@ -43,17 +43,17 @@ module.exports = function(grunt) {
 				}
 			}
 			const pid = parseInt(fs.readFileSync(data.pidFile));
-			grunt.log.writeln("Service " + target + "(pid=" + pid + ") is killing ");
+			grunt.log.writeln("Service " + target + " (pid=" + pid + ") is killing");
 			try {
 				process.kill(pid);
 			} catch (_error) {
-				grunt.log.writeln("Service " + target + "(pid=" + pid + ") does not exists.");
+				grunt.log.writeln("Service " + target + " (pid=" + pid + ") does not exists.");
 				return callback();
 			}
 			return loopUntil(function() {
 				return !existProcess(pid);
 			}, function() {
-				grunt.log.writeln("Service " + target + "(pid=" + pid + ") is killed.");
+				grunt.log.writeln("Service " + target + " (pid=" + pid + ") is killed.");
 				return callback();
 			});
 		}
@@ -100,12 +100,12 @@ module.exports = function(grunt) {
 			grunt.log.writeln("Service " + target + " is starting.");
 			if (proc.stdout) {
 				proc.stdout.on('data', function(d) {
-			if (!hasStarted) {
-				buffer += d.toString();
-				if (buffer.indexOf(" started") >= 0) {
-					hasStarted = true;
-				}
-			}
+					if (!hasStarted) {
+						buffer += d.toString();
+						if (buffer.indexOf(" started") >= 0) {
+							hasStarted = true;
+						}
+					}
 					return grunt.log.writeln(d);
 				});
 			}
@@ -116,18 +116,20 @@ module.exports = function(grunt) {
 			}
 			if (proc) {
 				grunt.log.writeln("Service Child PID = " + proc.pid);
-				proc.on('close', function(code) {
-					grunt.log.writeln('child process exited with code ', code);
+				proc.on('close', function(err, code) {
+					grunt.log.writeln('Child process exited, code:', code);
 					return closed();
 				});
 				proc.on('error', function() {
 					return grunt.log.error('error', arguments);
 				});
-				proc.on('exit', function() {
-					return grunt.log.writeln('exit', arguments);
+				proc.on('exit', function(err, code) {
+					// Enable for debug if desired
+					//return grunt.log.writeln('exit', arguments);
 				});
 				proc.on('close', function() {
-					return grunt.log.writeln('close', arguments);
+					// Enable for debug if desired
+					//return grunt.log.writeln('close', arguments);
 				});
 				proc.on('disconnect', function() {
 					return grunt.log.writeln('disconnect', arguments);

--- a/tasks/service.js
+++ b/tasks/service.js
@@ -62,7 +62,6 @@ module.exports = function(grunt) {
 			let buffer = "";
 			let hasStarted = false;
 			let pid;
-			let proc;
 			let command;
 			let args;
 
@@ -97,7 +96,7 @@ module.exports = function(grunt) {
 			} else {
 				args = data.args;
 			}
-			proc = child_process.spawn(command, args, options);
+			const proc = child_process.spawn(command, args, options);
 			grunt.log.writeln("Service " + target + " is starting.");
 			if (proc.stdout) {
 				proc.stdout.on('data', function(d) {

--- a/test/node/lib/test_index.js
+++ b/test/node/lib/test_index.js
@@ -126,7 +126,6 @@ describe("polyfillio", function() {
 					excludes: ["Promise", "non-existent-feature"],
 					uaString: 'chrome/30'
 				}).then(function(polyfillSet) {
-					console.log(polyfillSet, 2);
 					assert.deepEqual(polyfillSet, {
 						fetch: { flags: [] }
 					});


### PR DESCRIPTION
As a precursor to implementing #107 (self-learning configs) which will require new route endpoints, I wanted to refactor to separate the various types of endpoint we already have into modules since the main index.js is now getting quite large.

This update also includes a few miscellaneous fixes:
- Linting
- Fix navigation links to subsections of the contributors guide
- Spelling mistake in docs
- Clearer badging of dev mode output so that previous release number does not continue to be shown after subsequent commits
- Remove some debug
- Add a handler for uncaughtExceptions which otherwise print unhelpful output in more recent versions of Node
