### PR TITLE
Switch calls from buildsources to build

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -60,7 +60,7 @@ module.exports = function(grunt) {
 			},
 			polyfills: {
 				files: ['polyfills/**/*.js', 'polyfills/**/config.json', '!polyfills/__dist/**'],
-				tasks: ['service:polyfillservice:stop', 'buildsources', 'service:polyfillservice:start']
+				tasks: ['service:polyfillservice:stop', 'build', 'service:polyfillservice:start']
 			}
 		},
 		"service": {
@@ -95,7 +95,7 @@ module.exports = function(grunt) {
 	grunt.loadNpmTasks('grunt-simple-mocha');
 
 	grunt.registerTask("test", [
-		"buildsources",
+		"build",
 		"simplemocha",
 		"service",
 		"saucelabs:quick",
@@ -103,7 +103,7 @@ module.exports = function(grunt) {
 	]);
 
 	grunt.registerTask("compatgen", [
-		"buildsources",
+		"build",
 		"simplemocha",
 		"service",
 		"saucelabs:compat",
@@ -112,7 +112,7 @@ module.exports = function(grunt) {
 	]);
 
 	grunt.registerTask("ci", [
-		"buildsources",
+		"build",
 		"simplemocha",
 		"service",
 		"saucelabs:ci",

--- a/lib/sources.js
+++ b/lib/sources.js
@@ -22,7 +22,7 @@ try {
 	polyfillCount = features.length;
 	console.log("Found "+polyfillCount+" polyfills");
 } catch(e) {
-	throw Error("No polyfill sources found.  Run `grunt buildsources` to build them");
+	throw Error("No polyfill sources found.  Run `grunt build` to build them");
 }
 
 function Collection() {


### PR DESCRIPTION
This will run a `clean` task before running `buildsources`, ensuring that the built folder contains files only created by the latest `buildsources` execution.
