### PR TITLE
Failing Array.from test (IE)

### DIFF
--- a/polyfills/Array/from/tests.js
+++ b/polyfills/Array/from/tests.js
@@ -96,6 +96,7 @@ describe('returns an array with', function () {
 	it('objects with in-range lengths', function () {
 		expect(Array.from({ length: 0 }).length).to.be(0);
 		expect(Array.from({ length: 3 }).length).to.be(3);
+		expect(Array.from({ length: 3 })).to.eql([undefined, undefined, undefined]);
 		expect(Array.from({ length: '+3' }).length).to.be(3);
 		// expect(Array.from({ length: Infinity }).length).to.be();
 	});


### PR DESCRIPTION
In IE 11, `Array.from({ length: x })` doesn't produce a valid array. Test included.
