### PR TITLE
Added callback type check in addEventListener to avoid exceptions

### DIFF
--- a/polyfills/Event/polyfill.js
+++ b/polyfills/Event/polyfill.js
@@ -118,7 +118,7 @@
 						if (index in events) {
 							eventElement = events[index];
 
-							if (indexOf(list, eventElement) !== -1) {
+							if (indexOf(list, eventElement) !== -1 && typeof eventElement === 'function') {
 								eventElement.call(element, event);
 							}
 						}


### PR DESCRIPTION
I faced the same issue described in the [Issue 467](https://github.com/Financial-Times/polyfill-service/issues/467). Looks like it is common.
