### PR TITLE
Add browsers to IntersectionObserver config

### DIFF
--- a/polyfills/IntersectionObserver/config.json
+++ b/polyfills/IntersectionObserver/config.json
@@ -2,12 +2,16 @@
 	"aliases": [
 	],
 	"browsers": {
-		"firefox": "*",
-		"safari": "*",
 		"android": "*",
-		"opera": "*",
+		"bb": "*",
 		"chrome": "<51",
-		"ie": "*"
+		"firefox": "*",
+		"firefox_mob": "*",
+		"ie": "*",
+		"ie_mob": "*",
+		"ios_saf": "*",
+		"opera": "*",
+		"safari": "*"
 	},
 	"dependencies": [
 		"getComputedStyle",


### PR DESCRIPTION
Based on https://github.com/WICG/IntersectionObserver/blob/gh-pages/polyfill/README.md#browser-support
Also, tested in
- BB: 7, 10
- Samsung Galaxy Note 3: Opera mini 17, Firefox mob47
- Windows Phone 8.0
