### PR TITLE
Add browsers to IntersectionObserver config

### DIFF
--- a/polyfills/IntersectionObserver/config.json
+++ b/polyfills/IntersectionObserver/config.json
@@ -9,7 +9,7 @@
 		"firefox_mob": "47 - *",
 		"ie": "7 - *",
 		"ie_mob": "11 - *",
-		"ios_saf": "9 - *",
+		"ios_saf": "7 - *",
 		"op_mini": "17 - *",
 		"opera": "*",
 		"safari": "6 - *"

--- a/polyfills/IntersectionObserver/config.json
+++ b/polyfills/IntersectionObserver/config.json
@@ -2,16 +2,17 @@
 	"aliases": [
 	],
 	"browsers": {
-		"android": "*",
-		"bb": "*",
+		"android": "4.4 - *",
+		"bb": "7 - 10",
 		"chrome": "<51",
 		"firefox": "*",
-		"firefox_mob": "*",
-		"ie": "*",
-		"ie_mob": "*",
-		"ios_saf": "*",
+		"firefox_mob": "47 - *",
+		"ie": "7 - *",
+		"ie_mob": "11 - *",
+		"ios_saf": "9 - *",
+		"op_mini": "17 - *",
 		"opera": "*",
-		"safari": "*"
+		"safari": "6 - *"
 	},
 	"dependencies": [
 		"getComputedStyle",

--- a/polyfills/IntersectionObserver/config.json
+++ b/polyfills/IntersectionObserver/config.json
@@ -2,12 +2,16 @@
 	"aliases": [
 	],
 	"browsers": {
-		"firefox": "*",
-		"safari": "*",
 		"android": "*",
-		"opera": "*",
+		"bb": "*",
 		"chrome": "<51",
-		"ie": "*"
+		"firefox": "*",
+		"firefox_mob": "*",
+		"ie": "*",
+		"ie_mob": "*",
+		"ios_saf": "*",
+		"opera": "*",
+		"safari": "*"
 	},
 	"dependencies": [
 		"getComputedStyle",


### PR DESCRIPTION
Based on https://github.com/WICG/IntersectionObserver/blob/gh-pages/polyfill/README.md#browser-support
Also, tested in
- BB: 7, 10
- Samsung Galaxy Note 3: Opera mini 17, Firefox mob 47
- Windows Phone 8.0
- iOS 7 & 8
