### PR TITLE
Updated localStorage detect.js for Safari private browsing mode

### DIFF
--- a/polyfills/localStorage/detect.js
+++ b/polyfills/localStorage/detect.js
@@ -1,1 +1,1 @@
-'localStorage' in this
+try { localStorage.setItem('localStorage', true); localStorage.removeItem('localStorage'); true; } catch (e) { false; }


### PR DESCRIPTION
Hi,

On Safari private browsing Polyfill detect the `localStorage` availability with `'localStorage' in this` because `localStorage` exist and is an object. But Safari private browsing limit the localStorage session to 0Mb and when try to set a variable will show an error about the limit size.

With this changes Polyfill detects the Safari private browsing localStorage support.

Many thanks.
