### PR TITLE
Add aliasing for FB in-app browser on iOS, fixes #561

### DIFF
--- a/lib/UA.js
+++ b/lib/UA.js
@@ -79,6 +79,11 @@ const aliases = {
 	"iphone": "ios_saf",
 	"iphone simulator": "ios_saf",
 	"mobile safari uiwebview": "ios_saf",
+	"facebook": function(ua) {
+		if (ua.os.family === 'iOS') {
+			return {family:'ios_saf', major: ua.os.major, minor:ua.os.minor};
+		}
+	},
 
 	"phantomjs": ["safari", 5],
 
@@ -127,8 +132,12 @@ function UA(uaString) {
 		this.ua.family = this.ua.family.toLowerCase();
 		if (aliases[this.ua.family]) {
 
+			// Custom aliasing
+			if (typeof aliases[this.ua.family] === 'function') {
+				Object.assign(this.ua, aliases[this.ua.family](this.ua));
+
 			// Map to different family, use same version scheme
-			if (typeof aliases[this.ua.family] === 'string') {
+			} if (typeof aliases[this.ua.family] === 'string') {
 				this.ua.family = aliases[this.ua.family];
 
 			// Map to different family with constant version

--- a/lib/UA.js
+++ b/lib/UA.js
@@ -137,7 +137,7 @@ function UA(uaString) {
 				Object.assign(this.ua, aliases[this.ua.family](this.ua));
 
 			// Map to different family, use same version scheme
-			} if (typeof aliases[this.ua.family] === 'string') {
+			} else if (typeof aliases[this.ua.family] === 'string') {
 				this.ua.family = aliases[this.ua.family];
 
 			// Map to different family with constant version


### PR DESCRIPTION
Changes identification of FB iOS browser from facebook/80.0.0 to ios_saf/9.3.0.

Note that Android already spawns the standard OS browser from the Facebook app.
