### PR TITLE
Enable Object.create(Function.prototype) to work

### DIFF
--- a/polyfills/Object/create/polyfill.js
+++ b/polyfills/Object/create/polyfill.js
@@ -1,6 +1,11 @@
-Object.create = function create(prototype, properties) {
+(function(){
+	function isPrimitive(o) {
+		return o == null || (typeof o !== 'object' && typeof o !== 'function');
+  };
+
+	Object.create = function create(prototype, properties) {
 	/* jshint evil: true */
-    if (typeof prototype !== 'object' && prototype !== null) {
+    if (prototype !== null && isPrimitive(prototype)) {
       throw TypeError('Object prototype may only be an Object or null');
     }
 
@@ -15,3 +20,4 @@ Object.create = function create(prototype, properties) {
 
 	return object;
 };
+}());

--- a/polyfills/Object/create/tests.js
+++ b/polyfills/Object/create/tests.js
@@ -38,6 +38,15 @@ it("Should throw a TypeError if called with a number primitive", function() {
 	expect(function() { Object.create(100); }).to.throwException(assertTypeError);
 });
 
+it("Should not throw a TypeError if called with Function objects", function() {
+	expect(function() {
+		Object.create(Function);
+	}).to.not.throwException();
+	expect(function() {
+		Object.create(Function.prototype);
+	}).to.not.throwException();
+});
+
 it("Should return an instance of Object", function() {
 	expect(Object.create({})).to.be.an(Object);
 });


### PR DESCRIPTION
This throws with our polyfill but works in modern browsers and in es5-shim. This PR enables it to work with our polyfill.
