### PR TITLE
Minified reserved words

### DIFF
--- a/tasks/buildsources.js
+++ b/tasks/buildsources.js
@@ -93,7 +93,12 @@ module.exports = function(grunt) {
 					config.minSource = config.rawSource;
 				} else {
 					validateSource(config.rawSource, featureName+' from '+polyfillSourcePath);
-					config.minSource = uglify.minify(config.rawSource, {fromString: true}).code;
+					config.minSource = uglify.minify(config.rawSource, {
+						fromString: true,
+						compress: { screw_ie8: false},
+						mangle:   { screw_ie8: false},
+						output:   { screw_ie8: false, beautify: false }
+					}).code;
 				}
 
 				if (fs.existsSync(detectPath)) {

--- a/test/browser/runner.html.handlebars
+++ b/test/browser/runner.html.handlebars
@@ -16,7 +16,7 @@
 
 	{{#loadPolyfill}}
 		<!-- Code under test -->
-		<script src='/v2/polyfill.min.js?flags=gated{{#forceAlways}},always{{/forceAlways}}&amp;features={{#features}}{{feature}},{{/features}}'></script>
+		<script src='/v2/polyfill.js?flags=gated{{#forceAlways}},always{{/forceAlways}}&amp;features={{#features}}{{feature}},{{/features}}'></script>
 	{{/loadPolyfill}}
 
 	<!-- Tests -->

--- a/test/browser/runner.html.handlebars
+++ b/test/browser/runner.html.handlebars
@@ -16,7 +16,7 @@
 
 	{{#loadPolyfill}}
 		<!-- Code under test -->
-		<script src='/v2/polyfill.js?flags=gated{{#forceAlways}},always{{/forceAlways}}&amp;features={{#features}}{{feature}},{{/features}}'></script>
+		<script src='/v2/polyfill.min.js?flags=gated{{#forceAlways}},always{{/forceAlways}}&amp;features={{#features}}{{feature}},{{/features}}'></script>
 	{{/loadPolyfill}}
 
 	<!-- Tests -->


### PR DESCRIPTION
It seems Uglify-js 2.7.0 began to set `screw_ie8` to true by default which broke some of our minified polyfills in IE8.
This PR sets `screw_ie8` to false to enable IE8 support in all polyfills once again.

Resolves https://github.com/Financial-Times/polyfill-service/issues/778
