### PR TITLE
Use relative path to fix clean task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -7,8 +7,8 @@ module.exports = function(grunt) {
 
 	grunt.initConfig({
 		"clean": {
-			dist: [path.resolve(__dirname, '/polyfills/__dist')],
-			testResults: [path.resolve(__dirname, '/test/results')]
+			dist: [path.resolve(__dirname, './polyfills/__dist')],
+			testResults: [path.resolve(__dirname, './test/results')]
 		},
 		"simplemocha": {
 			options: {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -7,8 +7,8 @@ module.exports = function(grunt) {
 
 	grunt.initConfig({
 		"clean": {
-			dist: [path.resolve(__dirname, './polyfills/__dist')],
-			testResults: [path.resolve(__dirname, './test/results')]
+			dist: [path.resolve(__dirname, 'polyfills/__dist')],
+			testResults: [path.resolve(__dirname, 'test/results')]
 		},
 		"simplemocha": {
 			options: {


### PR DESCRIPTION
Fixes an issue where the `grunt clean` task was not cleaning the folders as it was trying to clean folders from the root of the filesystem (`/polyfills/__dist/` & `/test/results`) rather than relative from project.

<details><summary>

Before:</summary>



``` bash
❯ ./node_modules/.bin/grunt clean
/polyfills/__dist /test/results
Running "clean:dist" (clean) task
>> 0 paths cleaned.

Running "clean:testResults" (clean) task
>> 0 paths cleaned.

Done, without errors.
```

</details>
<details><summary>

After:</summary>



``` bash
~/Code/work/origami/polyfill-service clean-tests*
❯ ./node_modules/.bin/grunt clean
/Users/jake.champion/Code/work/origami/polyfill-service/polyfills/__dist /Users/jake.champion/Code/work/origami/polyfill-service/test/results
Running "clean:dist" (clean) task
>> 1 path cleaned.

Running "clean:testResults" (clean) task
>> 1 path cleaned.

Done, without errors.
```

</details>
