### PR TITLE
Sort querystring using boltsort for better caching

### DIFF
--- a/fastly-config.vcl
+++ b/fastly-config.vcl
@@ -15,6 +15,7 @@ sub vcl_recv {
 	}
 
 	if (req.url ~ "^/v2/polyfill\." && req.url !~ "[\?\&]ua=") {
+		set req.http.X-Orig-URL = req.url;
 		set req.url = "/v2/normalizeUa?ua=" urlencode(req.http.User-Agent);
 	}
 

--- a/fastly-config.vcl
+++ b/fastly-config.vcl
@@ -1,3 +1,5 @@
+import boltsort;
+
 sub vcl_recv {
 #FASTLY recv
 	if ( req.request == "FASTLYPURGE" ) {
@@ -13,13 +15,14 @@ sub vcl_recv {
 	}
 
 	if (req.url ~ "^/v2/polyfill\." && req.url !~ "[\?\&]ua=") {
-		set req.http.X-Orig-URL = req.url;
 		set req.url = "/v2/normalizeUa?ua=" urlencode(req.http.User-Agent);
 	}
 
 	if (req.url ~ "^/v2/recordRumData") {
 		error 204 "No Content";
 	}
+
+	set req.url = boltsort.sort(req.url);
 
 	return(lookup);
 }


### PR DESCRIPTION
_Disclaimer: Everytime I touch VCL I have to read through the documentation on what each function is meant to do._

This pull request takes the advice given in #803 to use `boltsort` for a higher caching hit ratio.

I've used the `boltsort` function inside the `vcl_recv` function to ensure every url in our cache has their querystring normalised.

I believe this is the correct location to add it as every URL except for `^/v2/recordRumData` should hit this code path.

I'm not entirely sure how to test this change except to deploy it to qa.polyfill.io and test it manually.
