### PR TITLE
Update Element.prototype.after et al. config

### DIFF
--- a/polyfills/Element/prototype/after/config.json
+++ b/polyfills/Element/prototype/after/config.json
@@ -9,7 +9,7 @@
 		"android": "*",
 		"bb": "*",
 		"chrome": "*",
-		"firefox": "3.6 - *",
+		"firefox": "<49",
 		"ios_chr": "*",
 		"ios_saf": "*",
 		"ie": "6 - *",
@@ -17,7 +17,7 @@
 		"opera": "*",
 		"op_mini": "*",
 		"safari": "4 - *",
-		"firefox_mob": "3.6 - *",
+		"firefox_mob": "<49",
 		"samsung_mob": "*"
 	},
 	"dependencies": [

--- a/polyfills/Element/prototype/append/config.json
+++ b/polyfills/Element/prototype/append/config.json
@@ -9,7 +9,7 @@
 		"android": "*",
 		"bb": "*",
 		"chrome": "*",
-		"firefox": "3.6 - *",
+		"firefox": "<49",
 		"ios_chr": "*",
 		"ios_saf": "*",
 		"ie": "6 - *",
@@ -17,7 +17,7 @@
 		"opera": "*",
 		"op_mini": "*",
 		"safari": "4 - *",
-		"firefox_mob": "3.6 - *",
+		"firefox_mob": "<49",
 		"samsung_mob": "*"
 	},
 	"dependencies": [

--- a/polyfills/Element/prototype/before/config.json
+++ b/polyfills/Element/prototype/before/config.json
@@ -9,7 +9,7 @@
 		"android": "*",
 		"bb": "*",
 		"chrome": "*",
-		"firefox": "3.6 - *",
+		"firefox": "<49",
 		"ios_chr": "*",
 		"ios_saf": "*",
 		"ie": "6 - *",
@@ -17,7 +17,7 @@
 		"opera": "*",
 		"op_mini": "*",
 		"safari": "4 - *",
-		"firefox_mob": "3.6 - *",
+		"firefox_mob": "<49",
 		"samsung_mob": "*"
 	},
 	"dependencies": [

--- a/polyfills/Element/prototype/prepend/config.json
+++ b/polyfills/Element/prototype/prepend/config.json
@@ -9,7 +9,7 @@
 		"android": "*",
 		"bb": "*",
 		"chrome": "*",
-		"firefox": "3.6 - *",
+		"firefox": "<49",
 		"ios_chr": "*",
 		"ios_saf": "*",
 		"ie": "6 - *",
@@ -17,7 +17,7 @@
 		"opera": "*",
 		"op_mini": "*",
 		"safari": "4 - *",
-		"firefox_mob": "3.6 - *",
+		"firefox_mob": "<49",
 		"samsung_mob": "*"
 	},
 	"dependencies": [

--- a/polyfills/Element/prototype/replaceWith/config.json
+++ b/polyfills/Element/prototype/replaceWith/config.json
@@ -9,7 +9,7 @@
 		"android": "*",
 		"bb": "*",
 		"chrome": "*",
-		"firefox": "3.6 - *",
+		"firefox": "<49",
 		"ios_chr": "*",
 		"ios_saf": "*",
 		"ie": "6 - *",
@@ -17,7 +17,7 @@
 		"opera": "*",
 		"op_mini": "*",
 		"safari": "4 - *",
-		"firefox_mob": "3.6 - *",
+		"firefox_mob": "<49",
 		"samsung_mob": "*"
 	},
 	"dependencies": [


### PR DESCRIPTION
Firefox 49 supports the new after/before/append/prepend/replaceWith DOM methods; see the relevant [Mozilla bug](https://bugzilla.mozilla.org/show_bug.cgi?id=911477#c40). (Notice how MDN has already been updated.)

I wanted to run your test locally, but I wasn’t able to install this project on my local machine ([screenshot](http://imgur.com/a/oyA5e); on Windows, there is no way to switch to a different version of Node, in case that’s the culprit here).

Instead, I’ve tested [my demo](https://jsbin.com/dewosa/edit?html,js,output) in Firefox 49 on both Windows and Android, and everything checks out.
