### PR TITLE
Add StyleSheetList[Symbol.iterator] for browsers which have StyleSheetList

### DIFF
--- a/polyfills/Object/defineProperties/polyfill.js
+++ b/polyfills/Object/defineProperties/polyfill.js
@@ -1,8 +1,6 @@
 Object.defineProperties = function defineProperties(object, descriptors) {
 	for (var property in descriptors) {
-		if (Object.hasOwnProperty(property)) {
-			Object.defineProperty(object, property, descriptors[property]);
-		}
+		Object.defineProperty(object, property, descriptors[property]);
 	}
 
 	return object;

--- a/polyfills/Object/defineProperties/polyfill.js
+++ b/polyfills/Object/defineProperties/polyfill.js
@@ -1,6 +1,8 @@
 Object.defineProperties = function defineProperties(object, descriptors) {
 	for (var property in descriptors) {
-		Object.defineProperty(object, property, descriptors[property]);
+		if (Object.hasOwnProperty(property)) {
+			Object.defineProperty(object, property, descriptors[property]);
+		}
 	}
 
 	return object;

--- a/polyfills/StyleSheetList/@@iterator/config.json
+++ b/polyfills/StyleSheetList/@@iterator/config.json
@@ -10,7 +10,8 @@
 	},
 	"dependencies": [
 		"_ArrayIterator",
-		"Symbol.iterator"
+		"Symbol.iterator",
+		"StyleSheetList"
 	],
 	"spec": "https://drafts.csswg.org/cssom/#the-stylesheetlist-interface",
 	"docs": "https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Array/@@iterator",

--- a/polyfills/StyleSheetList/@@iterator/config.json
+++ b/polyfills/StyleSheetList/@@iterator/config.json
@@ -1,6 +1,6 @@
 {
 	"browsers": {
-		"ie": "9 <",
+		"ie": "9 - *",
 		"firefox": "*",
 		"chrome": "*",
 		"safari": "*",

--- a/polyfills/StyleSheetList/@@iterator/config.json
+++ b/polyfills/StyleSheetList/@@iterator/config.json
@@ -1,6 +1,6 @@
 {
 	"browsers": {
-		"ie": "8 <",
+		"ie": "9 <",
 		"firefox": "*",
 		"chrome": "*",
 		"safari": "*",

--- a/polyfills/StyleSheetList/@@iterator/config.json
+++ b/polyfills/StyleSheetList/@@iterator/config.json
@@ -1,0 +1,20 @@
+{
+	"browsers": {
+		"ie": "8 <",
+		"firefox": "*",
+		"chrome": "*",
+		"safari": "*",
+		"android": "*",
+		"ios_saf": "*",
+		"opera": "*"
+	},
+	"dependencies": [
+		"_ArrayIterator",
+		"Symbol.iterator"
+	],
+	"spec": "https://drafts.csswg.org/cssom/#the-stylesheetlist-interface",
+	"docs": "https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Array/@@iterator",
+	"notes": [
+	  "This is not actually in the specification."
+	]
+}

--- a/polyfills/StyleSheetList/@@iterator/detect.js
+++ b/polyfills/StyleSheetList/@@iterator/detect.js
@@ -1,0 +1,1 @@
+'Symbol' in this && 'iterator' in this.Symbol && !!StyleSheetList.prototype[Symbol.iterator]

--- a/polyfills/StyleSheetList/@@iterator/detect.js
+++ b/polyfills/StyleSheetList/@@iterator/detect.js
@@ -1,1 +1,1 @@
-'Symbol' in this && 'iterator' in this.Symbol && !!StyleSheetList.prototype[Symbol.iterator]
+'Symbol' in this && 'iterator' in this.Symbol && StyleSheetList && !!StyleSheetList.prototype[Symbol.iterator]

--- a/polyfills/StyleSheetList/@@iterator/polyfill.js
+++ b/polyfills/StyleSheetList/@@iterator/polyfill.js
@@ -1,0 +1,4 @@
+/* global Symbol, ArrayIterator, StyleSheetList */
+StyleSheetList.prototype[Symbol.iterator] = function values () {
+	return new ArrayIterator(this);
+};

--- a/polyfills/StyleSheetList/@@iterator/tests.js
+++ b/polyfills/StyleSheetList/@@iterator/tests.js
@@ -1,0 +1,48 @@
+/* eslint-env mocha, browser*/
+/* global proclaim, it */
+'use strict';
+
+it('is named \'values\'', function () {
+	// Don't fail tests just because browser doesn't support the Function.name polyfill
+	if (StyleSheetList.prototype[Symbol.iterator].name) {
+		try {
+			proclaim.equal(StyleSheetList.prototype[Symbol.iterator].name, 'values');
+		} catch (e) {
+		}
+	}
+});
+
+it('returns a next-able object', function () {
+	var style = document.createElement('style');
+	var head = document.querySelector('head');
+	head.appendChild(style);
+	var iterator = document.styleSheets[Symbol.iterator]();
+
+	proclaim.isInstanceOf(iterator.next, Function);
+	proclaim.deepEqual(iterator.next(), {
+		value: document.styleSheets[0],
+		done: false
+	});
+
+	head.removeChild(style);
+});
+
+it('finally returns a done object', function () {
+	var style = document.createElement('style');
+	var head = document.querySelector('head');
+	head.appendChild(style);
+	var iterator = document.styleSheets[Symbol.iterator]();
+	var length = document.styleSheets.length;
+	var i = 0;
+	while(i < length) {
+		iterator.next();
+		i = i + 1;
+	}
+	proclaim.isInstanceOf(iterator.next, Function);
+	proclaim.deepEqual(iterator.next(), {
+		value: undefined,
+		done: true
+	});
+
+	head.removeChild(style);
+});


### PR DESCRIPTION
There is no specification for this feature that I can find, but it does seem to exists in Chrome and Firefox. It does not exist in Safari.

This polyfill currently doesn't target IE8 as IE8 doesn't have `document.styleSheets` and we do not have a polyfill for this as of yet.
