### PR TITLE
Add ability to use live feature detection instead of being based on User-Agent

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -231,6 +231,8 @@ function getDetectString(options) {
 	let callback;
 	if (options && typeof options.callback === 'string') {
 		callback = options.callback;
+	} else {
+		throw new TypeError('`getDetectString` requires a callback function to be passed. `getDetectString({callback: "callback"})`.');
 	}
 	const unknown = [];
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,8 @@ const UA = require('./UA');
 const sourceslib = require('./sources').getCollection();
 const appVersion = require(path.join(__dirname,'../package.json')).version;
 const Handlebars = require('handlebars');
+const {stripIndents} = require('common-tags');
+const co = require('co');
 
 // Load additional useragent features: primarily to use: agent.satisfies to
 // test a browser version against a semver string
@@ -34,6 +36,15 @@ function getOptions(opts) {
 	}, opts);
 }
 
+const resolveAliases = createAliasResolver([
+	function aliasFromConfig(featureName) {
+		return sourceslib.getConfigAliases(featureName);
+	},
+	function aliasAll(featureName) {
+		return (featureName === 'all') ? sourceslib.listPolyfills() : undefined;
+	}
+]);
+
 /**
  * Given a set of features that should be polyfilled in 'options.features' (with flags i.e. `{<featurename>: {flags:[<flaglist>]}, ...}`), determine which have a configuration valid for the given options.uaString, and return a promise of set of canonical (unaliased) features (with flags) and polyfills.
  *
@@ -44,15 +55,6 @@ function getPolyfills(options) {
 
 	options = getOptions(options);
 	const ua = new UA(options.uaString);
-
-	const resolveAliases = createAliasResolver([
-		function aliasFromConfig(featureName) {
-			return sourceslib.getConfigAliases(featureName);
-		},
-		function aliasAll(featureName) {
-			return (featureName === 'all') ? sourceslib.listPolyfills() : undefined;
-		}
-	]);
 
 	const resolveDependencies = createAliasResolver(
 		function aliasDependencies(featureName) {
@@ -224,10 +226,79 @@ function getPolyfillString(options) {
 	;
 }
 
+function getDetectString({features}) {
+	const unknown = [];
+
+	return Promise.resolve(resolveAliases(features))
+		.then(features => {
+			const featureNames = Object.keys(features);
+
+			function createDetectFor (name) {
+				const graph = tsort();
+				const featureDetects = new Map();
+				const createDetects = co.wrap(function* r (name) {
+					const polyfill = yield sourceslib.getPolyfill(name);
+
+					if (!polyfill) {
+						unknown.push(name);
+					} else {
+						graph.add(name);
+
+						if (polyfill.dependencies) {
+							for (const depName of polyfill.dependencies) {
+								if (!unknown.includes(depName)) {
+									graph.add(depName, name);
+									yield r(depName);
+								}
+							};
+						}
+						featureDetects.set(name, stripIndents`(
+							${polyfill.detectSource || false}
+							)`);
+					}
+				});
+
+				return createDetects(name).then(() => {
+					const detects = graph.sort().filter(name => !unknown.includes(name)).map(name => {
+						return featureDetects.get(name);
+					}).join(' && ');
+					return `if (!(${detects})) { featuresToPolyfill.push('${name}')}`;
+				});
+			}
+
+			return Promise.all(featureNames.map(createDetectFor));
+		})
+		.then(detects => {
+
+			// Outer closure hides private features from global scope
+			// Invoke the closure, binding `this` to window (in a browser), self (in a web worker), or global (in Node/IOjs)
+			let featureDetectBundle = stripIndents`(function(undefined) {
+				var featuresToPolyfill = [];
+				${detects.join('')}
+				return featuresToPolyfill;
+			}).call('object' === typeof window && window || 'object' === typeof self && self || 'object' === typeof global && global || {});`;
+
+			if (unknown.length) {
+				featureDetectBundle = stripIndents`/**
+				* These features were not recognised or we don't have polyfills for them:
+				* - ${Array.from(new Set(unknown)).join('\n* - ')}
+				*/
+				${featureDetectBundle}`;
+			}
+
+			return featureDetectBundle;
+		})
+		.catch(function(err) {
+			console.log(err.stack || err);
+		})
+	;
+}
+
 module.exports = {
 	describePolyfill: describePolyfill,
 	listAllPolyfills: listAllPolyfills,
 	getPolyfills: getPolyfills,
 	getPolyfillString: getPolyfillString,
 	normalizeUserAgent: UA.normalize,
+	getDetectString: getDetectString
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -226,10 +226,16 @@ function getPolyfillString(options) {
 	;
 }
 
-function getDetectString({features}) {
+function getDetectString(options) {
+	const features = options ? options.features : undefined;
+	let callback;
+	if (options && typeof options.callback === 'string') {
+		callback = options.callback;
+	}
 	const unknown = [];
 
-	return Promise.resolve(resolveAliases(features))
+	return Promise.resolve(features)
+		.then(resolveAliases)
 		.then(features => {
 			const featureNames = Object.keys(features);
 
@@ -275,6 +281,7 @@ function getDetectString({features}) {
 			let featureDetectBundle = stripIndents`(function(undefined) {
 				var featuresToPolyfill = [];
 				${detects.join('')}
+				${callback ? `${callback}(featuresToPolyfill);` : ''}
 				return featuresToPolyfill;
 			}).call('object' === typeof window && window || 'object' === typeof self && self || 'object' === typeof global && global || {});`;
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2,11 +2,6 @@
   "name": "polyfill-service",
   "version": "3.9.0",
   "dependencies": {
-    "@request/promise-core": {
-      "version": "1.1.0",
-      "from": "@request/promise-core@1.1.0",
-      "resolved": "https://registry.npmjs.org/@request/promise-core/-/promise-core-1.1.0.tgz"
-    },
     "abbrev": {
       "version": "1.0.9",
       "from": "abbrev@>=1.0.0 <2.0.0",
@@ -433,6 +428,11 @@
       "from": "buffer-crc32@>=0.2.1 <0.3.0",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.5.tgz"
     },
+    "buffer-shims": {
+      "version": "1.0.0",
+      "from": "buffer-shims@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+    },
     "builtin-modules": {
       "version": "1.1.1",
       "from": "builtin-modules@>=1.0.0 <2.0.0",
@@ -480,6 +480,11 @@
         }
       }
     },
+    "co": {
+      "version": "4.6.0",
+      "from": "co@latest",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
+    },
     "coffee-script": {
       "version": "1.10.0",
       "from": "coffee-script@>=1.10.0 <1.11.0",
@@ -499,6 +504,11 @@
       "version": "2.9.0",
       "from": "commander@2.9.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
+    },
+    "common-tags": {
+      "version": "1.3.1",
+      "from": "common-tags@latest",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.3.1.tgz"
     },
     "compress-commons": {
       "version": "0.2.9",
@@ -529,7 +539,7 @@
     },
     "convert-source-map": {
       "version": "1.3.0",
-      "from": "convert-source-map@1.3.0",
+      "from": "convert-source-map@>=1.3.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.3.0.tgz"
     },
     "cookie": {
@@ -1191,9 +1201,9 @@
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz"
     },
     "lodash": {
-      "version": "4.14.1",
-      "from": "lodash@>=4.14.1 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.14.1.tgz"
+      "version": "4.15.0",
+      "from": "lodash@>=4.15.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz"
     },
     "lodash._baseassign": {
       "version": "3.2.0",
@@ -1323,9 +1333,9 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz"
     },
     "minimatch": {
-      "version": "3.0.2",
+      "version": "3.0.3",
       "from": "minimatch@>=3.0.2 <4.0.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
     },
     "minimist": {
       "version": "1.2.0",
@@ -1345,9 +1355,9 @@
       }
     },
     "mocha": {
-      "version": "3.0.1",
-      "from": "mocha@>=3.0.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.0.1.tgz",
+      "version": "3.0.2",
+      "from": "mocha@>=3.0.2 <4.0.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.0.2.tgz",
       "dependencies": {
         "supports-color": {
           "version": "3.1.2",
@@ -1628,9 +1638,9 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.74.0.tgz"
     },
     "request-promise": {
-      "version": "4.1.0",
-      "from": "request-promise@>=4.1.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.1.0.tgz",
+      "version": "4.1.1",
+      "from": "request-promise@>=4.1.1 <5.0.0",
+      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.1.1.tgz",
       "dependencies": {
         "bluebird": {
           "version": "3.4.1",
@@ -1638,6 +1648,11 @@
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.1.tgz"
         }
       }
+    },
+    "request-promise-core": {
+      "version": "1.1.1",
+      "from": "request-promise-core@1.1.1",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz"
     },
     "resolve": {
       "version": "1.1.7",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
     "babel-core": "^6.13.2",
     "babel-preset-es2015": "^6.1.18",
     "blocked": "^1.1.0",
+    "co": "^4.6.0",
+    "common-tags": "^1.3.1",
     "convert-source-map": "^1.3.0",
     "denodeify": "^1.2.1",
     "dotenv": "^2.0.0",
@@ -77,6 +79,7 @@
   },
   "devDependencies": {
     "batch": "^0.5.1",
+    "comment-parser": "^0.4.0",
     "fastly": "Financial-Times/fastly#v2.5.0",
     "grunt-contrib-watch": "^1.0.0",
     "grunt-simple-mocha": "^0.4.0",

--- a/polyfills/setImmediate/detect.js
+++ b/polyfills/setImmediate/detect.js
@@ -1,1 +1,1 @@
-'setImmediate' in window
+'setImmediate' in this

--- a/polyfills/~html5-elements/config.json
+++ b/polyfills/~html5-elements/config.json
@@ -16,5 +16,8 @@
 	"install": {
 		"module": "html5shiv",
 		"paths": ["dist/html5shiv.min.js"]
-	}
+	},
+	"dependencies": [
+		"Document"
+	]
 }

--- a/service/routes/api.js
+++ b/service/routes/api.js
@@ -88,7 +88,8 @@ router.get(/^\/v2\/detect(\.\w+)(\.\w+)?/, (req, res) => {
 	const polyfills = PolyfillSet.fromQueryParam(req.query.features);
 
 	const params = {
-		features: polyfills.get()
+		features: polyfills.get(),
+		callback: req.query.callback
 	};
 
 	polyfillio.getDetectString(params).then(op => {

--- a/service/routes/api.js
+++ b/service/routes/api.js
@@ -84,6 +84,21 @@ router.get(/^\/v2\/polyfill(\.\w+)(\.\w+)?/, (req, res) => {
 
 });
 
+router.get(/^\/v2\/detect(\.\w+)(\.\w+)?/, (req, res) => {
+	const polyfills = PolyfillSet.fromQueryParam(req.query.features);
+
+	const params = {
+		features: polyfills.get()
+	};
+
+	polyfillio.getDetectString(params).then(op => {
+		res.set('Content-Type', contentTypes['.js']+';charset=utf-8');
+		res.set('Access-Control-Allow-Origin', '*');
+		res.send(op);
+	});
+
+});
+
 router.get("/v2/normalizeUa", (req, res) => {
 
 	if (req.query.ua) {

--- a/test/node/lib/test_index.js
+++ b/test/node/lib/test_index.js
@@ -307,5 +307,3 @@ describe("polyfillio", function() {
 		});
 	});
 });
-
-// new vm.Script("(function(undefined) { var featuresToPolyfill = []; if (!('Symbol' in this && 'iterator' in this.Symbol && !!Array.prototype[Symbol.iterator] && !!Array.prototype.values && (Array.prototype[Symbol.iterator] === Array.prototype.values))) { featuresToPolyfill.push('Array.prototype.values')}if (!('Symbol' in this)) { featuresToPolyfill.push('Symbol')} return featuresToPolyfill}).call('object' === typeof window && window || 'object' === typeof self && self || 'object' === typeof global && global || {});").runInNewContext()

--- a/test/node/lib/test_index.js
+++ b/test/node/lib/test_index.js
@@ -2,6 +2,8 @@
 
 var assert  = require('proclaim');
 var polyfillio = require('../../../lib/index');
+const vm = require('vm');
+const extract = require('comment-parser');
 
 describe("polyfillio", function() {
 	describe(".getPolyfills(features)", function() {
@@ -142,4 +144,168 @@ describe("polyfillio", function() {
 		});
 	});
 	*/
+
+	describe('.getDetectString', function() {
+
+		it('should exist', function() {
+		});
+
+		it('should be a function', function() {
+		});
+
+		it('should have argument length of 1', function() {
+		});
+
+		it('should throw if not passed an object with a `features` property', function() {
+		});
+
+		it('should return valid js', function() {
+		});
+
+		describe("should understand all the aliases that the service has defined", function() {
+			/**
+			 * This list is not exhaustive. These tests should really be within the test_aliases.js file.
+			 */
+			/**
+			 * This is not nice but, I can't think of a better way to test it.
+			 * Value is the length of and empty bundle.
+			 * E.G. "(function(undefined) { var featuresToPolyfill = [];  return featuresToPolyfill;}).call('object' === typeof window && window || 'object' === typeof self && self || 'object' === typeof global && global || {});".length;
+			 */
+			const smallestLengthOfBundle = 207;
+			it("should understand the 'all' alias", function() {
+				return polyfillio.getDetectString({
+					features: {
+						'all': { flags: [] }
+					}
+				}).then(function(polyfillSet) {
+					console.log(1111, new vm.Script(polyfillSet).runInNewContext());
+					assert(polyfillSet.length > smallestLengthOfBundle);
+				});
+			});
+
+			it("should understand the 'es6' alias", function() {
+				return polyfillio.getDetectString({
+					features: {
+						'es6': { flags: [] }
+					}
+				}).then(function(polyfillSet) {
+					assert(polyfillSet.length > smallestLengthOfBundle);
+				});
+			});
+
+			it("should understand the 'modernizr:es6array' alias", function() {
+				return polyfillio.getDetectString({
+					features: {
+						'modernizr:es6array': { flags: [] }
+					}
+				}).then(function(polyfillSet) {
+					assert(polyfillSet.length > smallestLengthOfBundle);
+				});
+			});
+
+			it("should understand the 'blissfuljs' alias", function() {
+				return polyfillio.getDetectString({
+					features: {
+						'blissfuljs': { flags: [] }
+					}
+				}).then(function(polyfillSet) {
+					assert(polyfillSet.length > smallestLengthOfBundle);
+				});
+			});
+
+			it("should understand the 'default' alias", function() {
+				return polyfillio.getDetectString({
+					features: {
+						'default': { flags: [] }
+					}
+				}).then(function(polyfillSet) {
+					assert(polyfillSet.length > smallestLengthOfBundle);
+				});
+			});
+
+			it("should understand the 'es5' alias", function() {
+				return polyfillio.getDetectString({
+					features: {
+						'es5': { flags: [] }
+					}
+				}).then(function(polyfillSet) {
+					assert(polyfillSet.length > smallestLengthOfBundle);
+				});
+			});
+
+			it("should understand the 'dom4' alias", function() {
+				return polyfillio.getDetectString({
+					features: {
+						'dom4': { flags: [] }
+					}
+				}).then(function(polyfillSet) {
+					assert(polyfillSet.length > smallestLengthOfBundle);
+				});
+			});
+
+			it("should understand the 'PageVisibility' alias", function() {
+				return polyfillio.getDetectString({
+					features: {
+						'PageVisibility': { flags: [] }
+					}
+				}).then(function(polyfillSet) {
+					assert(polyfillSet.length > smallestLengthOfBundle);
+				});
+			});
+		});
+
+		/**
+		 * This currently fails, I think this is due to a bug in /lib/aliases.js
+		 */
+		xit('should add unknown features to a comment block', function() {
+			return polyfillio.getDetectString({
+					features: {
+						'this_feature_does_not_exist': { flags: [] }
+					}
+				}).then(function(polyfillSet) {
+					assert(extract(polyfillSet)[0].description.includes('this_feature_does_not_exist'));
+				});
+		});
+
+		it('should add known features\' detection code into returned bundle', function() {
+			// Need to mock polyfills.
+		});
+
+		it('should initialise an empty array named `featuresToPolyfill` within the bundle', function() {
+			return polyfillio.getDetectString({
+					features: {
+						'this_feature_does_not_exist': { flags: [] }
+					}
+				}).then(function(polyfillSet) {
+					assert(polyfillSet.includes('var featuresToPolyfill = []'));
+				});
+		});
+
+		it('should add the name of each feature to polyfill to the array returned', function() {
+			/**
+			 * We are testing it is the array named featuresToPolyfill by
+			 * relying on the features tested previously. If a feature's
+			 * not detected in the users' system it's name will be added to the
+			 * featuresToPolyfill array. Because of this fact, if we request a feature
+			 * we know is going to be added to the featuresToPolyfill array, we can
+			 * test that this feature exists within the array returned by the bundle,
+			 * thereby giving us a high level of certainty that the returned array is
+			 * the same as the array named featuresToPolyfill.
+			 */
+			return polyfillio.getDetectString({
+					features: {
+						'Event.focusin': { flags: [] }
+					}
+				}).then(function(polyfillSet) {
+					const returnedValue = new vm.Script(polyfillSet).runInNewContext();
+					assert(Array.isArray(returnedValue));
+					assert(returnedValue.includes('Event.focusin'));
+				});
+		});
+
+		xit('should execute callback function provided by user, with an array containing the names of each feature requiring a polyfill', function() {
+		});
+	});
 });
+
+// new vm.Script("(function(undefined) { var featuresToPolyfill = []; if (!('Symbol' in this && 'iterator' in this.Symbol && !!Array.prototype[Symbol.iterator] && !!Array.prototype.values && (Array.prototype[Symbol.iterator] === Array.prototype.values))) { featuresToPolyfill.push('Array.prototype.values')}if (!('Symbol' in this)) { featuresToPolyfill.push('Symbol')} return featuresToPolyfill}).call('object' === typeof window && window || 'object' === typeof self && self || 'object' === typeof global && global || {});").runInNewContext()

--- a/test/node/lib/test_index.js
+++ b/test/node/lib/test_index.js
@@ -157,10 +157,10 @@ describe("polyfillio", function() {
 		});
 
 		it('should return valid js', function() {
-			return polyfillio.getDetectString()
+			return polyfillio.getDetectString({callback: 'hello'})
 			.then(detectString => {
 				assert.doesNotThrow(function(){
-					new vm.Script(detectString).runInNewContext();
+					new vm.Script(detectString).runInNewContext({hello:Function});
 				});
 			});
 		});
@@ -179,7 +179,8 @@ describe("polyfillio", function() {
 				return polyfillio.getDetectString({
 					features: {
 						'all': { flags: [] }
-					}
+					},
+					callback: 'hello'
 				}).then(function(polyfillSet) {
 					assert(polyfillSet.length > smallestLengthOfBundle);
 				});
@@ -189,7 +190,8 @@ describe("polyfillio", function() {
 				return polyfillio.getDetectString({
 					features: {
 						'es6': { flags: [] }
-					}
+					},
+					callback: 'hello'
 				}).then(function(polyfillSet) {
 					assert(polyfillSet.length > smallestLengthOfBundle);
 				});
@@ -199,7 +201,8 @@ describe("polyfillio", function() {
 				return polyfillio.getDetectString({
 					features: {
 						'modernizr:es6array': { flags: [] }
-					}
+					},
+					callback: 'hello'
 				}).then(function(polyfillSet) {
 					assert(polyfillSet.length > smallestLengthOfBundle);
 				});
@@ -209,7 +212,8 @@ describe("polyfillio", function() {
 				return polyfillio.getDetectString({
 					features: {
 						'blissfuljs': { flags: [] }
-					}
+					},
+					callback: 'hello'
 				}).then(function(polyfillSet) {
 					assert(polyfillSet.length > smallestLengthOfBundle);
 				});
@@ -219,7 +223,8 @@ describe("polyfillio", function() {
 				return polyfillio.getDetectString({
 					features: {
 						'default': { flags: [] }
-					}
+					},
+					callback: 'hello'
 				}).then(function(polyfillSet) {
 					assert(polyfillSet.length > smallestLengthOfBundle);
 				});
@@ -229,7 +234,8 @@ describe("polyfillio", function() {
 				return polyfillio.getDetectString({
 					features: {
 						'es5': { flags: [] }
-					}
+					},
+					callback: 'hello'
 				}).then(function(polyfillSet) {
 					assert(polyfillSet.length > smallestLengthOfBundle);
 				});
@@ -239,7 +245,8 @@ describe("polyfillio", function() {
 				return polyfillio.getDetectString({
 					features: {
 						'dom4': { flags: [] }
-					}
+					},
+					callback: 'hello'
 				}).then(function(polyfillSet) {
 					assert(polyfillSet.length > smallestLengthOfBundle);
 				});
@@ -249,7 +256,8 @@ describe("polyfillio", function() {
 				return polyfillio.getDetectString({
 					features: {
 						'PageVisibility': { flags: [] }
-					}
+					},
+					callback: 'hello'
 				}).then(function(polyfillSet) {
 					assert(polyfillSet.length > smallestLengthOfBundle);
 				});
@@ -263,7 +271,8 @@ describe("polyfillio", function() {
 			return polyfillio.getDetectString({
 					features: {
 						'this_feature_does_not_exist': { flags: [] }
-					}
+					},
+					callback: 'hello'
 				}).then(function(polyfillSet) {
 					assert(extract(polyfillSet)[0].description.includes('this_feature_does_not_exist'));
 				});
@@ -277,31 +286,10 @@ describe("polyfillio", function() {
 			return polyfillio.getDetectString({
 					features: {
 						'this_feature_does_not_exist': { flags: [] }
-					}
+					},
+					callback: 'hello'
 				}).then(function(polyfillSet) {
 					assert(polyfillSet.includes('var featuresToPolyfill = []'));
-				});
-		});
-
-		it('should add the name of each feature to polyfill to the array returned', function() {
-			/**
-			 * We are testing it is the array named featuresToPolyfill by
-			 * relying on the features tested previously. If a feature's
-			 * not detected in the users' system it's name will be added to the
-			 * featuresToPolyfill array. Because of this fact, if we request a feature
-			 * we know is going to be added to the featuresToPolyfill array, we can
-			 * test that this feature exists within the array returned by the bundle,
-			 * thereby giving us a high level of certainty that the returned array is
-			 * the same as the array named featuresToPolyfill.
-			 */
-			return polyfillio.getDetectString({
-					features: {
-						'Event.focusin': { flags: [] }
-					}
-				}).then(function(polyfillSet) {
-					const returnedValue = new vm.Script(polyfillSet).runInNewContext();
-					assert(Array.isArray(returnedValue));
-					assert(returnedValue.includes('Event.focusin'));
 				});
 		});
 


### PR DESCRIPTION
This is a proposed solution to the live feature detection requested in issue #84.

This PR adds a new endpoint (`/v2/detect.js`) for serving the feature detects only.

The endpoint `/v2/detect.js` accepts two query parameters:
- `features` : List of browser features to feature-detect. Accepts a comma-separated list of feature names. Available feature names are shown on the [Browsers and Features page](https://cdn.polyfill.io/v2/docs/features/), as well as group aliases such as 'es5' and 'es6'.
- `callback` : Name of JavaScript function to call after detects are loaded. The function will be invoked with an array containing the names of each feature which was not detected from the `features` list provided. If all features are supported by the browser, an empty array will be passed into the callback function.

One way to use this endpoint is to make a custom request to our polyfill endpoint with the missing features for the browser. Here is one example of this:

``` js
<script>
var callback = function(features) {
    var url = 'https://cdn.polyfill.io/v1/polyfill.min.js?ua=false&unknown=polyfill&flags=always&features=' + features.join(',');
    var script = document.createElement('script');
    script.src = url;
    document.body.appendChild(script);
};
</script>
<script src="http://localhost:3000/v2/detect.js?features=Event.focusin&callback=callback"></script>
```
