### PR TITLE
Add es6 alias to es6 features

### DIFF
--- a/polyfills/Array/prototype/@@iterator/config.json
+++ b/polyfills/Array/prototype/@@iterator/config.json
@@ -1,4 +1,8 @@
 {
+	"aliases": [
+		"es6",
+		"modernizr:es6array"
+	],
 	"browsers": {
 		"ie": "9 - 12",
 		"firefox": "<38",

--- a/polyfills/Array/prototype/entries/config.json
+++ b/polyfills/Array/prototype/entries/config.json
@@ -1,4 +1,8 @@
 {
+	"aliases": [
+		"es6",
+		"modernizr:es6array"
+	],
 	"browsers": {
 		"ie": "9 - 12",
 		"firefox": "<38",

--- a/polyfills/Array/prototype/fill/config.json
+++ b/polyfills/Array/prototype/fill/config.json
@@ -1,6 +1,7 @@
 {
 	"aliases": [
 		"es6",
+		"modernizr:es6array",
 		"default-3.4",
 		"default-3.5",
 		"default-3.6",

--- a/polyfills/Array/prototype/keys/config.json
+++ b/polyfills/Array/prototype/keys/config.json
@@ -1,4 +1,8 @@
 {
+	"aliases": [
+		"es6",
+		"modernizr:es6array"
+	],
 	"browsers": {
 		"ie": "9 - 12",
 		"firefox": "<38",

--- a/polyfills/Array/prototype/values/config.json
+++ b/polyfills/Array/prototype/values/config.json
@@ -1,4 +1,8 @@
 {
+	"aliases": [
+		"es6",
+		"modernizr:es6array"
+	],
 	"browsers": {
 		"ie": "9 - 12",
 		"firefox": "<38",

--- a/polyfills/Map/config.json
+++ b/polyfills/Map/config.json
@@ -1,5 +1,6 @@
 {
 	"aliases": [
+		"es6",
 		"default-3.6",
 		"default"
 	],

--- a/polyfills/Number/isNaN/config.json
+++ b/polyfills/Number/isNaN/config.json
@@ -1,5 +1,6 @@
 {
 	"aliases": [
+		"es6",
 		"default-3.4",
 		"default-3.5",
 		"default-3.6",

--- a/polyfills/Object/setPrototypeOf/config.json
+++ b/polyfills/Object/setPrototypeOf/config.json
@@ -1,4 +1,7 @@
 {
+	"aliases": [
+		"es6"
+	],
 	"browsers": {
 		"android": "*",
 		"bb": "*",

--- a/polyfills/Set/config.json
+++ b/polyfills/Set/config.json
@@ -1,5 +1,6 @@
 {
 	"aliases": [
+		"es6",
 		"default-3.6",
 		"default"
 	],

--- a/polyfills/Symbol/config.json
+++ b/polyfills/Symbol/config.json
@@ -1,4 +1,7 @@
 {
+	"aliases": [
+		"es6"
+	],
 	"browsers": {
 		"ie": "< 13",
 		"ie_mob": "*",

--- a/polyfills/Symbol/hasInstance/config.json
+++ b/polyfills/Symbol/hasInstance/config.json
@@ -1,4 +1,7 @@
 {
+	"aliases": [
+		"es6"
+	],
 	"browsers": {
 		"ie": "*",
 		"ie_mob": "*",

--- a/polyfills/Symbol/isConcatSpreadable/config.json
+++ b/polyfills/Symbol/isConcatSpreadable/config.json
@@ -1,4 +1,7 @@
 {
+	"aliases": [
+		"es6"
+	],
 	"browsers": {
 		"ie": "*",
 		"ie_mob": "*",

--- a/polyfills/Symbol/iterator/config.json
+++ b/polyfills/Symbol/iterator/config.json
@@ -1,4 +1,7 @@
 {
+	"aliases": [
+		"es6"
+	],
 	"browsers": {
 		"ie": "*",
 		"ie_mob": "*",

--- a/polyfills/Symbol/match/config.json
+++ b/polyfills/Symbol/match/config.json
@@ -1,4 +1,7 @@
 {
+	"aliases": [
+		"es6"
+	],
 	"browsers": {
 		"ie": "*",
 		"ie_mob": "*",

--- a/polyfills/Symbol/replace/config.json
+++ b/polyfills/Symbol/replace/config.json
@@ -1,4 +1,7 @@
 {
+	"aliases": [
+		"es6"
+	],
 	"browsers": {
 		"ie": "*",
 		"ie_mob": "*",

--- a/polyfills/Symbol/search/config.json
+++ b/polyfills/Symbol/search/config.json
@@ -1,4 +1,7 @@
 {
+	"aliases": [
+		"es6"
+	],
 	"browsers": {
 		"ie": "*",
 		"ie_mob": "*",

--- a/polyfills/Symbol/species/config.json
+++ b/polyfills/Symbol/species/config.json
@@ -1,4 +1,7 @@
 {
+	"aliases": [
+		"es6"
+	],
 	"browsers": {
 		"ie": "*",
 		"ie_mob": "*",

--- a/polyfills/Symbol/split/config.json
+++ b/polyfills/Symbol/split/config.json
@@ -1,4 +1,7 @@
 {
+	"aliases": [
+		"es6"
+	],
 	"browsers": {
 		"ie": "*",
 		"ie_mob": "*",

--- a/polyfills/Symbol/toPrimitive/config.json
+++ b/polyfills/Symbol/toPrimitive/config.json
@@ -1,4 +1,7 @@
 {
+	"aliases": [
+		"es6"
+	],
 	"browsers": {
 		"ie": "*",
 		"ie_mob": "*",

--- a/polyfills/Symbol/toStringTag/config.json
+++ b/polyfills/Symbol/toStringTag/config.json
@@ -1,4 +1,7 @@
 {
+	"aliases": [
+		"es6"
+	],
 	"browsers": {
 		"ie": "*",
 		"ie_mob": "*",

--- a/polyfills/Symbol/unscopables/config.json
+++ b/polyfills/Symbol/unscopables/config.json
@@ -1,4 +1,7 @@
 {
+	"aliases": [
+		"es6"
+	],
 	"browsers": {
 		"ie": "*",
 		"ie_mob": "*",


### PR DESCRIPTION
I noticed we haven't added the `es6` alias to all the es6 features we polyfill based upon [this comment](https://github.com/Financial-Times/polyfill-service/issues/792#issuecomment-241525129). This PR adds all the missing `es6` aliases.
