### PR TITLE
widen browser delivery of iterators

### DIFF
--- a/polyfills/Array/prototype/@@iterator/config.json
+++ b/polyfills/Array/prototype/@@iterator/config.json
@@ -5,12 +5,14 @@
 	],
 	"browsers": {
 		"ie": "9 - 12",
+		"ie_mob": "9 - 12",
 		"firefox": "<38",
 		"chrome": "<49",
 		"safari": "<9",
 		"android": "<5.1",
 		"ios_saf": "<9",
-		"opera": "<25"
+		"opera": "<25",
+		"samsung_mob": "*"
 	},
 	"dependencies": [
 		"_ArrayIterator",

--- a/polyfills/Array/prototype/entries/config.json
+++ b/polyfills/Array/prototype/entries/config.json
@@ -5,12 +5,14 @@
 	],
 	"browsers": {
 		"ie": "9 - 12",
+		"ie_mob": "9 - 12",
 		"firefox": "<38",
 		"chrome": "<38",
 		"safari": "<7.1",
 		"android": "<5.1",
 		"ios_saf": "<8",
-		"opera": "<25"
+		"opera": "<25",
+		"samsung_mob": "*"
 	},
 	"dependencies": [
 		"_ArrayIterator",

--- a/polyfills/Array/prototype/keys/config.json
+++ b/polyfills/Array/prototype/keys/config.json
@@ -5,12 +5,14 @@
 	],
 	"browsers": {
 		"ie": "9 - 12",
+		"ie_mob": "9 - 12",
 		"firefox": "<38",
 		"chrome": "<38",
 		"safari": "<7.1",
 		"android": "<5.1",
 		"ios_saf": "<8",
-		"opera": "<25"
+		"opera": "<25",
+		"samsung_mob": "*"
 	},
 	"dependencies": [
 		"_ArrayIterator",

--- a/polyfills/Array/prototype/values/config.json
+++ b/polyfills/Array/prototype/values/config.json
@@ -5,6 +5,7 @@
 	],
 	"browsers": {
 		"ie": "9 - 12",
+		"ie_mob": "9 - 12",
 		"firefox": "<38",
 		"chrome": "*",
 		"safari": "<9",

--- a/polyfills/DOMTokenList/prototype/@@iterator/config.json
+++ b/polyfills/DOMTokenList/prototype/@@iterator/config.json
@@ -1,11 +1,13 @@
 {
 	"browsers": {
 		"ie": "9-12",
+		"ie_mob": "9 - 12",
 		"safari": "<9",
 		"chrome": "<50",
 		"firefox": "<40",
 		"ios_saf": "*",
-		"opera": "<50"
+		"opera": "<50",
+		"samsung_mob": "*"
 	},
 	"dependencies": [
 		"_ArrayIterator",

--- a/polyfills/NodeList/prototype/@@iterator/config.json
+++ b/polyfills/NodeList/prototype/@@iterator/config.json
@@ -1,11 +1,13 @@
 {
 	"browsers": {
 		"ie": "9-12",
+		"ie_mob": "9 - 12",
 		"safari": "<9",
 		"chrome": "<50",
 		"firefox": "<40",
 		"ios_saf": "*",
-		"opera": "<50"
+		"opera": "<50",
+		"samsung_mob": "*"
 	},
 	"dependencies": [
 		"_ArrayIterator",


### PR DESCRIPTION
@JakeChampion 

The ie_mob rule is definitely needed (and also makes me think we should perhaps fallback to ie on ie_mob if ie_mob isn't defined)

In the absence of data I'm going for '*' for samsung browsers. We can make it more stringent using RUM in the near future I suppose, but until then not covering samsung is a blocker to next using polyfill.io for symbol
