### PR TITLE
Add UC Browser - mimic IE

### DIFF
--- a/lib/UA.js
+++ b/lib/UA.js
@@ -73,7 +73,7 @@ const aliases = {
 	"internet explorer": "ie",
 	"edge": "ie",
 	"edge mobile": "ie",
-	"uc browser": ["ie", 10],
+	"uc browser": "ie",
 
 	"chrome mobile ios": "ios_chr",
 

--- a/lib/UA.js
+++ b/lib/UA.js
@@ -73,7 +73,7 @@ const aliases = {
 	"internet explorer": "ie",
 	"edge": "ie",
 	"edge mobile": "ie",
-	"uc browser": "ie",
+	"uc browser": ["ie", 10],
 
 	"chrome mobile ios": "ios_chr",
 

--- a/lib/UA.js
+++ b/lib/UA.js
@@ -73,7 +73,9 @@ const aliases = {
 	"internet explorer": "ie",
 	"edge": "ie",
 	"edge mobile": "ie",
-	"uc browser": ["ie", 10],
+	"uc browser": {
+		"9.9.*": ["ie", 10]
+	},
 
 	"chrome mobile ios": "ios_chr",
 

--- a/lib/UA.js
+++ b/lib/UA.js
@@ -73,6 +73,7 @@ const aliases = {
 	"internet explorer": "ie",
 	"edge": "ie",
 	"edge mobile": "ie",
+	"uc browser": ["ie", 10],
 
 	"chrome mobile ios": "ios_chr",
 


### PR DESCRIPTION
Related: https://github.com/Financial-Times/polyfill-service/issues/846

Grabbing name from https://github.com/ua-parser/uap-core/blob/master/regexes.yaml#L113

Using caniuse.com I've found that a majority of items UC Browser does not support closely match IE and am proposing this browser to act as IE (IE10 more specifically) on recent versions of UC Browser `9.9`.
