### PR TITLE
Change from ESI to cookie for data centre detection

### DIFF
--- a/fastly-config.vcl
+++ b/fastly-config.vcl
@@ -49,8 +49,8 @@ sub vcl_deliver {
 	}
 
 	if (req.url ~ "[\&\?]rum=1") {
-    	add resp.http.Set-Cookie = "FastlyDC=" server.datacenter "; Path=/; HttpOnly; max-age=60";
-    }
+		add resp.http.Set-Cookie = "FastlyDC=" server.datacenter "; Path=/; HttpOnly; max-age=60";
+	}
 
 	return(deliver);
 }

--- a/fastly-config.vcl
+++ b/fastly-config.vcl
@@ -24,11 +24,6 @@ sub vcl_recv {
 		error 204 "No Content";
 	}
 
-	if (req.url == "/esi/data_center") {
-		error 752 "data_center";
-	}
-
-
 	set req.url = boltsort.sort(req.url);
 
 	return(lookup);

--- a/lib/rumTemplate.js.handlebars
+++ b/lib/rumTemplate.js.handlebars
@@ -1,7 +1,6 @@
 (function() {
 	var beacon = new Image();
-	var data_center = '<esi:include src="/esi/data_center" />';
-	beacon.src = '//{{{host}}}/v2/recordRumData?X&data_center=' + data_center;
+	beacon.src = '//{{{host}}}/v2/recordRumData?X';
 	{{#each features}}
 	{{#if this.detect}}"&{{{@key}}}=" + (({{{this.detect}}})?1:0) +{{/if}}{{/each}}
 	(('performance' in window && 'getEntriesByType' in window.performance && 'find' in Array.prototype) ? (function() {


### PR DESCRIPTION
Fastly cannot enable ESI and also gzip responses.  That sucks, and we can't sacrifice gzip.  So instead of splicing the data centre ID into the response body using ESI, set a 1 minute cookie with the value.  Read the cookie when receiving the beacon request, falling back to the ID of the data center processing the beacon which is _probably_ the same.
