### PR TITLE
Serve Fetch polyfill to Edge 14

### DIFF
--- a/polyfills/fetch/config.json
+++ b/polyfills/fetch/config.json
@@ -2,7 +2,7 @@
 	"browsers": {
 		"android": "* - 4.4.4",
 		"bb": "10 - *",
-		"ie": "*",
+		"ie": "< 15",
 		"ie_mob": "*",
 		"firefox": "* - 38",
 		"opera": "* - 28",

--- a/polyfills/fetch/config.json
+++ b/polyfills/fetch/config.json
@@ -2,7 +2,7 @@
 	"browsers": {
 		"android": "* - 4.4.4",
 		"bb": "10 - *",
-		"ie": "< 14",
+		"ie": "*",
 		"ie_mob": "*",
 		"firefox": "* - 38",
 		"opera": "* - 28",


### PR DESCRIPTION
Currently we are seeing quite a lot of `'fetch' is undefined` errors on our site due to older (supported) versions of EDGE not having fetch. As per [the edge blog](https://blogs.windows.com/msedgedev/2016/05/24/fetch-and-xhr-limitations/#m82TdcSqlraBgqeu.97) you need to have at least build 14342, while there are lots of machines still around with older builds. I'll suggest that we only enable it for EDGE 15 as the user agent library does not provide a more exact version string.
