### PR TITLE
Missing a space in an exception message.

### DIFF
--- a/polyfills/Array/prototype/every/polyfill.js
+++ b/polyfills/Array/prototype/every/polyfill.js
@@ -1,6 +1,6 @@
 Array.prototype.every = function every(callback) {
 	if (this === undefined || this === null) {
-		throw new TypeError(this + 'is not an object');
+		throw new TypeError(this + ' is not an object');
 	}
 
 	if (!(callback instanceof Function)) {

--- a/polyfills/Array/prototype/filter/polyfill.js
+++ b/polyfills/Array/prototype/filter/polyfill.js
@@ -1,6 +1,6 @@
 Array.prototype.filter = function filter(callback) {
 	if (this === undefined || this === null) {
-		throw new TypeError(this + 'is not an object');
+		throw new TypeError(this + ' is not an object');
 	}
 
 	if (!(callback instanceof Function)) {

--- a/polyfills/Array/prototype/find/polyfill.js
+++ b/polyfills/Array/prototype/find/polyfill.js
@@ -2,7 +2,7 @@ Object.defineProperty(Array.prototype, 'find', {
 	configurable: true,
 	value: function find(callback) {
 		if (this === undefined || this === null) {
-			throw new TypeError(this + 'is not an object');
+			throw new TypeError(this + ' is not an object');
 		}
 
 		if (!(callback instanceof Function)) {

--- a/polyfills/Array/prototype/findIndex/polyfill.js
+++ b/polyfills/Array/prototype/findIndex/polyfill.js
@@ -2,7 +2,7 @@ Object.defineProperty(Array.prototype, 'findIndex', {
 	configurable: true,
 	value: function findIndex(callback) {
 		if (this === undefined || this === null) {
-			throw new TypeError(this + 'is not an object');
+			throw new TypeError(this + ' is not an object');
 		}
 
 		if (!(callback instanceof Function)) {

--- a/polyfills/Array/prototype/forEach/polyfill.js
+++ b/polyfills/Array/prototype/forEach/polyfill.js
@@ -1,6 +1,6 @@
 Array.prototype.forEach = function forEach(callback) {
 	if (this === undefined || this === null) {
-		throw new TypeError(this + 'is not an object');
+		throw new TypeError(this + ' is not an object');
 	}
 
 	if (!(callback instanceof Function)) {

--- a/polyfills/Array/prototype/indexOf/polyfill.js
+++ b/polyfills/Array/prototype/indexOf/polyfill.js
@@ -1,6 +1,6 @@
 Array.prototype.indexOf = function indexOf(searchElement) {
 	if (this === undefined || this === null) {
-		throw new TypeError(this + 'is not an object');
+		throw new TypeError(this + ' is not an object');
 	}
 
 	var

--- a/polyfills/Array/prototype/lastIndexOf/polyfill.js
+++ b/polyfills/Array/prototype/lastIndexOf/polyfill.js
@@ -1,6 +1,6 @@
 Array.prototype.lastIndexOf = function lastIndexOf(searchElement) {
 	if (this === undefined || this === null) {
-		throw new TypeError(this + 'is not an object');
+		throw new TypeError(this + ' is not an object');
 	}
 
 	var

--- a/polyfills/Array/prototype/map/polyfill.js
+++ b/polyfills/Array/prototype/map/polyfill.js
@@ -1,6 +1,6 @@
 Array.prototype.map = function map(callback) {
 	if (this === undefined || this === null) {
-		throw new TypeError(this + 'is not an object');
+		throw new TypeError(this + ' is not an object');
 	}
 
 	if (!(callback instanceof Function)) {

--- a/polyfills/Array/prototype/reduce/polyfill.js
+++ b/polyfills/Array/prototype/reduce/polyfill.js
@@ -1,6 +1,6 @@
 Array.prototype.reduce = function reduce(callback) {
 	if (this === undefined || this === null) {
-		throw new TypeError(this + 'is not an object');
+		throw new TypeError(this + ' is not an object');
 	}
 
 	if (!(callback instanceof Function)) {

--- a/polyfills/Array/prototype/reduceRight/polyfill.js
+++ b/polyfills/Array/prototype/reduceRight/polyfill.js
@@ -1,6 +1,6 @@
 Array.prototype.reduceRight = function reduceRight(callback) {
 	if (this === undefined || this === null) {
-		throw new TypeError(this + 'is not an object');
+		throw new TypeError(this + ' is not an object');
 	}
 
 	if (!(callback instanceof Function)) {

--- a/polyfills/Array/prototype/some/polyfill.js
+++ b/polyfills/Array/prototype/some/polyfill.js
@@ -1,6 +1,6 @@
 Array.prototype.some = function some(callback) {
 	if (this === undefined || this === null) {
-		throw new TypeError(this + 'is not an object');
+		throw new TypeError(this + ' is not an object');
 	}
 
 	if (!(callback instanceof Function)) {

--- a/polyfills/requestAnimationFrame/polyfill.js
+++ b/polyfills/requestAnimationFrame/polyfill.js
@@ -22,7 +22,7 @@
 
 		global.requestAnimationFrame = function (callback) {
 			if (typeof callback !== 'function') {
-				throw new TypeError(callback + 'is not a function');
+				throw new TypeError(callback + ' is not a function');
 			}
 
 			var


### PR DESCRIPTION
Several cases of a missing space in error messages for exceptions. These occurred where a callback parameter was being tested to ensure that it is a function.
