### PR TITLE
Update Array.from to work with all types of iterators

### DIFF
--- a/polyfills/Array/from/config.json
+++ b/polyfills/Array/from/config.json
@@ -21,7 +21,8 @@
 		"samsung_mob": "*"
 	},
 	"dependencies": [
-		"Object.defineProperty"
+		"Object.defineProperty",
+		"Object.getOwnPropertyDescriptor"
 	],
 	"spec": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-array.from",
 	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from"

--- a/polyfills/Array/from/detect.js
+++ b/polyfills/Array/from/detect.js
@@ -6,4 +6,4 @@
 	} catch (e) {
 		return false;
 	}
-})()
+}())

--- a/polyfills/Array/from/polyfill.js
+++ b/polyfills/Array/from/polyfill.js
@@ -1,104 +1,205 @@
+(function(){
+	'use strict';
 
-// Wrapped in IIFE to prevent leaking to global scope.
-(function () {
-	function parseIterable (arraylike) {
+	function toObject(value) {
+		if (value == null) {
+			throw new TypeError('Cannot call method on ' + value);
+		}
+		return Object(value);
+	}
+	function toLength(argument) {
+		var MAX_SAFE_INTEGER = Math.pow(2, 53) - 1;
+		var number = Number(argument);
+		if (isNaN(number)) {
+			number = 0;
+		}
+		var len = (number >= 0 ? 1 : -1) * Math.floor(Math.abs(number));
+		if (len <= 0) { return 0; } // includes converting -0 to +0
+		if (len > MAX_SAFE_INTEGER) { return MAX_SAFE_INTEGER; }
+		return len;
+	}
+	function isCallable(value) {
+		return typeof value !== 'function' && typeof value !== 'object';
+	};
+	function isString (value) {
+		return typeof value === 'string';
+	}
+
+	var parseIterable = function (iterator) {
 		var done = false;
 		var iterableResponse;
 		var tempArray = [];
 
-		// if the iterable doesn't have next;
-		// it is an iterable if 'next' is a function but it has not been defined on
-		// the object itself.
-		if (typeof arraylike.next === 'function') {
+		if (iterator && typeof iterator.next === 'function') {
 			while (!done) {
-				iterableResponse = arraylike.next();
+				iterableResponse = iterator.next();
 				if (
-					iterableResponse.hasOwnProperty('value') &&
-					iterableResponse.hasOwnProperty('done')
+					iterableResponse.hasOwnProperty('value')
+					&& iterableResponse.hasOwnProperty('done')
 				) {
 					if (iterableResponse.done === true) {
 						done = true;
-						break;
+						break; // eslint-disable-line no-restricted-syntax
 
-					// handle the case where the done value is not Boolean
 					} else if (iterableResponse.done !== false) {
-						break;
+						break; // eslint-disable-line no-restricted-syntax
 					}
 
 					tempArray.push(iterableResponse.value);
+				} else if (iterableResponse.done === true) {
+					done = true;
+					break; // eslint-disable-line no-restricted-syntax
 				} else {
-
-					// it does not conform to the iterable pattern
-					break;
+					break; // eslint-disable-line no-restricted-syntax
 				}
 			}
 		}
 
-		if (done) {
-			return tempArray;
+		return done ? tempArray : false;
+	};
+
+	var hasSymbols = typeof Symbol === 'function' && typeof Symbol.iterator === 'symbol';
+	var iteratorSymbol;
+	var forOf;
+	var hasSet = !!this.Set && isCallable(Set.prototype.values);
+	var hasMap = !!this.Map && isCallable(Map.prototype.entries);
+
+	if (hasSymbols) {
+		iteratorSymbol = Symbol.iterator;
+	} else {
+		var supportsStrIterator = (function () {
+			try {
+				var supported = false;
+				var obj = { // eslint-disable-line no-unused-vars
+					'@@iterator': function () {
+						return {
+							'next': function () {
+								supported = true;
+								return {
+									'done': true,
+									'value': undefined
+								};
+							}
+						};
+					}
+				};
+
+				Function('obj', // eslint-disable-line no-new-func
+					'for (var x of obj) {}'
+				)(obj);
+				return supported;
+			} catch (e) {
+				return false;
+			}
+		}());
+
+		if (supportsStrIterator) {
+			iteratorSymbol = '@@iterator';
 		} else {
-
-			// something went wrong return false;
-			return false;
+			try {
+				if (Function('var s = new Set(); s.add(0); for (var x of s) return x;')() === 0) { // eslint-disable-line no-new-func
+					forOf = Function('iterable', 'var arr = []; for (var value of iterable) arr.push(value); return arr;'); // eslint-disable-line no-new-func
+				}
+			} catch (e) {
+			}
 		}
-
 	}
 
-	Object.defineProperty(Array, 'from', {
-		configurable: true,
-		value: function from(source) {
-			// handle non-objects
-			if (source === undefined || source === null) {
-				throw new TypeError(source + ' is not an object');
+	var isSet;
+	if (hasSet) {
+		var setSize = Object.getOwnPropertyDescriptor(Set.prototype, 'size').get;
+		isSet = function (set) {
+			try {
+				setSize.call(set);
+				return true;
+			} catch (e) {
+				return false;
 			}
+		};
+	}
 
-			// handle maps that are not functions
-			if (1 in arguments && !(arguments[1] instanceof Function)) {
-				throw new TypeError(arguments[1] + ' is not a function');
+	var isMap;
+	if (hasMap) {
+		var mapSize = Object.getOwnPropertyDescriptor(Map.prototype, 'size').get;
+		isMap = function (m) {
+			try {
+				mapSize.call(m);
+				return true;
+			} catch (e) {
+				return false;
 			}
+		};
+	}
 
-			var arraylike = typeof source === 'string' ? source.split('') : Object(source);
-			var map = arguments[1];
-			var scope = arguments[2];
-			var array = [];
-			var index = -1;
-			var length = Math.min(Math.max(Number(arraylike.length) || 0, 0), 9007199254740991);
-			var value;
+	var setValues = hasSet && Set.prototype.values;
+	var mapEntries = hasMap && Map.prototype.entries;
+	var usingIterator = function (items) {
+		if (items.hasOwnProperty(iteratorSymbol)) {
+			return items[iteratorSymbol]();
+		} else if (hasSet && isSet(items)) {
+			return setValues.call(items);
+		} else if (hasMap && isMap(items)) {
+			return mapEntries.call(items);
+		}
+		return items;
+	};
 
-			// variables for rebuilding array from iterator
-			var arrayFromIterable;
+	var strMatch = String.prototype.match;
 
-			// if it is an iterable treat like one
-			arrayFromIterable = parseIterable(arraylike);
+	var parseIterableLike = function (items) {
+		var arr = parseIterable(usingIterator(items));
 
-			//if it is a Map or a Set then handle them appropriately
-			if (
-				typeof arraylike.entries === 'function' &&
-				typeof arraylike.values === 'function'
-			) {
-				if (arraylike.constructor.name === 'Set' && 'values' in Set.prototype) {
-					arrayFromIterable = parseIterable(arraylike.values());
-				}
-				if (arraylike.constructor.name === 'Map' && 'entries' in Map.prototype) {
-					arrayFromIterable = parseIterable(arraylike.entries());
-				}
+		if (!arr) {
+			if (forOf) {
+				// Safari 8's native Map or Set can't be iterated except with for..of
+				arr = forOf(items);
+			} else if (isString(items)) {
+				arr = strMatch.call(items, /[\uD800-\uDBFF][\uDC00-\uDFFF]?|[^\uD800-\uDFFF]|./g) || [];
 			}
+		}
+		return arr || items;
+	};
 
-			if (arrayFromIterable) {
-				arraylike = arrayFromIterable;
-				length = arrayFromIterable.length;
+	/*! https://mths.be/array-from v0.2.0 by @mathias */
+	Array.prototype.from = function from(items) {
+		var defineProperty = Object.defineProperty;
+		var C = this;
+		if (items === null || typeof items === 'undefined') {
+			throw new TypeError('`Array.from` requires an array-like object, not `null` or `undefined`');
+		}
+		var mapFn, T;
+		if (typeof arguments[1] !== 'undefined') {
+			mapFn = arguments[1];
+			if (!isCallable(mapFn)) {
+				throw new TypeError('When provided, the second argument to `Array.from` must be a function');
 			}
-
-			while (++index < length) {
-					value = arraylike[index];
-
-					array[index] = map ? map.call(scope, value, index) : value;
+			if (arguments.length > 2) {
+				T = arguments[2];
 			}
+		}
 
-			array.length = length;
+		var arrayLike = toObject(parseIterableLike(items));
+		var len = toLength(arrayLike.length);
+		var A = isCallable(C) ? toObject(new C(len)) : new Array(len);
+		var k = 0;
+		var kValue, mappedValue;
 
-			return array;
-		},
-		writable: true
-	});
+		while (k < len) {
+			kValue = arrayLike[k];
+			if (mapFn) {
+				mappedValue = typeof T === 'undefined' ? mapFn(kValue, k) : mapFn.apply(T, [kValue, k]);
+			} else {
+				mappedValue = kValue;
+			}
+			defineProperty(A, k, {
+				'configurable': true,
+				'enumerable': true,
+				'value': mappedValue,
+				'writable': true
+			});
+			k += 1;
+		}
+		A.length = len;
+		return A;
+	};
 }());

--- a/polyfills/Array/from/polyfill.js
+++ b/polyfills/Array/from/polyfill.js
@@ -1,4 +1,4 @@
-(function(){
+(function(global){
 	'use strict';
 
 	function toObject(value) {
@@ -58,11 +58,11 @@
 		return done ? tempArray : false;
 	};
 
-	var hasSymbols = 'Symbol' in this && 'iterator' in Symbol;
+	var hasSymbols = 'Symbol' in global && 'iterator' in Symbol;
 	var iteratorSymbol;
 	var forOf;
-	var hasSet = !!this.Set && isCallable(Set.prototype.values);
-	var hasMap = !!this.Map && isCallable(Map.prototype.entries);
+	var hasSet = !!global.Set && isCallable(Set.prototype.values);
+	var hasMap = !!global.Map && isCallable(Map.prototype.entries);
 
 	if (hasSymbols) {
 		iteratorSymbol = Symbol.iterator;
@@ -161,7 +161,7 @@
 	};
 
 	/*! https://mths.be/array-from v0.2.0 by @mathias */
-	Array.prototype.from = function from(items) {
+	Array.from = function from(items) {
 		var defineProperty = Object.defineProperty;
 		var C = this;
 		if (items === null || typeof items === 'undefined') {
@@ -202,4 +202,4 @@
 		A.length = len;
 		return A;
 	};
-}());
+}(this));

--- a/polyfills/Array/from/polyfill.js
+++ b/polyfills/Array/from/polyfill.js
@@ -19,7 +19,7 @@
 		return len;
 	}
 	function isCallable(value) {
-		return typeof value !== 'function' && typeof value !== 'object';
+		return typeof value === 'function';
 	};
 	function isString (value) {
 		return typeof value === 'string';

--- a/polyfills/Array/from/polyfill.js
+++ b/polyfills/Array/from/polyfill.js
@@ -58,7 +58,7 @@
 		return done ? tempArray : false;
 	};
 
-	var hasSymbols = typeof Symbol === 'function' && typeof Symbol.iterator === 'symbol';
+	var hasSymbols = 'Symbol' in this && 'iterator' in Symbol;
 	var iteratorSymbol;
 	var forOf;
 	var hasSet = !!this.Set && isCallable(Set.prototype.values);


### PR DESCRIPTION
This PR enables iterators of all types to work with `Array.from`, whether they be custom iterators, Sets, Maps, iterators passed from a different realm such as a Web Worker, and iterators from old version of Firefox and old versions of Safari.

This PR also enables Strings to be iterated correctly as well, thanks to the work by @falsandtru.
