### PR TITLE
Don't serve Symbol polyfills for Opera version 37 or higher

### DIFF
--- a/polyfills/Symbol/config.json
+++ b/polyfills/Symbol/config.json
@@ -9,7 +9,7 @@
 		"chrome": "< 50",
 		"firefox": "< 40",
 		"ios_saf": "*",
-		"opera": "< 50",
+		"opera": "< 37",
 		"samsung_mob": "*",
 		"android": "<5.1"
 	},

--- a/polyfills/Symbol/hasInstance/config.json
+++ b/polyfills/Symbol/hasInstance/config.json
@@ -9,7 +9,7 @@
 		"chrome": "< 50",
 		"firefox": "< 40",
 		"ios_saf": "*",
-		"opera": "< 50",
+		"opera": "< 37",
 		"samsung_mob": "*",
 		"android": "*"
 	},

--- a/polyfills/Symbol/isConcatSpreadable/config.json
+++ b/polyfills/Symbol/isConcatSpreadable/config.json
@@ -9,7 +9,7 @@
 		"chrome": "< 50",
 		"firefox": "< 40",
 		"ios_saf": "*",
-		"opera": "< 50",
+		"opera": "< 37",
 		"samsung_mob": "*",
 		"android": "*"
 	},

--- a/polyfills/Symbol/iterator/config.json
+++ b/polyfills/Symbol/iterator/config.json
@@ -9,7 +9,7 @@
 		"chrome": "< 50",
 		"firefox": "< 40",
 		"ios_saf": "*",
-		"opera": "< 50",
+		"opera": "< 37",
 		"samsung_mob": "*",
 		"android": "<5.1"
 	},

--- a/polyfills/Symbol/match/config.json
+++ b/polyfills/Symbol/match/config.json
@@ -9,7 +9,7 @@
 		"chrome": "< 50",
 		"firefox": "< 40",
 		"ios_saf": "*",
-		"opera": "< 50",
+		"opera": "< 37",
 		"samsung_mob": "*",
 		"android": "*"
 	},

--- a/polyfills/Symbol/replace/config.json
+++ b/polyfills/Symbol/replace/config.json
@@ -9,7 +9,7 @@
 		"chrome": "< 50",
 		"firefox": "< 40",
 		"ios_saf": "*",
-		"opera": "< 50",
+		"opera": "< 37",
 		"samsung_mob": "*",
 		"android": "*"
 	},

--- a/polyfills/Symbol/search/config.json
+++ b/polyfills/Symbol/search/config.json
@@ -9,7 +9,7 @@
 		"chrome": "< 50",
 		"firefox": "< 40",
 		"ios_saf": "*",
-		"opera": "< 50",
+		"opera": "< 37",
 		"samsung_mob": "*",
 		"android": "*"
 	},

--- a/polyfills/Symbol/species/config.json
+++ b/polyfills/Symbol/species/config.json
@@ -9,7 +9,7 @@
 		"chrome": "< 50",
 		"firefox": "< 40",
 		"ios_saf": "*",
-		"opera": "< 50",
+		"opera": "< 37",
 		"samsung_mob": "*",
 		"android": "*"
 	},

--- a/polyfills/Symbol/split/config.json
+++ b/polyfills/Symbol/split/config.json
@@ -9,7 +9,7 @@
 		"chrome": "< 50",
 		"firefox": "< 40",
 		"ios_saf": "*",
-		"opera": "< 50",
+		"opera": "< 37",
 		"samsung_mob": "*",
 		"android": "*"
 	},

--- a/polyfills/Symbol/toPrimitive/config.json
+++ b/polyfills/Symbol/toPrimitive/config.json
@@ -9,7 +9,7 @@
 		"chrome": "< 50",
 		"firefox": "< 40",
 		"ios_saf": "*",
-		"opera": "< 50",
+		"opera": "< 37",
 		"samsung_mob": "*",
 		"android": "*"
 	},

--- a/polyfills/Symbol/toStringTag/config.json
+++ b/polyfills/Symbol/toStringTag/config.json
@@ -9,7 +9,7 @@
 		"chrome": "< 50",
 		"firefox": "< 40",
 		"ios_saf": "*",
-		"opera": "< 50",
+		"opera": "< 37",
 		"samsung_mob": "*",
 		"android": "*"
 	},

--- a/polyfills/Symbol/unscopables/config.json
+++ b/polyfills/Symbol/unscopables/config.json
@@ -9,7 +9,7 @@
 		"chrome": "< 50",
 		"firefox": "< 40",
 		"ios_saf": "*",
-		"opera": "< 50",
+		"opera": "< 37",
 		"samsung_mob": "*",
 		"android": "*"
 	},


### PR DESCRIPTION
This PR updates the Opera browser requirements for `Symbol` polyfills with the correct version number compared to the given minimum Chrome version.

Opera 37 is based on Chrome 50 and [supports all `Symbol` properties](https://kangax.github.io/compat-table/es6/#test-Symbol). Actually, full support seems to be present already in Opera 36, but I felt that it made sense to align with the current Chrome configuration.

Sidenote: With the current polyfill configuration, the polyfill messes with iterators:

```
// Without polyfill
[1,2,3][Symbol.iterator]()
> ArrayIterator {}

// With polyfill
[1,2,3][Symbol.iterator]()
> Uncaught TypeError: [1,2,3][Symbol.iterator] is not a function(…)
```

This type of iterator is output by Babel when using `for ... of` iteration so it's quite prevalent throughout our code :-) I've verified that this problem currently exists in both Opera 39 and 40.

Thank you for an awesome service.
