### PR TITLE
Map/Set IteratorResults now always have a value

### DIFF
--- a/polyfills/Map/polyfill.js
+++ b/polyfills/Map/polyfill.js
@@ -24,7 +24,7 @@
 					while (mapInst._keys[nextIdx] === undefMarker) nextIdx++;
 					return {value: getter.call(mapInst, nextIdx++), done: false};
 				} else {
-					return {done:true};
+					return {value: void 0, done:true};
 				}
 			}
 		};

--- a/polyfills/Map/tests.js
+++ b/polyfills/Map/tests.js
@@ -141,6 +141,12 @@ it("exhibits correct iterator behaviour", function () {
 	// new element shows up in iterators that didn't yet finish
 	proclaim.equal(entriesagain.next().value[0], "4");
 	proclaim.equal(entriesagain.next().done, true);
+	// value is present but undefined when done is true, so that Array.from and other noncompliant
+	// interfaces recognize it as a valid iterator
+	var lastResult = entriesagain.next();
+	proclaim.equal(lastResult.done, true);
+	proclaim.ok(lastResult.hasOwnProperty('value'));
+	proclaim.equal(lastResult.value, void 0);
 });
 
 it("implements .forEach()", function () {

--- a/polyfills/Set/polyfill.js
+++ b/polyfills/Set/polyfill.js
@@ -24,7 +24,7 @@
 					while (setInst._values[nextIdx] === undefMarker) nextIdx++;
 					return {value: getter.call(setInst, nextIdx++), done: false};
 				} else {
-					return {done:true};
+					return {value: void 0, done:true};
 				}
 			}
 		};

--- a/polyfills/Set/tests.js
+++ b/polyfills/Set/tests.js
@@ -91,6 +91,12 @@ it("exhibits correct iterator behaviour", function () {
 	// new element shows up in iterators that didn't yet finish
 	proclaim.equal(entriesagain.next().value[0], "4");
 	proclaim.equal(entriesagain.next().done, true);
+	// value is present but undefined when done is true, so that Array.from and other noncompliant
+	// interfaces recognize it as a valid iterator
+	var lastResult = entriesagain.next();
+	proclaim.equal(lastResult.done, true);
+	proclaim.ok(lastResult.hasOwnProperty('value'));
+	proclaim.equal(lastResult.value, void 0);
 });
 
 it("implements .forEach()", function () {


### PR DESCRIPTION
IteratorResults returned from `map.keys()`, `map.entries()`, and
`map.values()` used to return an object `{done: true}`, with no `value`
property, when they were done. However, that triggered a bug in
`Array.from` implementations that didn't conform to the spec. This bug
exists in native and polyfilled implementations--including [this one](https://github.com/Financial-Times/polyfill-service/blob/master/polyfills/Array/from/polyfill.js#L16)!

The bug causes Array.from to convert an affected iterator into an empty
array, [demonstrated here](http://jsbin.com/jaliguyaqe/3/edit?html,js,console).

It IS a bug in Array.from and not in this implementation, in fact: the
[IteratorResult](http://www.ecma-international.org/ecma-262/6.0/#sec-iteratorresult-interface) interface specifies that the `value` property
"may be absent from the conforming object", but unfortunately, both
native and polyfilled implementations of Array.from don't respect that
(at least in Chrome, which is a popular browser, I'm led to believe.)
