### PR TITLE
Fix: Safari 10 now supports Intl

### DIFF
--- a/polyfills/Intl/config.json
+++ b/polyfills/Intl/config.json
@@ -6,7 +6,7 @@
 		"firefox": "<29",
 		"opera": "<15",
 		"chrome": "<24",
-		"safari": "*",
+		"safari": "<10",
 		"ios_saf": "*",
 		"firefox_mob": "*",
 		"samsung_mob": "*"


### PR DESCRIPTION
Support for Intl listed by Apple: https://developer.apple.com/library/content/releasenotes/General/WhatsNewInSafari/Articles/Safari_10_0.html

Tested on macOs Sierra with Safari Version 10.0 (12602.1.50.0.10)

I agree with contribution terms
