### PR TITLE
Change setImmediate detect to use `this` instead of `window`

### DIFF
--- a/polyfills/setImmediate/detect.js
+++ b/polyfills/setImmediate/detect.js
@@ -1,1 +1,1 @@
-'setImmediate' in window
+'setImmediate' in this


### PR DESCRIPTION
This enables the detect to work in contexts which don't have a `window` object such as Worker contexts or NodeJS.
