### PR TITLE
Simplify require call for appVersion

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,7 @@ const tsort = require('tsort');
 const createAliasResolver = require('./aliases');
 const UA = require('./UA');
 const sourceslib = require('./sources').getCollection();
-const appVersion = require(path.join(__dirname,'../package.json')).version;
+const appVersion = require('../package.json').version;
 const Handlebars = require('handlebars');
 const cloneDeep = require('lodash').cloneDeep;
 


### PR DESCRIPTION
`require` can take a relative path as an argument, no need to use `path.join` here.
