### PR TITLE
polyfill symbol in BlackBerry

### DIFF
--- a/polyfills/Array/from/config.json
+++ b/polyfills/Array/from/config.json
@@ -19,7 +19,7 @@
 		"android": "*",
 		"ios_saf": "<9",
 		"samsung_mob": "*",
-		"bb": ">=10"
+		"bb": "10 - *"
 	},
 	"dependencies": [
 		"Object.defineProperty"

--- a/polyfills/Array/from/config.json
+++ b/polyfills/Array/from/config.json
@@ -18,7 +18,8 @@
 		"firefox_mob": "<32",
 		"android": "*",
 		"ios_saf": "<9",
-		"samsung_mob": "*"
+		"samsung_mob": "*",
+		"bb": ">=10"
 	},
 	"dependencies": [
 		"Object.defineProperty"

--- a/polyfills/DOMTokenList/prototype/@@iterator/config.json
+++ b/polyfills/DOMTokenList/prototype/@@iterator/config.json
@@ -7,7 +7,8 @@
 		"firefox": "<40",
 		"ios_saf": "*",
 		"opera": "<50",
-		"samsung_mob": "*"
+		"samsung_mob": "*",
+		"bb": ">=10"
 	},
 	"dependencies": [
 		"_ArrayIterator",

--- a/polyfills/DOMTokenList/prototype/@@iterator/config.json
+++ b/polyfills/DOMTokenList/prototype/@@iterator/config.json
@@ -8,7 +8,7 @@
 		"ios_saf": "*",
 		"opera": "<50",
 		"samsung_mob": "*",
-		"bb": ">=10"
+		"bb": "10 - *"
 	},
 	"dependencies": [
 		"_ArrayIterator",

--- a/polyfills/Map/config.json
+++ b/polyfills/Map/config.json
@@ -14,7 +14,7 @@
 		"ie_mob": "*",
 		"opera_mob": "*",
 		"ios_saf": "<9",
-		"bb": ">=10"
+		"bb": "10 - *"
 	},
 	"dependencies": [
 		"Array.prototype.indexOf",

--- a/polyfills/Map/config.json
+++ b/polyfills/Map/config.json
@@ -13,7 +13,8 @@
 		"firefox_mob": "<29",
 		"ie_mob": "*",
 		"opera_mob": "*",
-		"ios_saf": "<9"
+		"ios_saf": "<9",
+		"bb": ">=10"
 	},
 	"dependencies": [
 		"Array.prototype.indexOf",

--- a/polyfills/NodeList/prototype/@@iterator/config.json
+++ b/polyfills/NodeList/prototype/@@iterator/config.json
@@ -7,7 +7,8 @@
 		"firefox": "<40",
 		"ios_saf": "*",
 		"opera": "<50",
-		"samsung_mob": "*"
+		"samsung_mob": "*",
+		"bb": ">=10"
 	},
 	"dependencies": [
 		"_ArrayIterator",

--- a/polyfills/NodeList/prototype/@@iterator/config.json
+++ b/polyfills/NodeList/prototype/@@iterator/config.json
@@ -8,7 +8,7 @@
 		"ios_saf": "*",
 		"opera": "<50",
 		"samsung_mob": "*",
-		"bb": ">=10"
+		"bb": "10 - *"
 	},
 	"dependencies": [
 		"_ArrayIterator",

--- a/polyfills/Set/config.json
+++ b/polyfills/Set/config.json
@@ -14,7 +14,7 @@
 		"ie_mob": "*",
 		"opera_mob": "*",
 		"ios_saf": "<7.1",
-		"bb": ">=10"
+		"bb": "10 - *"
 	},
 	"dependencies": [
 		"Array.prototype.indexOf",

--- a/polyfills/Set/config.json
+++ b/polyfills/Set/config.json
@@ -13,7 +13,8 @@
 		"firefox_mob": "<29",
 		"ie_mob": "*",
 		"opera_mob": "*",
-		"ios_saf": "<7.1"
+		"ios_saf": "<7.1",
+		"bb": ">=10"
 	},
 	"dependencies": [
 		"Array.prototype.indexOf",

--- a/polyfills/Symbol/config.json
+++ b/polyfills/Symbol/config.json
@@ -11,7 +11,8 @@
 		"ios_saf": "*",
 		"opera": "< 37",
 		"samsung_mob": "*",
-		"android": "<5.1"
+		"android": "<5.1",
+		"bb": "10 - *"
 	},
 	"dependencies": [
 		"Array.prototype.forEach",

--- a/polyfills/Symbol/hasInstance/config.json
+++ b/polyfills/Symbol/hasInstance/config.json
@@ -12,7 +12,7 @@
 		"opera": "< 37",
 		"samsung_mob": "*",
 		"android": "*",
-		"bb": ">=10"
+		"bb": "10 - *"
 	},
 	"dependencies": [
 		"Object.defineProperty",

--- a/polyfills/Symbol/hasInstance/config.json
+++ b/polyfills/Symbol/hasInstance/config.json
@@ -11,7 +11,8 @@
 		"ios_saf": "*",
 		"opera": "< 37",
 		"samsung_mob": "*",
-		"android": "*"
+		"android": "*",
+		"bb": ">=10"
 	},
 	"dependencies": [
 		"Object.defineProperty",

--- a/polyfills/Symbol/isConcatSpreadable/config.json
+++ b/polyfills/Symbol/isConcatSpreadable/config.json
@@ -12,7 +12,7 @@
 		"opera": "< 37",
 		"samsung_mob": "*",
 		"android": "*",
-		"bb": ">=10"
+		"bb": "10 - *"
 	},
 	"dependencies": [
 		"Object.defineProperty",

--- a/polyfills/Symbol/isConcatSpreadable/config.json
+++ b/polyfills/Symbol/isConcatSpreadable/config.json
@@ -11,7 +11,8 @@
 		"ios_saf": "*",
 		"opera": "< 37",
 		"samsung_mob": "*",
-		"android": "*"
+		"android": "*",
+		"bb": ">=10"
 	},
 	"dependencies": [
 		"Object.defineProperty",

--- a/polyfills/Symbol/iterator/config.json
+++ b/polyfills/Symbol/iterator/config.json
@@ -11,7 +11,8 @@
 		"ios_saf": "*",
 		"opera": "< 37",
 		"samsung_mob": "*",
-		"android": "<5.1"
+		"android": "<5.1",
+		"bb": ">=10"
 	},
 	"dependencies": [
 		"Object.defineProperty",

--- a/polyfills/Symbol/iterator/config.json
+++ b/polyfills/Symbol/iterator/config.json
@@ -12,7 +12,7 @@
 		"opera": "< 37",
 		"samsung_mob": "*",
 		"android": "<5.1",
-		"bb": ">=10"
+		"bb": "10 - *"
 	},
 	"dependencies": [
 		"Object.defineProperty",

--- a/polyfills/Symbol/match/config.json
+++ b/polyfills/Symbol/match/config.json
@@ -12,7 +12,7 @@
 		"opera": "< 37",
 		"samsung_mob": "*",
 		"android": "*",
-		"bb": ">=10"
+		"bb": "10 - *"
 	},
 	"dependencies": [
 		"Object.defineProperty",

--- a/polyfills/Symbol/match/config.json
+++ b/polyfills/Symbol/match/config.json
@@ -11,7 +11,8 @@
 		"ios_saf": "*",
 		"opera": "< 37",
 		"samsung_mob": "*",
-		"android": "*"
+		"android": "*",
+		"bb": ">=10"
 	},
 	"dependencies": [
 		"Object.defineProperty",

--- a/polyfills/Symbol/replace/config.json
+++ b/polyfills/Symbol/replace/config.json
@@ -12,7 +12,7 @@
 		"opera": "< 37",
 		"samsung_mob": "*",
 		"android": "*",
-		"bb": ">=10"
+		"bb": "10 - *"
 	},
 	"dependencies": [
 		"Object.defineProperty",

--- a/polyfills/Symbol/replace/config.json
+++ b/polyfills/Symbol/replace/config.json
@@ -11,7 +11,8 @@
 		"ios_saf": "*",
 		"opera": "< 37",
 		"samsung_mob": "*",
-		"android": "*"
+		"android": "*",
+		"bb": ">=10"
 	},
 	"dependencies": [
 		"Object.defineProperty",

--- a/polyfills/Symbol/search/config.json
+++ b/polyfills/Symbol/search/config.json
@@ -12,7 +12,7 @@
 		"opera": "< 37",
 		"samsung_mob": "*",
 		"android": "*",
-		"bb": ">=10"
+		"bb": "10 - *"
 	},
 	"dependencies": [
 		"Object.defineProperty",

--- a/polyfills/Symbol/search/config.json
+++ b/polyfills/Symbol/search/config.json
@@ -11,7 +11,8 @@
 		"ios_saf": "*",
 		"opera": "< 37",
 		"samsung_mob": "*",
-		"android": "*"
+		"android": "*",
+		"bb": ">=10"
 	},
 	"dependencies": [
 		"Object.defineProperty",

--- a/polyfills/Symbol/species/config.json
+++ b/polyfills/Symbol/species/config.json
@@ -12,7 +12,7 @@
 		"opera": "< 37",
 		"samsung_mob": "*",
 		"android": "*",
-		"bb": ">=10"
+		"bb": "10 - *"
 	},
 	"dependencies": [
 		"Object.defineProperty",

--- a/polyfills/Symbol/species/config.json
+++ b/polyfills/Symbol/species/config.json
@@ -11,7 +11,8 @@
 		"ios_saf": "*",
 		"opera": "< 37",
 		"samsung_mob": "*",
-		"android": "*"
+		"android": "*",
+		"bb": ">=10"
 	},
 	"dependencies": [
 		"Object.defineProperty",

--- a/polyfills/Symbol/split/config.json
+++ b/polyfills/Symbol/split/config.json
@@ -12,7 +12,7 @@
 		"opera": "< 37",
 		"samsung_mob": "*",
 		"android": "*",
-		"bb": ">=10"
+		"bb": "10 - *"
 	},
 	"dependencies": [
 		"Object.defineProperty",

--- a/polyfills/Symbol/split/config.json
+++ b/polyfills/Symbol/split/config.json
@@ -11,7 +11,8 @@
 		"ios_saf": "*",
 		"opera": "< 37",
 		"samsung_mob": "*",
-		"android": "*"
+		"android": "*",
+		"bb": ">=10"
 	},
 	"dependencies": [
 		"Object.defineProperty",

--- a/polyfills/Symbol/toPrimitive/config.json
+++ b/polyfills/Symbol/toPrimitive/config.json
@@ -12,7 +12,7 @@
 		"opera": "< 37",
 		"samsung_mob": "*",
 		"android": "*",
-		"bb": ">=10"
+		"bb": "10 - *"
 	},
 	"dependencies": [
 		"Object.defineProperty",

--- a/polyfills/Symbol/toPrimitive/config.json
+++ b/polyfills/Symbol/toPrimitive/config.json
@@ -11,7 +11,8 @@
 		"ios_saf": "*",
 		"opera": "< 37",
 		"samsung_mob": "*",
-		"android": "*"
+		"android": "*",
+		"bb": ">=10"
 	},
 	"dependencies": [
 		"Object.defineProperty",

--- a/polyfills/Symbol/toStringTag/config.json
+++ b/polyfills/Symbol/toStringTag/config.json
@@ -12,7 +12,7 @@
 		"opera": "< 37",
 		"samsung_mob": "*",
 		"android": "*",
-		"bb": ">=10"
+		"bb": "10 - *"
 	},
 	"dependencies": [
 		"Object.defineProperty",

--- a/polyfills/Symbol/toStringTag/config.json
+++ b/polyfills/Symbol/toStringTag/config.json
@@ -11,7 +11,8 @@
 		"ios_saf": "*",
 		"opera": "< 37",
 		"samsung_mob": "*",
-		"android": "*"
+		"android": "*",
+		"bb": ">=10"
 	},
 	"dependencies": [
 		"Object.defineProperty",

--- a/polyfills/Symbol/unscopables/config.json
+++ b/polyfills/Symbol/unscopables/config.json
@@ -12,7 +12,7 @@
 		"opera": "< 37",
 		"samsung_mob": "*",
 		"android": "*",
-		"bb": ">=10"
+		"bb": "10 - *"
 	},
 	"dependencies": [
 		"Object.defineProperty",

--- a/polyfills/Symbol/unscopables/config.json
+++ b/polyfills/Symbol/unscopables/config.json
@@ -11,7 +11,8 @@
 		"ios_saf": "*",
 		"opera": "< 37",
 		"samsung_mob": "*",
-		"android": "*"
+		"android": "*",
+		"bb": ">=10"
 	},
 	"dependencies": [
 		"Object.defineProperty",

--- a/polyfills/WeakMap/config.json
+++ b/polyfills/WeakMap/config.json
@@ -11,7 +11,8 @@
 		"android": "*",
 		"ios_saf": "<9",
 		"opera": "<25",
-		"firefox_mob": "<36"
+		"firefox_mob": "<36",
+		"bb": ">=10"
 	},
 	"dependencies": [
 		"Object.defineProperty",

--- a/polyfills/WeakMap/config.json
+++ b/polyfills/WeakMap/config.json
@@ -12,7 +12,7 @@
 		"ios_saf": "<9",
 		"opera": "<25",
 		"firefox_mob": "<36",
-		"bb": ">=10"
+		"bb": "10 - *"
 	},
 	"dependencies": [
 		"Object.defineProperty",

--- a/polyfills/WeakSet/config.json
+++ b/polyfills/WeakSet/config.json
@@ -12,7 +12,7 @@
 		"ios_saf": "<9",
 		"opera": "<25",
 		"firefox_mob": "<34",
-		"bb": ">=10"
+		"bb": "10 - *"
 	},
 	"dependencies": [
 		"Object.defineProperty",

--- a/polyfills/WeakSet/config.json
+++ b/polyfills/WeakSet/config.json
@@ -11,7 +11,8 @@
 		"android": "*",
 		"ios_saf": "<9",
 		"opera": "<25",
-		"firefox_mob": "<34"
+		"firefox_mob": "<34",
+		"bb": ">=10"
 	},
 	"dependencies": [
 		"Object.defineProperty",


### PR DESCRIPTION
@JakeChampion being deliberately conservative with versions given the compatibility problems we've had with symbol before. FT only needs v10 covered. If others want to invest time in verifying Symbol and related polyfills don't blow up in BB<10 then config can be modified in future PRs
