### PR TITLE
Remove detect from fetch polyfill

### DIFF
--- a/polyfills/fetch/polyfill.js
+++ b/polyfills/fetch/polyfill.js
@@ -3,10 +3,6 @@
 (function(self) {
   'use strict';
 
-  if (self.fetch) {
-    return;
-  }
-
   function normalizeName(name) {
     if (typeof name !== 'string') {
       name = String(name);


### PR DESCRIPTION
Edge 14 has a broken version of fetch, we target Edge 14 but fail to apply polyfill due to an embedded feature detect in the polyfill. Thanks to @wessberg for spotting this issue.
