### PR TITLE
Add Event and performance.now as deps to intersectionobserver

### DIFF
--- a/polyfills/IntersectionObserver/config.json
+++ b/polyfills/IntersectionObserver/config.json
@@ -23,7 +23,9 @@
 		"Array.prototype.indexOf",
 		"Array.prototype.map",
 		"Array.prototype.some",
-		"Function.prototype.bind"
+		"Event",
+		"Function.prototype.bind",
+		"perfomance.now"
 	],
 	"docs": "https://github.com/WICG/IntersectionObserver/blob/master/explainer.md",
 	"spec": "http://rawgit.com/WICG/IntersectionObserver/master/index.html",


### PR DESCRIPTION
performance.now is used on line 525 -- https://github.com/WICG/IntersectionObserver/blob/gh-pages/polyfill/intersection-observer.js#L525

addEventListener is on line 559 -- https://github.com/WICG/IntersectionObserver/blob/gh-pages/polyfill/intersection-observer.js#L559
