### PR TITLE
Update error messages for Object.defineProperty

### DIFF
--- a/polyfills/Object/defineProperty/polyfill.js
+++ b/polyfills/Object/defineProperty/polyfill.js
@@ -12,11 +12,11 @@
 		}
 
 		if (object === null || !(object instanceof Object || typeof object === 'object')) {
-			throw new TypeError('Object must be an object (Object.defineProperty polyfill)');
+			throw new TypeError('Object.defineProperty called on non-object');
 		}
 
 		if (!(descriptor instanceof Object)) {
-			throw new TypeError('Descriptor must be an object (Object.defineProperty polyfill)');
+			throw new TypeError('Property description must be an object');
 		}
 
 		var propertyString = String(property);
@@ -27,7 +27,7 @@
 		// handle descriptor.get
 		if (getterType) {
 			if (getterType !== 'function') {
-				throw new TypeError('Getter expected a function (Object.defineProperty polyfill)');
+				throw new TypeError('Getter must be a function');
 			}
 			if (!supportsAccessors) {
 				throw new TypeError(ERR_ACCESSORS_NOT_SUPPORTED);
@@ -43,7 +43,7 @@
 		// handle descriptor.set
 		if (setterType) {
 			if (setterType !== 'function') {
-				throw new TypeError('Setter expected a function (Object.defineProperty polyfill)');
+				throw new TypeError('Setter must be a function');
 			}
 			if (!supportsAccessors) {
 				throw new TypeError(ERR_ACCESSORS_NOT_SUPPORTED);

--- a/polyfills/Object/defineProperty/tests.js
+++ b/polyfills/Object/defineProperty/tests.js
@@ -97,7 +97,7 @@ describe('Error handling', function () {
 
 		proclaim.throws(function () {
 			Object.defineProperty(object, property);
-		}, 'Descriptor must be an object (Object.defineProperty polyfill)');
+		}, 'Property description must be an object: undefined');
 	});
 
 	it('Throws an error when both an accessor and a value are specified', function () {

--- a/polyfills/Object/defineProperty/tests.js
+++ b/polyfills/Object/defineProperty/tests.js
@@ -97,7 +97,7 @@ describe('Error handling', function () {
 
 		proclaim.throws(function () {
 			Object.defineProperty(object, property);
-		}, 'Property description must be an object: undefined');
+		}, /^Property description must be an object/);
 	});
 
 	it('Throws an error when both an accessor and a value are specified', function () {


### PR DESCRIPTION
I noticed our error messages were a bit out dated and that these tests were failing in Canary.
