### PR TITLE
Firefox shipped IO in 52

### DIFF
--- a/polyfills/IntersectionObserver/config.json
+++ b/polyfills/IntersectionObserver/config.json
@@ -5,7 +5,7 @@
 		"android": "4.4 - *",
 		"bb": "7 - 10",
 		"chrome": "<51",
-		"firefox": "*",
+		"firefox": "<52",
 		"firefox_mob": "47 - *",
 		"ie": "7 - *",
 		"ie_mob": "11 - *",


### PR DESCRIPTION
At TAG meeting, dbaron noted that IO will likely ship in FF52. If it does this update can go through.