### PR TITLE
fix `polyfill.io CDN` link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Status](https://circleci.com/gh/Financial-Times/polyfill-service.svg?&style=shie
 * [Configuration](#configuration)
 * [Testing](#testing)
 * [Real user monitoring](#real-user-monitoring)
-* [polyfill.io CDN](polyfill.io-cdn)
+* [polyfill.io CDN](#polyfillio-cdn)
 * [Library](#library)
 * [License](#license)
 


### PR DESCRIPTION
When I click the `polyfill.io CDN` link in REAEME, it take me to https://github.com/Financial-Times/polyfill-service/blob/master/polyfill.io-cdn

This PR fix it.