### PR TITLE
es6 compliant Object.keys polyfill

### DIFF
--- a/polyfills/Object/keys/tests.js
+++ b/polyfills/Object/keys/tests.js
@@ -37,3 +37,43 @@ it('works with objects containing otherwise non-enumerable keys', function () {
 		valueOf: 0
 	}).length, 7);
 });
+
+it('throws on empty, undefined, or null arguments', function () {
+  proclaim.throws(function () {
+    Object.keys();
+  });
+  proclaim.throws(function () {
+    Object.keys(null);
+  });
+  proclaim.throws(function () {
+    Object.keys(undefined);
+  });
+});
+
+it('treats functions as Objects', function () {
+  function testFn(a, b, c) {
+    a;
+    b;
+    c;
+    return 1;
+  }
+
+  testFn.something = 2;
+  testFn.somethingElse = 3;
+
+  proclaim.equal(Object.keys(testFn).length, 2);
+});
+
+it('treats Arrays and strings as Object with index keys', function () {
+  proclaim.deepEqual(Object.keys([]), []);
+  proclaim.deepEqual(Object.keys(['a', 'b', 'c']), ['0', '1', '2']);
+
+  proclaim.deepEqual(Object.keys(''), []);
+  proclaim.deepEqual(Object.keys('hello'), ['0', '1', '2', '3', '4']);
+});
+
+it('returns an empty Array for numbers and booleans', function () {
+  proclaim.equal(Object.keys(3).length, 0);
+  proclaim.equal(Object.keys(true).length, 0);
+  proclaim.equal(Object.keys(false).length, 0);
+});


### PR DESCRIPTION
This PR updates tests to reflect expected es2015 behavior of Object.keys (for example how latest Chrome treats this method)

Note that because IE9+ has es5 compliant Object.keys support it is not getting this polyfill and it is not running these tests at all. I don't know how you intend to make this polyfill available to browsers that support an older API for a function so I did not change which browsers are targeted in tests yet.

* adds new tests for behavior of Functions as well as empty, null, undefined arguments
* adds new failing tests for Arrays, numbers, strings
