### PR TITLE
Add Intl polyfill support for QupZilla

### DIFF
--- a/polyfills/Intl/config.json
+++ b/polyfills/Intl/config.json
@@ -9,7 +9,8 @@
 		"safari": "<10",
 		"ios_saf": "*",
 		"firefox_mob": "*",
-		"samsung_mob": "*"
+		"samsung_mob": "*",
+		"qupzilla": "<2"
 	},
 	"dependencies": [],
 	"build": {


### PR DESCRIPTION
Add Intl polyfill support for QupZilla versions older than 2.0

As the browser isn't very widespread there's no specific info at MDN, caniuse and Kangax or anywhere else. However I found about the needed Intl polyfill when checking a user-submited issue concering our app (https://github.com/Openki/Openki/issues/596).

This is the infinite loading screen I get when using any version of QupZilla earlier than 2.0 (here 1.8.9-1):

![openki_net_qupzilla_1 8 9](https://cloud.githubusercontent.com/assets/9354955/20688831/dbfa8cdc-b5c2-11e6-8cee-05c5508b093c.png)

And this is how the same page looks starting from 2.0 (here 2.0.2-1):

![openki_net_qupzilla_2 0 2](https://cloud.githubusercontent.com/assets/9354955/20688844/e7419e50-b5c2-11e6-9913-37924c17edc7.png)

Hereby I agree to the [contribution terms](https://polyfill.io/v2/docs/contributing#contribution-terms).