### PR TITLE
Add logging from fastly for 0.1% of requests

### DIFF
--- a/fastly-config.vcl
+++ b/fastly-config.vcl
@@ -2,6 +2,22 @@ import boltsort;
 
 sub vcl_recv {
 #FASTLY recv
+
+	# Only log 0.1% of requests.
+	if (randombool(1, 1000)) {
+		set req.http.log = "1";
+	}
+
+	# Attach a unique id to each request, can be useful when investigating logs
+	if (!req.http.request-id) {
+		set req.http.request-id =
+			randomstr(8, "0123456789abcdef") "-"
+			randomstr(4, "0123456789abcdef") "-4"
+			randomstr(3, "0123456789abcdef") "-"
+			randomstr(1, "89ab") randomstr(3, "0123456789abcdef") "-"
+			randomstr(12, "0123456789abcdef");
+	}
+
 	if ( req.request == "FASTLYPURGE" ) {
 		set req.http.Fastly-Purge-Requires-Auth = "1";
 	}
@@ -41,6 +57,14 @@ sub vcl_recv {
 sub vcl_deliver {
 #FASTLY deliver
 
+	call custom_syslog;
+
+	# If we are debugging, it is useful to know what the request-id will be so
+	# that we can look at the logs for our requests
+	if (req.http.FT-Debug) {
+		set resp.http.request-id = req.http.request-id;
+	}
+
 	# If the response is to a normalise request and there's a parked "original request", use the normalised UA response to modify the original request and restart it
 	if (req.url ~ "^/v\d/normalizeUa" && resp.status == 200 && req.http.X-Orig-URL ~ "^/v2/(polyfill\.|recordRumData)") {
 		set req.http.Fastly-force-Shield = "1";
@@ -65,6 +89,10 @@ sub vcl_deliver {
 }
 
 sub vcl_error {
+#FASTLY error
+
+	# We log all vcl_error calls as these are probably exceptional circumstances
+	call custom_error_syslog;
 
 	# Redirect to canonical prod/qa origins
 	if (obj.status == 751 || obj.status == 752) {
@@ -74,4 +102,58 @@ sub vcl_error {
 		synthetic {""};
 		return (deliver);
 	}
+}
+
+sub custom_syslog {
+	# The log function will only be called if the request is one of the 25%
+	# which we labelled as having logging enabled
+	if (req.http.log) {
+		log {"syslog ${SERVICEID} Fastly :: serviceid=${SERVICEID}"}
+			{" timestamp="} time.start.sec
+			{" event="} {"REQUEST"}
+			{" host="} req.http.host
+			{" request-id="} req.http.request-id
+			{" bytes="} resp.http.content-length
+			{" client_ip="} req.http.Fastly-Client-IP
+			{" method="} req.request
+			{" useragent="} req.http.User-Agent
+			{" url=""} req.url {"""}
+			{" content_type=""} resp.http.Content-Type {"""}
+			{" status="} resp.status
+			{" content-length="} resp.http.content-length
+			if(geoip.city,{" geoip_city=""} geoip.city {"""},{""})
+			if(geoip.region,{" geoip_region=""} geoip.region {"""},{""})
+			if(geoip.country_code,{" geoip_country="} geoip.country_code,{""})
+			if(geoip.continent_code,{" geoip_continent="} geoip.continent_code,{""})
+			{" fastly_region="} server.region
+			{" fastly_datacenter="} server.datacenter
+			{" fastly_node="} server.identity
+			{" fastly_state="} fastly_info.state
+			{" duration_ms="} time.elapsed.msec;
+	}
+}
+
+sub custom_error_syslog {
+	# The reason custom_error_syslog is different from custom_syslog is because when
+	# vcl_error is entered, there will be no resp object, which is used inside
+	# custom_syslog to log information about the response we are sending
+
+	log {"syslog ${SERVICEID} Fastly :: serviceid=${SERVICEID}"}
+		{" timestamp="} time.start.sec
+		{" event="} {"REQUEST"}
+		{" host="} req.http.host
+		{" request-id="} req.http.request-id
+		{" client_ip="} req.http.Fastly-Client-IP
+		{" method="} req.request
+		{" useragent="} req.http.User-Agent
+		{" url=""} req.url {"""}
+		if(geoip.city,{" geoip_city=""} geoip.city {"""},{""})
+		if(geoip.region,{" geoip_region=""} geoip.region {"""},{""})
+		if(geoip.country_code,{" geoip_country="} geoip.country_code,{""})
+		if(geoip.continent_code,{" geoip_continent="} geoip.continent_code,{""})
+		{" fastly_region="} server.region
+		{" fastly_datacenter="} server.datacenter
+		{" fastly_node="} server.identity
+		{" fastly_state="} fastly_info.state
+		{" duration_ms="} time.elapsed.msec;
 }


### PR DESCRIPTION
The reason for the low number of requests being logged is because we are not yet sure if our splunk instance will be able to handle the full traffic of polyfill.io