### PR TITLE
Bugfix: Element.prototype.placeholder not working on textarea

### DIFF
--- a/polyfills/Element/prototype/placeholder/polyfill.js
+++ b/polyfills/Element/prototype/placeholder/polyfill.js
@@ -28,6 +28,7 @@ Object.defineProperty(Element.prototype, 'placeholder', {
 		xPlaceholderRuntimeStyle.backgroundColor = 'transparent';
 		xPlaceholderRuntimeStyle.fontFamily = elementCurrentStyle.fontFamily;
 		xPlaceholderRuntimeStyle.fontSize = elementCurrentStyle.fontSize;
+		xPlaceholderRuntimeStyle.fontWeight = elementCurrentStyle.fontWeight;
 		xPlaceholderRuntimeStyle.margin = '2px 0 0 2px';
 		xPlaceholderRuntimeStyle.padding = elementCurrentStyle.padding;
 		xPlaceholderRuntimeStyle.position = 'absolute';

--- a/polyfills/Element/prototype/placeholder/polyfill.js
+++ b/polyfills/Element/prototype/placeholder/polyfill.js
@@ -4,7 +4,7 @@ Object.defineProperty(Element.prototype, 'placeholder', {
 	},
 
 	set: function (value) {
-		if (!value || !/^(input|textarea)$/i.test(this.nodeName) || !/^(email|number|password|search|tel|text|url|)$/i.test(this.getAttribute('type'))) {
+		if (!value || !/^(input|textarea)$/i.test(this.nodeName) || (/^(input)$/i.test(this.nodeName) && !/^(email|number|password|search|tel|text|url|)$/i.test(this.getAttribute('type')))) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes polyfill for Element.prototype.placeholder not working on textareas.
Adds fontWeight to placeholder styling.