### PR TITLE
Fix tests for browsers with partial Symbol support.

### DIFF
--- a/polyfills/Object/entries/tests.js
+++ b/polyfills/Object/entries/tests.js
@@ -225,7 +225,7 @@ it('accepts string primitives', function() {
 
 
 it('accepts Symbol primitives', function() {
-	if (hasSymbols) {
+	if (hasSymbols && objectKeysWorksWithPrimitives) {
 		var result = Object.entries(Symbol());
 
 		proclaim.isArray(result, 'result is an array');


### PR DESCRIPTION
Skip test if browser supports Symbol but not Object.keys with primitives.