### PR TITLE
Add bespoke detects for each Intl locale

### DIFF
--- a/polyfills/Intl/update.task.js
+++ b/polyfills/Intl/update.task.js
@@ -77,7 +77,6 @@ locales.forEach(function (file) {
 	const polyfillOutputPath = path.join(localeOutputPath, 'polyfill.js');
 	const detectOutputPath = path.join(localeOutputPath, 'detect.js');
 	const configOutputPath = path.join(localeOutputPath, 'config.json');
-// locale
 	writeFileIfChanged(polyfillOutputPath, localePolyfillSource);
 	writeFileIfChanged(detectOutputPath, intlLocaleDetectFor(locale));
 	writeFileIfChanged(configOutputPath, configFileSource);

--- a/polyfills/Intl/update.task.js
+++ b/polyfills/Intl/update.task.js
@@ -1,3 +1,5 @@
+/* eslint-env node */
+
 /*
  * This script will copy all of the localisation language files from the Intl
  * module and install them within a folder in this directory named ~locale.
@@ -40,7 +42,6 @@ function writeFileIfChanged (filePath, newFile) {
 	}
 }
 
-const detectFileSource = fs.readFileSync(path.join(IntlPolyfillOutput, 'detect.js'));
 const configSource = require(path.join(IntlPolyfillOutput, 'config.json'));
 delete configSource.install;
 
@@ -56,6 +57,12 @@ configSource.test = { ci: false };
 
 const configFileSource = JSON.stringify(configSource, null, 4);
 
+function intlLocaleDetectFor(locale) {
+    return `'Intl' in this && Intl.Collator.supportedLocalesOf('${locale}').length === 1 &&
+			Intl.DateTimeFormat.supportedLocalesOf('${locale}').length === 1 &&
+			Intl.NumberFormat.supportedLocalesOf('${locale}').length === 1`;
+}
+
 console.log('Importing Intl.~locale.* polyfill from ' + LocalesPath);
 const locales = fs.readdirSync(LocalesPath);
 locales.forEach(function (file) {
@@ -70,9 +77,9 @@ locales.forEach(function (file) {
 	const polyfillOutputPath = path.join(localeOutputPath, 'polyfill.js');
 	const detectOutputPath = path.join(localeOutputPath, 'detect.js');
 	const configOutputPath = path.join(localeOutputPath, 'config.json');
-
+// locale
 	writeFileIfChanged(polyfillOutputPath, localePolyfillSource);
-	writeFileIfChanged(detectOutputPath, detectFileSource);
+	writeFileIfChanged(detectOutputPath, intlLocaleDetectFor(locale));
 	writeFileIfChanged(configOutputPath, configFileSource);
 });
 


### PR DESCRIPTION
Detects for locales are currently:
```js
'Intl' in this
```

I propose we switch to this:
```js
'Intl' in this && Intl.Collator.supportedLocalesOf(locale).length === 1 &&
Intl.DateTimeFormat.supportedLocalesOf(locale).length === 1 &&
Intl.NumberFormat.supportedLocalesOf(locale).length === 1
```

where `locale` is the locale we are aiming at detecting support for. This is similar to the approach [yahoo/intl-locales-supported](https://github.com/yahoo/intl-locales-supported/blob/master/index.js) has taken.