### PR TITLE
Serve intl to browsers who identify as chrome <= version 34 (Samsung 2)

### DIFF
--- a/polyfills/Intl/config.json
+++ b/polyfills/Intl/config.json
@@ -5,7 +5,7 @@
 		"ie_mob": "10",
 		"firefox": "<29",
 		"opera": "<15",
-		"chrome": "<24",
+		"chrome": "<=34",
 		"safari": "<10",
 		"ios_saf": "*",
 		"firefox_mob": "*",


### PR DESCRIPTION
Resolves https://github.com/Financial-Times/polyfill-service/issues/509