### PR TITLE
Make `Array.prototype.keys` and `Array.prototype.entries` non-enumerable

### DIFF
--- a/polyfills/Array/prototype/entries/polyfill.js
+++ b/polyfills/Array/prototype/entries/polyfill.js
@@ -1,3 +1,5 @@
-Array.prototype.entries = function entries () {
-	return new ArrayIterator(this, 'key+value');
-};
+Object.defineProperty(Array.prototype, 'entries', {
+	value: function () {
+		return new ArrayIterator(this, 'key+value');
+	}
+});

--- a/polyfills/Array/prototype/entries/tests.js
+++ b/polyfills/Array/prototype/entries/tests.js
@@ -29,3 +29,14 @@ it('finally returns a done object', function () {
 		done: true
 	});
 });
+
+it('property isn\'t enumerable', function () {
+	var array = ['val1', 'val2'];
+	var enumerableLength = 0;
+
+	for (var i in array) {
+		enumerableLength++;
+	}
+
+	proclaim.equal(enumerableLength, array.length);
+});

--- a/polyfills/Array/prototype/entries/tests.js
+++ b/polyfills/Array/prototype/entries/tests.js
@@ -22,8 +22,10 @@ it('returns a next-able object', function () {
 it('finally returns a done object', function () {
 	var array = ['val1', 'val2'];
 	var iterator = array.entries();
+
 	iterator.next();
 	iterator.next();
+
 	proclaim.deepEqual(iterator.next(), {
 		value: undefined,
 		done: true

--- a/polyfills/Array/prototype/keys/polyfill.js
+++ b/polyfills/Array/prototype/keys/polyfill.js
@@ -1,4 +1,6 @@
 /* global ArrayIterator*/
-Array.prototype.keys = function keys () {
-	return new ArrayIterator(this, 'key');
-};
+Object.defineProperty(Array.prototype, 'keys', {
+	value: function () {
+		return new ArrayIterator(this, 'key');
+	}
+});

--- a/polyfills/Array/prototype/keys/tests.js
+++ b/polyfills/Array/prototype/keys/tests.js
@@ -22,10 +22,23 @@ it('returns a next-able object', function () {
 it('finally returns a done object', function () {
 	var array = ['val1', 'val2'];
 	var iterator = array.keys();
+
 	iterator.next();
 	iterator.next();
+
 	proclaim.deepEqual(iterator.next(), {
 		value: undefined,
 		done: true
 	});
+});
+
+it('property isn\'t enumerable', function () {
+	var array = ['val1', 'val2'];
+	var enumerableLength = 0;
+
+	for (var i in array) {
+		enumerableLength++;
+	}
+
+	proclaim.equal(enumerableLength, array.length);
 });


### PR DESCRIPTION
Wraps entries and keys functions in Object.defineProperty for setting enumerable to false (defineProperty sets enumerable to false by default). Issue #1036 