### PR TITLE
use URI Template in API doc

### DIFF
--- a/docs/api.html
+++ b/docs/api.html
@@ -16,7 +16,7 @@
 				<li>There are changes to the Node API.  See the README for details.</li>
 			</ul>
 
-			<h2>GET /v2/polyfill<var>:minify</var>.<var>:type</var></h2>
+			<h2>GET /v2/polyfill{.minify}.{type}{?features,excludes,flags,ua,callback,unknown,rum}</h2>
 
 			<p>Fetch a polyfill bundle.</p>
 


### PR DESCRIPTION
I find the API documentation unclear and took me a while to understand.

What do you think about using a standard URL template (RFC6570)? I didn't include the `<var></var>` tags. Please edit as you see fit. I just wasn't sure what to outline.

Given such change you could get rid of the `WHERE` column completely. Up to you