### PR TITLE
Update sponsor links

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -29,7 +29,7 @@
 				<p>The polyfill service is developed and maintained by a community of contributors led by a team at the <a href='http://www.ft.com'>Financial Times</a>.  It evolved from a previous service developed by <a href='http://www.jonathantneal.com/'>Jonathan Neal</a>, and our <code>cdn.polyfill.io</code> domain routes traffic through <a href='http://www.fastly.com'>Fastly</a>, which makes it available with global high availability and superb performance no matter where your users are.</p>
 			</div>
 			<div class='showcase__media'>
-				<a href='http://labs.ft.com'><img src='https://origami-build.ft.com/files/o-header@2.5.13/img/ft-logo.png' class='transparent' style='height:60px; margin-right:10px;vertical-align:middle' alt='FT logo' title='The polyfill service is hosted and developed by the Financial Times'></a>
+				<a href='http://www.ft.com'><img src='https://origami-build.ft.com/files/o-header@2.5.13/img/ft-logo.png' class='transparent' style='height:60px; margin-right:10px;vertical-align:middle' alt='FT logo' title='The polyfill service is hosted and developed by the Financial Times'></a>
 				<a href='http://www.fastly.com'><img src='/v2/assets/images/fastly-logo.png' class='transparent' style='height:60px; margin-right:10px;vertical-align:middle' alt='Fastly logo' title='The polyfill service is supported by Fastly'></a>
 			</div>
 		</div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -29,8 +29,8 @@
 				<p>The polyfill service is developed and maintained by a community of contributors led by a team at the <a href='http://www.ft.com'>Financial Times</a>.  It evolved from a previous service developed by <a href='http://www.jonathantneal.com/'>Jonathan Neal</a>, and our <code>cdn.polyfill.io</code> domain routes traffic through <a href='http://www.fastly.com'>Fastly</a>, which makes it available with global high availability and superb performance no matter where your users are.</p>
 			</div>
 			<div class='showcase__media'>
-				<a href='http://www.ft.com'><img src='https://origami-build.ft.com/files/o-header@2.5.13/img/ft-logo.png' class='transparent' style='height:60px; margin-right:10px;vertical-align:middle' alt='FT logo' title='The polyfill service is hosted and developed by the Financial Times'></a>
-				<a href='http://www.fastly.com'><img src='/v2/assets/images/fastly-logo.png' class='transparent' style='height:60px; margin-right:10px;vertical-align:middle' alt='Fastly logo' title='The polyfill service is supported by Fastly'></a>
+				<a href='https://www.ft.com'><img src='https://origami-build.ft.com/files/o-header@2.5.13/img/ft-logo.png' class='transparent' style='height:60px; margin-right:10px;vertical-align:middle' alt='FT logo' title='The polyfill service is hosted and developed by the Financial Times'></a>
+				<a href='https://www.fastly.com'><img src='/v2/assets/images/fastly-logo.png' class='transparent' style='height:60px; margin-right:10px;vertical-align:middle' alt='Fastly logo' title='The polyfill service is supported by Fastly'></a>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
Linking to www.ft.com instead of labs.ft.com as this project has not been maintained by any Labs developers for some time.

Linking to https domain instead of http.