### PR TITLE
Update polyfills config for Samsung Internet 5

### DIFF
--- a/polyfills/Array/from/config.json
+++ b/polyfills/Array/from/config.json
@@ -19,7 +19,7 @@
 		"firefox_mob": "<32",
 		"android": "*",
 		"ios_saf": "<9",
-		"samsung_mob": "*",
+		"samsung_mob": "<5",
 		"bb": "10 - *"
 	},
 	"dependencies": [

--- a/polyfills/Array/of/config.json
+++ b/polyfills/Array/of/config.json
@@ -17,7 +17,7 @@
 		"firefox_mob": "<25",
 		"android": "*",
 		"ios_saf": "<9",
-		"samsung_mob": "*"
+		"samsung_mob": "<5"
 	},
 	"dependencies": [
 		"Object.defineProperty"

--- a/polyfills/Array/prototype/@@iterator/config.json
+++ b/polyfills/Array/prototype/@@iterator/config.json
@@ -12,7 +12,7 @@
 		"android": "<5.1",
 		"ios_saf": "<9",
 		"opera": "<25",
-		"samsung_mob": "*"
+		"samsung_mob": "<5"
 	},
 	"dependencies": [
 		"_ArrayIterator",

--- a/polyfills/Array/prototype/entries/config.json
+++ b/polyfills/Array/prototype/entries/config.json
@@ -12,7 +12,7 @@
 		"android": "<5.1",
 		"ios_saf": "<8",
 		"opera": "<25",
-		"samsung_mob": "*"
+		"samsung_mob": "<5"
 	},
 	"dependencies": [
 		"_ArrayIterator",

--- a/polyfills/Array/prototype/fill/config.json
+++ b/polyfills/Array/prototype/fill/config.json
@@ -14,7 +14,7 @@
 		"chrome": "< 45",
 		"android": "*",
 		"ios_saf": "<= 7",
-		"samsung_mob": "*"
+		"samsung_mob": "<5"
 	},
 	"dependencies": [
 		"Object.defineProperty"

--- a/polyfills/Array/prototype/findIndex/config.json
+++ b/polyfills/Array/prototype/findIndex/config.json
@@ -15,7 +15,7 @@
 		"ios_chr": "* - 8.0",
 		"android": "*",
 		"firefox_mob": "3.6 - 24",
-		"samsung_mob": "*"
+		"samsung_mob": "<5"
 	},
 	"dependencies": [
 		"Object.defineProperty"

--- a/polyfills/Array/prototype/includes/config.json
+++ b/polyfills/Array/prototype/includes/config.json
@@ -15,7 +15,7 @@
 		"op_mob": "*",
 		"ie_mob": "*",
 		"firefox_mob": "*",
-		"samsung_mob": "*",
+		"samsung_mob": "<5",
 		"bb": "10 - *"
 	},
 	"license": "CC0",

--- a/polyfills/Array/prototype/keys/config.json
+++ b/polyfills/Array/prototype/keys/config.json
@@ -12,7 +12,7 @@
 		"android": "<5.1",
 		"ios_saf": "<8",
 		"opera": "<25",
-		"samsung_mob": "*"
+		"samsung_mob": "<5"
 	},
 	"dependencies": [
 		"_ArrayIterator",

--- a/polyfills/Array/prototype/values/config.json
+++ b/polyfills/Array/prototype/values/config.json
@@ -12,7 +12,7 @@
 		"android": "*",
 		"ios_saf": "<9",
 		"opera": "*",
-		"samsung_mob": "*"
+		"samsung_mob": "<5"
 	},
 	"dependencies": [
 		"Symbol.iterator",

--- a/polyfills/DOMTokenList/prototype/@@iterator/config.json
+++ b/polyfills/DOMTokenList/prototype/@@iterator/config.json
@@ -7,7 +7,7 @@
 		"firefox": "<40",
 		"ios_saf": "*",
 		"opera": "<50",
-		"samsung_mob": "*",
+		"samsung_mob": "<5",
 		"bb": "10 - *"
 	},
 	"dependencies": [

--- a/polyfills/Event/hashchange/config.json
+++ b/polyfills/Event/hashchange/config.json
@@ -11,7 +11,7 @@
 	"browsers": {
 		"ie": "6 - 7",
 		"safari": "4",
-		"samsung_mob": "*"
+		"samsung_mob": "<5"
 	},
 	"dependencies": [
 		"Event"

--- a/polyfills/NodeList/prototype/@@iterator/config.json
+++ b/polyfills/NodeList/prototype/@@iterator/config.json
@@ -7,7 +7,7 @@
 		"firefox": "<40",
 		"ios_saf": "*",
 		"opera": "<50",
-		"samsung_mob": "*",
+		"samsung_mob": "<5",
 		"bb": "10 - *"
 	},
 	"dependencies": [

--- a/polyfills/Number/isInteger/config.json
+++ b/polyfills/Number/isInteger/config.json
@@ -15,7 +15,7 @@
 		"opera": "<22",
 		"op_mob": "*",
 		"op_mini": "*",
-		"samsung_mob": "*",
+		"samsung_mob": "<5",
 		"bb": "*"
 	},
 	"license": "MIT",

--- a/polyfills/Object/assign/config.json
+++ b/polyfills/Object/assign/config.json
@@ -22,7 +22,7 @@
 		"op_mini": "*",
 		"safari": "1 - 8",
 		"firefox_mob": "1 - 33",
-		"samsung_mob": "*"
+		"samsung_mob": "<5"
 	},
 	"docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign"
 }

--- a/polyfills/Symbol/config.json
+++ b/polyfills/Symbol/config.json
@@ -10,7 +10,7 @@
 		"firefox": "< 40",
 		"ios_saf": "<9",
 		"opera": "< 37",
-		"samsung_mob": "*",
+		"samsung_mob": "<5",
 		"android": "<5.1",
 		"bb": "10 - *"
 	},

--- a/polyfills/Symbol/hasInstance/config.json
+++ b/polyfills/Symbol/hasInstance/config.json
@@ -10,7 +10,7 @@
 		"firefox": "< 40",
 		"ios_saf": "*",
 		"opera": "< 37",
-		"samsung_mob": "*",
+		"samsung_mob": "<5",
 		"android": "*",
 		"bb": "10 - *"
 	},

--- a/polyfills/Symbol/isConcatSpreadable/config.json
+++ b/polyfills/Symbol/isConcatSpreadable/config.json
@@ -10,7 +10,7 @@
 		"firefox": "< 40",
 		"ios_saf": "*",
 		"opera": "< 37",
-		"samsung_mob": "*",
+		"samsung_mob": "<5",
 		"android": "*",
 		"bb": "10 - *"
 	},

--- a/polyfills/Symbol/iterator/config.json
+++ b/polyfills/Symbol/iterator/config.json
@@ -10,7 +10,7 @@
 		"firefox": "< 40",
 		"ios_saf": "*",
 		"opera": "< 37",
-		"samsung_mob": "*",
+		"samsung_mob": "<5",
 		"android": "<5.1",
 		"bb": "10 - *"
 	},

--- a/polyfills/Symbol/match/config.json
+++ b/polyfills/Symbol/match/config.json
@@ -10,7 +10,7 @@
 		"firefox": "< 40",
 		"ios_saf": "*",
 		"opera": "< 37",
-		"samsung_mob": "*",
+		"samsung_mob": "<5",
 		"android": "*",
 		"bb": "10 - *"
 	},

--- a/polyfills/Symbol/replace/config.json
+++ b/polyfills/Symbol/replace/config.json
@@ -10,7 +10,7 @@
 		"firefox": "< 40",
 		"ios_saf": "*",
 		"opera": "< 37",
-		"samsung_mob": "*",
+		"samsung_mob": "<5",
 		"android": "*",
 		"bb": "10 - *"
 	},

--- a/polyfills/Symbol/search/config.json
+++ b/polyfills/Symbol/search/config.json
@@ -10,7 +10,7 @@
 		"firefox": "< 40",
 		"ios_saf": "*",
 		"opera": "< 37",
-		"samsung_mob": "*",
+		"samsung_mob": "<5",
 		"android": "*",
 		"bb": "10 - *"
 	},

--- a/polyfills/Symbol/species/config.json
+++ b/polyfills/Symbol/species/config.json
@@ -10,7 +10,7 @@
 		"firefox": "< 40",
 		"ios_saf": "*",
 		"opera": "< 37",
-		"samsung_mob": "*",
+		"samsung_mob": "<5",
 		"android": "*",
 		"bb": "10 - *"
 	},

--- a/polyfills/Symbol/split/config.json
+++ b/polyfills/Symbol/split/config.json
@@ -10,7 +10,7 @@
 		"firefox": "< 40",
 		"ios_saf": "*",
 		"opera": "< 37",
-		"samsung_mob": "*",
+		"samsung_mob": "<5",
 		"android": "*",
 		"bb": "10 - *"
 	},

--- a/polyfills/Symbol/toPrimitive/config.json
+++ b/polyfills/Symbol/toPrimitive/config.json
@@ -10,7 +10,7 @@
 		"firefox": "< 40",
 		"ios_saf": "*",
 		"opera": "< 37",
-		"samsung_mob": "*",
+		"samsung_mob": "<5",
 		"android": "*",
 		"bb": "10 - *"
 	},

--- a/polyfills/Symbol/toStringTag/config.json
+++ b/polyfills/Symbol/toStringTag/config.json
@@ -10,7 +10,7 @@
 		"firefox": "< 40",
 		"ios_saf": "*",
 		"opera": "< 37",
-		"samsung_mob": "*",
+		"samsung_mob": "<5",
 		"android": "*",
 		"bb": "10 - *"
 	},

--- a/polyfills/Symbol/unscopables/config.json
+++ b/polyfills/Symbol/unscopables/config.json
@@ -10,7 +10,7 @@
 		"firefox": "< 40",
 		"ios_saf": "*",
 		"opera": "< 37",
-		"samsung_mob": "*",
+		"samsung_mob": "<5",
 		"android": "*",
 		"bb": "10 - *"
 	},

--- a/polyfills/URL/config.json
+++ b/polyfills/URL/config.json
@@ -16,7 +16,7 @@
 		"firefox_mob": "<29",
 		"opera": "<36",
 		"android": "*",
-		"samsung_mob": "*",
+		"samsung_mob": "<5",
 		"ios_saf": "*"
 	},
 	"dependencies": [


### PR DESCRIPTION
This PR is to update the configuration of the polyfills to account for the recently released Samsung Internet 5.0. This will also be valid for subsequent 5.x releases, such as the 5.2 Beta.

Note: Promise test is failing because of absence of finally but that issue is present in the other browsers set to not receive the polyfill, left it unpolyfilled to match behaviour.

Note: Can not get intersectionObserver tests to pass regardless of presence of polyfill.