### PR TITLE
Fix for errant comments in imported sources, fixes #1080

### DIFF
--- a/tasks/node/buildsources.js
+++ b/tasks/node/buildsources.js
@@ -192,7 +192,7 @@ class Polyfill {
             // skipping any validation or minification process since
             // the raw source is supposed to be production ready.
             // Add a line break in case the final line is a comment
-            return { raw, min: source + '\n' };
+            return { raw: raw + '\n', min: source + '\n' };
         }
         else {
             validateSource(source, `${this.name} from ${this.sourcePath}`);


### PR DESCRIPTION
As described in #1080, if an imported polyfill (Intl in this case) includes a comment on the final line, and no trailing LF, then when it is wrapped in our outer IIFE, it's possible for the closing `)` of the IIFE to be appended to the comment.  Adding an extra line break prevents this.