### PR TITLE
Cache results to avoid extraneous fs operations

### DIFF
--- a/lib/sources.js
+++ b/lib/sources.js
@@ -5,6 +5,12 @@ const fs = require('graceful-fs');
 const denodeify = require('denodeify');
 const readFile = denodeify(fs.readFile);
 
+const streamFromString = require('from2-string');
+const streamToString = require('stream-to-string');
+const cache = require('lru-cache')({
+	max: 5000
+});
+
 const polyfillsPath = path.join(__dirname, '../polyfills/__dist');
 
 let features;
@@ -44,8 +50,19 @@ exports.getConfigAliasesSync = function(featureName) {
 	return configuredAliases[featureName];
 };
 
-exports.streamPolyfillSource = function(featureName, type) {
-	return fs.createReadStream(path.join(polyfillsPath, featureName, type+'.js'), {encoding: 'UTF-8'});
+exports.streamPolyfillSource = function (featureName, type) {
+	const key = featureName + type;
+	const hit = cache.get(key);
+	if (hit) {
+		return streamFromString(hit);
+	} else {
+		const polyfill = fs.createReadStream(path.join(polyfillsPath, featureName, type + '.js'), { encoding: 'UTF-8' });
+
+		streamToString(polyfill)
+			.then(polyfillString => cache.set(key, polyfillString));
+
+		return polyfill;
+	}
 };
 
 // TODO: deprecate this


### PR DESCRIPTION
Currently on the service, each request which hits the server for a polyfill bundle will cause the server to open a read stream for each polyfill inside the bundle. This is what caused the issue yesterday when the server ran out of available file descriptors.

Making use of a Least Recently Used (LRU) cache will help avoid making read streams for frequently requested polyfills.