### PR TITLE
Update iOS Safari browser versions for Symbol

### DIFF
--- a/polyfills/Symbol/hasInstance/config.json
+++ b/polyfills/Symbol/hasInstance/config.json
@@ -8,7 +8,7 @@
 		"safari": "<9",
 		"chrome": "< 50",
 		"firefox": "< 40",
-		"ios_saf": "*",
+		"ios_saf": "< 10",
 		"opera": "< 37",
 		"samsung_mob": "<5",
 		"android": "*",

--- a/polyfills/Symbol/isConcatSpreadable/config.json
+++ b/polyfills/Symbol/isConcatSpreadable/config.json
@@ -8,7 +8,7 @@
 		"safari": "<9",
 		"chrome": "< 50",
 		"firefox": "< 40",
-		"ios_saf": "*",
+		"ios_saf": "< 10",
 		"opera": "< 37",
 		"samsung_mob": "<5",
 		"android": "*",

--- a/polyfills/Symbol/iterator/config.json
+++ b/polyfills/Symbol/iterator/config.json
@@ -8,7 +8,7 @@
 		"safari": "<9",
 		"chrome": "< 50",
 		"firefox": "< 40",
-		"ios_saf": "<10",
+		"ios_saf": "< 9",
 		"opera": "< 37",
 		"samsung_mob": "<5",
 		"android": "<5.1",

--- a/polyfills/Symbol/match/config.json
+++ b/polyfills/Symbol/match/config.json
@@ -8,7 +8,7 @@
 		"safari": "<9",
 		"chrome": "< 50",
 		"firefox": "< 40",
-		"ios_saf": "*",
+		"ios_saf": "< 10",
 		"opera": "< 37",
 		"samsung_mob": "<5",
 		"android": "*",

--- a/polyfills/Symbol/replace/config.json
+++ b/polyfills/Symbol/replace/config.json
@@ -8,7 +8,7 @@
 		"safari": "<9",
 		"chrome": "< 50",
 		"firefox": "< 40",
-		"ios_saf": "*",
+		"ios_saf": "< 10",
 		"opera": "< 37",
 		"samsung_mob": "<5",
 		"android": "*",

--- a/polyfills/Symbol/search/config.json
+++ b/polyfills/Symbol/search/config.json
@@ -8,7 +8,7 @@
 		"safari": "<9",
 		"chrome": "< 50",
 		"firefox": "< 40",
-		"ios_saf": "*",
+		"ios_saf": "< 10",
 		"opera": "< 37",
 		"samsung_mob": "<5",
 		"android": "*",

--- a/polyfills/Symbol/split/config.json
+++ b/polyfills/Symbol/split/config.json
@@ -8,7 +8,7 @@
 		"safari": "<9",
 		"chrome": "< 50",
 		"firefox": "< 40",
-		"ios_saf": "*",
+		"ios_saf": "< 10",
 		"opera": "< 37",
 		"samsung_mob": "<5",
 		"android": "*",

--- a/polyfills/Symbol/toPrimitive/config.json
+++ b/polyfills/Symbol/toPrimitive/config.json
@@ -8,7 +8,7 @@
 		"safari": "<9",
 		"chrome": "< 50",
 		"firefox": "< 40",
-		"ios_saf": "*",
+		"ios_saf": "< 10",
 		"opera": "< 37",
 		"samsung_mob": "<5",
 		"android": "*",

--- a/polyfills/Symbol/toStringTag/config.json
+++ b/polyfills/Symbol/toStringTag/config.json
@@ -8,7 +8,7 @@
 		"safari": "<9",
 		"chrome": "< 50",
 		"firefox": "< 40",
-		"ios_saf": "*",
+		"ios_saf": "< 10",
 		"opera": "< 37",
 		"samsung_mob": "<5",
 		"android": "*",

--- a/polyfills/Symbol/unscopables/config.json
+++ b/polyfills/Symbol/unscopables/config.json
@@ -8,7 +8,7 @@
 		"safari": "<9",
 		"chrome": "< 50",
 		"firefox": "< 40",
-		"ios_saf": "*",
+		"ios_saf": "< 9",
 		"opera": "< 37",
 		"samsung_mob": "<5",
 		"android": "*",


### PR DESCRIPTION
Based on https://kangax.github.io/compat-table/es6/ iOS 10 has full support for `Symbol` and iOS 9 only needs the well-known Symbols e.g. `Symbol.iterator` - not `Symbol` itself.

This is the error I'm seeing on `https://qa.polyfill.io/v2/`.
![screen shot 2017-03-13 at 10 21 29](https://cloud.githubusercontent.com/assets/1671025/23850331/dd1feb78-07d6-11e7-9012-f1c174df7479.png)