### PR TITLE
Fix UA detection for wkwebview

### DIFF
--- a/lib/UA.js
+++ b/lib/UA.js
@@ -85,6 +85,7 @@ const aliases = {
 	"iphone": "ios_saf",
 	"iphone simulator": "ios_saf",
 	"mobile safari uiwebview": "ios_saf",
+	"mobile safari ui/wkwebview": "ios_saf",
 	"facebook": function(ua) {
 		if (ua.os.family === 'iOS') {
 			return {family:'ios_saf', major: ua.os.major, minor:ua.os.minor};

--- a/test/node/lib/test_ua.js
+++ b/test/node/lib/test_ua.js
@@ -27,6 +27,11 @@ describe("UA", () => {
 			proclaim.equal(test, "ie/12.10130.0");
 		});
 
+		it("should resolve wkwebview to the iOS family", () => {
+			const test = UA.normalize("Mozilla/5.0 (iPhone; CPU iPhone OS 10_2_1 like Mac OS X) AppleWebKit/602.4.6 (KHTML, like Gecko) Mobile/14D27");
+			proclaim.equal(test, "ios_saf/10.2.0");
+		});
+
 		it("should resolve Facebook iOS App to the version of iOS it is running within", () => {
 			let test = UA.normalize("Mozilla/5.0 (iPad; CPU OS 6_0_1 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Mobile/10A523 [FBAN/FBIOS;FBAV/6.0.1;FBBV/180945;FBDV/iPad2,1;FBMD/iPad;FBSN/iPhone OS;FBSV/6.0.1;FBSS/1; FBCR/;FBID/tablet;FBLC/en_US;FBOP/1]");
 			proclaim.equal(test, "ios_saf/6.0.0");


### PR DESCRIPTION
ref: https://github.com/Financial-Times/polyfill-service/issues/1121

The family of wkwebview is `mobile safari ui/wkwebview`.