### PR TITLE
Polyfill prepend for DocumentFragment

### DIFF
--- a/polyfills/DocumentFragment/prototype/prepend/config.json
+++ b/polyfills/DocumentFragment/prototype/prepend/config.json
@@ -1,0 +1,30 @@
+{
+	"aliases": [
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
+		"default"
+	],
+	"browsers": {
+		"android": "*",
+		"bb": "*",
+		"chrome": "<54",
+		"firefox": "<49",
+		"ios_chr": "*",
+		"ios_saf": "<10",
+		"ie": "8 - *",
+		"ie_mob": "10 - *",
+		"opera": "*",
+		"op_mini": "*",
+		"safari": "<10",
+		"firefox_mob": "<49",
+		"samsung_mob": "*"
+	},
+	"dependencies": [
+		"Document",
+		"DocumentFragment",
+		"Element",
+		"_mutation"
+	],
+	"spec": "https://dom.spec.whatwg.org/#dom-parentnode-prepend"
+}

--- a/polyfills/DocumentFragment/prototype/prepend/detect.js
+++ b/polyfills/DocumentFragment/prototype/prepend/detect.js
@@ -1,0 +1,1 @@
+'DocumentFragment' in this && 'prepend' in DocumentFragment.prototype

--- a/polyfills/DocumentFragment/prototype/prepend/polyfill.js
+++ b/polyfills/DocumentFragment/prototype/prepend/polyfill.js
@@ -1,0 +1,3 @@
+DocumentFragment.prototype.prepend = function prepend() {
+	this.insertBefore(_mutation(arguments), this.firstChild);
+};

--- a/polyfills/DocumentFragment/prototype/prepend/tests.js
+++ b/polyfills/DocumentFragment/prototype/prepend/tests.js
@@ -1,0 +1,34 @@
+/* eslint-env mocha, browser*/
+/* global proclaim, it */
+
+var fragment, child;
+
+function nameOf(fn) {
+        return Function.prototype.toString.call(fn).match(/function\s*([^\s]*)\(/)[1];
+}
+
+beforeEach(function () {
+	fragment = document.createDocumentFragment();
+});
+
+it('has correct instance', function () {
+        proclaim.isInstanceOf(fragment.prepend, Function);
+});
+
+it('has correct name', function () {
+        proclaim.equal(nameOf(fragment.prepend), 'prepend');
+});
+
+it('has correct argument length', function () {
+        proclaim.equal(fragment.prepend.length, 0);
+});
+
+it('can prepend elements to itself', function () {
+        proclaim.equal(fragment.prepend(document.createElement('div')), undefined);
+        proclaim.equal(fragment.prepend(document.createElement('div'), document.createElement('div')), undefined);
+        proclaim.equal(fragment.prepend('text', document.createElement('div')), undefined);
+
+        proclaim.equal(fragment.childNodes.length, 5);
+        proclaim.equal(fragment.firstChild.nodeName, '#text');
+});
+


### PR DESCRIPTION
According to:
- https://dom.spec.whatwg.org/#dom-parentnode-prepend
- https://dom.spec.whatwg.org/#interface-parentnode
- https://developer.mozilla.org/en-US/docs/Web/API/ParentNode/prepend

Prepend is a method for ParentNode yet ParentNode is an interface
which is implemented by Document, DocumentFragment and Element.
So prepend should be polyfilled for DocumentFragment too.
Polyfill provided by MozillaDeveloperNetwork confirms it.