### PR TITLE
Prevent Map/Set polyfills from failing on UCBrowser (#1172)

### DIFF
--- a/polyfills/Map/polyfill.js
+++ b/polyfills/Map/polyfill.js
@@ -142,6 +142,6 @@
 	Map.length = 0;
 
 	// Export the object
-	this.Map = Map;
+	global.Map = Map;
 
 }(this));

--- a/polyfills/Set/polyfill.js
+++ b/polyfills/Set/polyfill.js
@@ -106,6 +106,6 @@
 	Set.length = 0;
 
 	// Export the object
-	this.Set = Set;
+	global.Set = Set;
 
 }(this));


### PR DESCRIPTION
Map/Set polyfills fail on UC Browser, since `this` is undefined
inside the IIFE on UC Browser. Since the global object is already passed to the
IIFE, using `global` in place of `this` resolves the issue.

Fixes #1172 