### PR TITLE
Serve NodeList.prototype[Symbol.iterator] to Safari 9

### DIFF
--- a/polyfills/NodeList/prototype/@@iterator/config.json
+++ b/polyfills/NodeList/prototype/@@iterator/config.json
@@ -2,7 +2,7 @@
 	"browsers": {
 		"ie": "9 - *",
 		"ie_mob": "9 - *",
-		"safari": "<9",
+		"safari": "<10",
 		"chrome": "<50",
 		"firefox": "<40",
 		"ios_saf": "*",


### PR DESCRIPTION
https://developer.mozilla.org/en/docs/Web/API/NodeList#Browser_compatibility