### PR TITLE
Add a feature detect for mutationobserver, fixes #1155

### DIFF
--- a/polyfills/MutationObserver/detect.js
+++ b/polyfills/MutationObserver/detect.js
@@ -1,0 +1,1 @@
+"MutationObserver" in this

--- a/service/routes/test.js
+++ b/service/routes/test.js
@@ -44,18 +44,18 @@ function createEndpoint(type, polyfillio) {
 				return Promise.all(featuresList.map(featureName => {
 					return polyfillio.describePolyfill(featureName)
 						.then(config => {
-							if (config.isTestable && config.isPublic && config.hasTests) {
-								const baseDir = path.join(__dirname, '../../polyfills');
-								const testFile = path.join(baseDir, config.baseDir, '/tests.js');
-								return readFile(testFile)
-									.then(tests => {
-										return {
-											feature: featureName,
-											detect: config.detectSource ? config.detectSource : false,
-											tests
-										};
-									})
-								;
+							if (config.isTestable && config.isPublic) {
+								let testsPromise = Promise.resolve([]);
+								if (config.hasTests) {
+									const baseDir = path.join(__dirname, '../../polyfills');
+									const testFile = path.join(baseDir, config.baseDir, '/tests.js');
+									testsPromise = readFile(testFile);
+								}
+								return testsPromise.then(tests => ({
+									feature: featureName,
+									detect: config.detectSource ? config.detectSource : false,
+									tests
+								}));
 							}
 						})
 					;


### PR DESCRIPTION
Without a detect.js, our compat generator will show the feature passing in every browser.  Also found that features without a tests.js file were also not running any tests even though they could run a simple test suite using just the detect.  We used to do that so I suspect that regressed at some point without us noticing.