### PR TITLE
Default value of deep parameter should be false (Fixes #1189)

### DIFF
--- a/polyfills/Element/prototype/cloneNode/config.json
+++ b/polyfills/Element/prototype/cloneNode/config.json
@@ -8,7 +8,8 @@
 		"blissfuljs"
 	],
 	"browsers": {
-		"ie": "8"
+		"ie": "8",
+		"firefox": "<30"
 	},
 	"dependencies": [
 		"Element"

--- a/polyfills/Element/prototype/cloneNode/detect.js
+++ b/polyfills/Element/prototype/cloneNode/detect.js
@@ -3,7 +3,9 @@
 	test.type = "radio";
 	test.checked = true;
 	div.appendChild(test);
-	var result = test.cloneNode();
-	var result2 = div.cloneNode();
-	return !!result.checked && (result2.childNodes.length === 0);
+	var result = test.cloneNode(false), result2;
+	try {
+		result2 = div.cloneNode();
+	} catch (e) {}
+	return !!result.checked && (!result2 || result2.childNodes.length === 0);
 })()

--- a/polyfills/Element/prototype/cloneNode/detect.js
+++ b/polyfills/Element/prototype/cloneNode/detect.js
@@ -1,6 +1,8 @@
 'document' in this && "cloneNode" in document.documentElement && (function() {
-	var test = document.createElement('input');
+	var div = document.createElement('div'), test = document.createElement('input');
 	test.checked = true;
+	div.appendChild(test);
 	var result = test.cloneNode();
-	return !!result.checked;
+	var result2 = div.cloneNode();
+	return !!result.checked && (result2.childNodes.length === 0);
 })()

--- a/polyfills/Element/prototype/cloneNode/polyfill.js
+++ b/polyfills/Element/prototype/cloneNode/polyfill.js
@@ -1,5 +1,8 @@
-Element.prototype.cloneNode = (function(nativeFunc) {
+Element.prototype.cloneNode = (function(nativeFunc, undefined) {
 	return function(deep) {
+		if (deep === undefined) {
+			deep = false;
+		}
 		var clone = nativeFunc.call(this, deep);
 
 		if ('checked' in this) clone.checked = this.checked;


### PR DESCRIPTION
According to MDN, the default value for the deep parameter was true in Firefox up to v29.

https://developer.mozilla.org/en/docs/Web/API/Node/cloneNode

Fixes #1189