### PR TITLE
Do not include fetch in latest safari and safari ios versions

### DIFF
--- a/polyfills/fetch/config.json
+++ b/polyfills/fetch/config.json
@@ -6,9 +6,9 @@
 		"ie_mob": "*",
 		"firefox": "* - 38",
 		"opera": "* - 28",
-		"safari": "*",
+		"safari": "< 10.1",
 		"chrome": "* - 41",
-		"ios_saf": "*",
+		"ios_saf": "< 10.3 ",
 		"firefox_mob": "* - 38"
 	},
 	"dependencies": [


### PR DESCRIPTION
Update fetch config for safari and safari ios. Fetch has been added to the latest version of those browser: http://caniuse.com/#search=fetch