### PR TITLE
Fix Set.prototype[@@iterator]

### DIFF
--- a/polyfills/Set/polyfill.js
+++ b/polyfills/Set/polyfill.js
@@ -72,11 +72,11 @@
 		this.size = this._size = 0;
 	};
 	Set.prototype['values'] =
-	Set.prototype['keys'] = function() {
+	Set.prototype['keys'] =
+	Set.prototype[Symbol.iterator] = function() {
 		return makeIterator(this, function(i) { return decodeVal(this._values[i]); });
 	};
-	Set.prototype['entries'] =
-	Set.prototype[Symbol.iterator] = function() {
+	Set.prototype['entries'] = function() {
 		return makeIterator(this, function(i) { return [decodeVal(this._values[i]), decodeVal(this._values[i])]; });
 	};
 	Set.prototype['forEach'] = function(callbackFn, thisArg) {

--- a/polyfills/Set/tests.js
+++ b/polyfills/Set/tests.js
@@ -104,6 +104,10 @@ it("exhibits correct iterator behaviour", function () {
 	proclaim.equal(lastResult.value, void 0);
 });
 
+it("implements @@iterator() as an alias for .values()", function () {
+	proclaim.equal(o.values, o[Symbol.iterator]);
+});
+
 it("implements .forEach()", function () {
 	var o = new Set(), i = 0;
 	o.add("val 0");


### PR DESCRIPTION
As per spec (https://tc39.github.io/ecma262/#sec-set.prototype-@@iterator -
23.2.3.11) Set.prototype[@@iterator] must be equal to Set.prototype.values.

Currently the @@iterator() method is an alias for .entries(), which is
incorrect and easily breaks any code that uses this Set polyfill.

For example, a for-of loop transpiled by Babel will call the @@iterator()
method and get the wrong objects (array entries instead of the values in
the set): http://jsbin.com/jenavoxumu/1/edit?html,js,console