### PR TITLE
Object.entries is only available on chrome 54+

### DIFF
--- a/polyfills/Object/entries/config.json
+++ b/polyfills/Object/entries/config.json
@@ -5,7 +5,7 @@
 	"browsers": {
 		"ie": "9 - 14",
 		"ie_mob": "*",
-		"chrome": "< 51",
+		"chrome": "< 54",
 		"ios_chr": "*",
 		"safari": "*",
 		"ios_saf": "*",


### PR DESCRIPTION
https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_objects/Object/entries