### PR TITLE
Fix script injection in 'unknown' parameter - allows for CSP bypass

### DIFF
--- a/service/routes/api.js
+++ b/service/routes/api.js
@@ -64,7 +64,7 @@ router.get(/^\/v2\/polyfill(\.\w+)(\.\w+)?/, (req, res) => {
 		stream: true
 	};
 	if (req.query.unknown) {
-		params.unknown = req.query.unknown;
+		params.unknown = (req.query.unknown === 'polyfill') ? 'polyfill' : 'ignore';
 	}
 	if (uaString) {
 		params.uaString = uaString;


### PR DESCRIPTION
When using the unminified version `polyfill.js` there is a script injection vulnerability which allows to inject arbitrary scripts using the `unknown` parameter.

Consider the following URL: https://cdn.polyfill.io/v2/polyfill.js?ua=foo&unknown=*/%0aalert(document.domain)%0a/%2a
It will return:

```javascript
/* Polyfill service v3.18.1
 * For detailed credits and licence information see https://github.com/financial-times/polyfill-service.
 * 
 * UA detected: other/0.0.0 (unknown/unsupported; using policy `unknown=*/
alert(document.domain)
/*`)
 * Features requested: default
 *  */

/* No polyfills found for current settings */
```

Notice that we managed to break out of the multiline comments and insert a simple `alert(document.domain)`.

### Why is this bad?
Many sites employ CSP directives, which specify from which domains scripts can be loaded and executed.
For example the following CSP configuration would only allow execution of the specific polyfill.js script and scripts served from the same domain as the website (`'self'`).
```
Content-Security-Policy: script-src 'self' https://cdn.polyfill.io/v2/polyfill.js; default-src 'self';
```
In case of a XSS vulnerability, an attacker would not be able to execute his payloads because inline javascript (for example `<script>...</script>`)is forbidden. All he could do is include any external javascript files from the same domain or the polyfill.js file. He can then abuse the bug described in this report by loading the polyfill file with his own payload, which in turn will then get executed.

### Fix
Since `unknown` can only take `polyfill` and `ignore` as valid values according to the documentation, it would be best to explicitly only allow those two.
I have fixed it in the API, but maybe it would be better to fix it in the library (https://github.com/Financial-Times/polyfill-service/blob/master/lib/index.js#L29) instead / as well?