### PR TITLE
Do not use the callback value if it is not a string

### DIFF
--- a/service/routes/api.js
+++ b/service/routes/api.js
@@ -78,7 +78,7 @@ router.get(/^\/v2\/polyfill(\.\w+)(\.\w+)?/, (req, res) => {
 
 	outputStream.add(polyfillio.getPolyfillString(params));
 
-	if (req.query.callback && req.query.callback.match(/^[\w\.]+$/)) {
+	if (req.query.callback && typeof req.query.callback === 'string' && req.query.callback.match(/^[\w\.]+$/)) {
 		outputStream.add(streamFromString("\ntypeof "+req.query.callback+"==='function' && "+req.query.callback+"();"));
 	}
 

--- a/test/integration/v2/api.js
+++ b/test/integration/v2/api.js
@@ -25,6 +25,21 @@ describe('GET /v2/polyfill.js', function() {
 	});
 });
 
+describe('GET /v2/polyfill.js?callback=AAA&callback=BBB', function() {
+	setupRequest('GET', '/v2/polyfill.js?callback=AAA&callback=BBB');
+	itRespondsWithStatus(200);
+	itRespondsWithContentType('application/javascript');
+	itRespondsWithHeader('cache-control', 'public, s-maxage=31536000, max-age=604800, stale-while-revalidate=604800, stale-if-error=604800');
+	itRespondsWithHeader('surrogate-key', 'polyfill-service');
+
+	it('responds with valid javascript', function() {
+		return this.request.expect(response => {
+			assert.isString(response.text);
+			assert.doesNotThrow(() => new vm.Script(response.text));
+		});
+	});
+});
+
 describe('GET /v2/polyfill.min.js', function() {
 	setupRequest('GET', '/v2/polyfill.min.js');
 	itRespondsWithStatus(200);


### PR DESCRIPTION
Issue:
We use a query-string parser which turns query-strings such as `callback=complete&callback=done` into an object containing an array `{callback: ['complete', 'done'}`. We have assumed we only get strings back, not arrays. We are trying to call a `String.prototype` method on the `callback` array, which is causing a runtime error to be thrown.

Resolution:
Check the type of the callback value, if it is not a string, do not do anything with it, act like the request was not passed a callback value.

First commit added the test (this commit should fail), second commit added the fix (this commit should pass).