### PR TITLE
Do not run compat task on android 4.3 or 4.2

### DIFF
--- a/tasks/node/remotetest.js
+++ b/tasks/node/remotetest.js
@@ -79,8 +79,8 @@ const browserSets = {
 		'android/5.1',
 		'android/5',
 		'android/4.4',
-		'android/4.3',
-		'android/4.2',
+		// 'android/4.3', // Not working correctly on BrowserStack or SauceLabs
+		// 'android/4.2', // Not working correctly on BrowserStack or SauceLabs
 		'ios_saf/10.3',
 		'ios_saf/9.1',
 		'ios_saf/8',


### PR DESCRIPTION
BrowserStack is having Selenium issues on Android 4.3 and Android 4.2, these issues are stopping us from generating our compatibility file. Since we do not actually use the compatibility data for mobile browsers on our website, I suggest we do not run the compatibility task on these devices.