### PR TITLE
Fix Map polyfill clear method

### DIFF
--- a/polyfills/Map/polyfill.js
+++ b/polyfills/Map/polyfill.js
@@ -104,7 +104,8 @@
 		return true;
 	};
 	Map.prototype['clear'] = function() {
-		this._keys = this._values = [];
+		this._keys = [];
+		this._values = [];
 		this.size = this._size = 0;
 	};
 	Map.prototype['values'] = function() {

--- a/polyfills/Map/tests.js
+++ b/polyfills/Map/tests.js
@@ -202,5 +202,5 @@ it("allows set after clear", function(){
 	proclaim.equal(o.size, 0);
 	o.set(2, '2');
 	proclaim.equal(o.size, 1);
-	proclaim.equal(o.get(1), '2');
+	proclaim.equal(o.get(2), '2');
 });

--- a/polyfills/Map/tests.js
+++ b/polyfills/Map/tests.js
@@ -194,3 +194,13 @@ it("implements .clear()", function(){
 	o.clear();
 	proclaim.equal(o.size, 0);
 });
+
+it("allows set after clear", function(){
+	var o = new Map();
+	o.set(1, '1');
+	o.clear();
+	proclaim.equal(o.size, 0);
+	o.set(2, '2');
+	proclaim.equal(o.size, 1);
+	proclaim.equal(o.get(1), '2');
+});


### PR DESCRIPTION
Array is not a primitive so assigning the same object of type 'Array' to _keys and _values is a bug. It causes 'set' to push both keys and values to the same array.