### PR TITLE
Update compat.json in preparation for a new release

### DIFF
--- a/docs/assets/compat.json
+++ b/docs/assets/compat.json
@@ -6,32 +6,7 @@
       "42": "native",
       "46": "native",
       "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "native",
-      "10": "native",
-      "11": "native",
-      "13": "native",
-      "14": "native"
+      "58": "native"
     },
     "firefox": {
       "30": "native",
@@ -40,95 +15,42 @@
       "42": "native",
       "44": "native",
       "49": "native",
-      "52": "native"
-    }
-  },
-  "Array.prototype.@@iterator": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
+      "53": "native"
     },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "native",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
+    "ie": {
+      "7": "polyfilled",
       "8": "polyfilled",
       "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "missing",
-      "8": "missing",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
+      "10": "native",
+      "11": "native",
       "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "polyfilled",
-      "41": "missing",
-      "42": "missing",
-      "44": "missing",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "Array.prototype.entries": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "native",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
+      "14": "native",
+      "15": "native"
     },
     "safari": {
-      "8": "missing",
+      "6": "native",
+      "7": "native",
+      "8": "native",
       "9": "native",
-      "5.1": "polyfilled"
+      "10": "native",
+      "5.1": "native"
     },
-    "ie": {
-      "7": "missing",
-      "8": "missing",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "native",
-      "14": "native"
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
     },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "polyfilled",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
     }
   },
   "Array.prototype.every": {
@@ -138,32 +60,7 @@
       "42": "native",
       "46": "native",
       "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "native",
-      "10": "native",
-      "11": "native",
-      "13": "native",
-      "14": "native"
+      "58": "native"
     },
     "firefox": {
       "30": "native",
@@ -172,7 +69,42 @@
       "42": "native",
       "44": "native",
       "49": "native",
-      "52": "native"
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
     }
   },
   "Array.prototype.filter": {
@@ -182,32 +114,7 @@
       "42": "native",
       "46": "native",
       "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "native",
-      "10": "native",
-      "11": "native",
-      "13": "native",
-      "14": "native"
+      "58": "native"
     },
     "firefox": {
       "30": "native",
@@ -216,7 +123,42 @@
       "42": "native",
       "44": "native",
       "49": "native",
-      "52": "native"
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
     }
   },
   "Array.prototype.forEach": {
@@ -226,32 +168,7 @@
       "42": "native",
       "46": "native",
       "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "native",
-      "10": "native",
-      "11": "native",
-      "13": "native",
-      "14": "native"
+      "58": "native"
     },
     "firefox": {
       "30": "native",
@@ -260,7 +177,42 @@
       "42": "native",
       "44": "native",
       "49": "native",
-      "52": "native"
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
     }
   },
   "Array.prototype.indexOf": {
@@ -270,32 +222,7 @@
       "42": "native",
       "46": "native",
       "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "native",
-      "10": "native",
-      "11": "native",
-      "13": "native",
-      "14": "native"
+      "58": "native"
     },
     "firefox": {
       "30": "native",
@@ -304,51 +231,42 @@
       "42": "native",
       "44": "native",
       "49": "native",
-      "52": "native"
-    }
-  },
-  "Array.prototype.keys": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "native",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "missing",
-      "9": "native",
-      "5.1": "polyfilled"
+      "53": "native"
     },
     "ie": {
-      "7": "missing",
-      "8": "missing",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "11": "native",
       "13": "native",
-      "14": "native"
+      "14": "native",
+      "15": "native"
     },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "polyfilled",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
     }
   },
   "Array.prototype.lastIndexOf": {
@@ -358,32 +276,7 @@
       "42": "native",
       "46": "native",
       "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "native",
-      "10": "native",
-      "11": "native",
-      "13": "native",
-      "14": "native"
+      "58": "native"
     },
     "firefox": {
       "30": "native",
@@ -392,7 +285,42 @@
       "42": "native",
       "44": "native",
       "49": "native",
-      "52": "native"
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
     }
   },
   "Array.prototype.map": {
@@ -402,32 +330,7 @@
       "42": "native",
       "46": "native",
       "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "native",
-      "10": "native",
-      "11": "native",
-      "13": "native",
-      "14": "native"
+      "58": "native"
     },
     "firefox": {
       "30": "native",
@@ -436,7 +339,42 @@
       "42": "native",
       "44": "native",
       "49": "native",
-      "52": "native"
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
     }
   },
   "Array.prototype.reduce": {
@@ -446,32 +384,7 @@
       "42": "native",
       "46": "native",
       "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "native",
-      "10": "native",
-      "11": "native",
-      "13": "native",
-      "14": "native"
+      "58": "native"
     },
     "firefox": {
       "30": "native",
@@ -480,7 +393,42 @@
       "42": "native",
       "44": "native",
       "49": "native",
-      "52": "native"
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
     }
   },
   "Array.prototype.reduceRight": {
@@ -490,32 +438,7 @@
       "42": "native",
       "46": "native",
       "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "native",
-      "10": "native",
-      "11": "native",
-      "13": "native",
-      "14": "native"
+      "58": "native"
     },
     "firefox": {
       "30": "native",
@@ -524,7 +447,42 @@
       "42": "native",
       "44": "native",
       "49": "native",
-      "52": "native"
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
     }
   },
   "Array.prototype.some": {
@@ -534,32 +492,7 @@
       "42": "native",
       "46": "native",
       "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "native",
-      "10": "native",
-      "11": "native",
-      "13": "native",
-      "14": "native"
+      "58": "native"
     },
     "firefox": {
       "30": "native",
@@ -568,7 +501,42 @@
       "42": "native",
       "44": "native",
       "49": "native",
-      "52": "native"
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
     }
   },
   "AudioContext": {
@@ -578,22 +546,16 @@
       "42": "native",
       "46": "native",
       "48": "native",
-      "54": "native"
+      "58": "native"
     },
-    "ios_saf": {
-      "9.2": "polyfilled",
-      "9.1": "polyfilled"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "native",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "5.1": "polyfilled"
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
     },
     "ie": {
       "7": "polyfilled",
@@ -602,15 +564,33 @@
       "10": "polyfilled",
       "11": "polyfilled",
       "13": "native",
-      "14": "native"
+      "14": "native",
+      "15": "native"
     },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native"
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "polyfilled"
     }
   },
   "CustomEvent": {
@@ -620,32 +600,7 @@
       "42": "native",
       "46": "native",
       "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "native",
-      "14": "native"
+      "58": "native"
     },
     "firefox": {
       "30": "native",
@@ -654,7 +609,42 @@
       "42": "native",
       "44": "native",
       "49": "native",
-      "52": "native"
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
     }
   },
   "DOMTokenList": {
@@ -664,22 +654,16 @@
       "42": "native",
       "46": "native",
       "48": "native",
-      "54": "native"
+      "58": "native"
     },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "polyfilled"
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
     },
     "ie": {
       "7": "polyfilled",
@@ -688,59 +672,33 @@
       "10": "polyfilled",
       "11": "polyfilled",
       "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native"
-    }
-  },
-  "DOMTokenList.prototype.@@iterator": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "polyfilled",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "polyfilled",
-      "9.1": "polyfilled"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "polyfilled",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
+      "14": "native",
+      "15": "native"
     },
     "safari": {
-      "8": "polyfilled",
-      "9": "polyfilled",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
       "5.1": "polyfilled"
     },
-    "ie": {
-      "7": "missing",
-      "8": "missing",
-      "9": "missing",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "polyfilled",
-      "14": "polyfilled"
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
     },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "polyfilled",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
     }
   },
   "Date.now": {
@@ -750,22 +708,16 @@
       "42": "native",
       "46": "native",
       "48": "native",
-      "54": "native"
+      "58": "native"
     },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
     },
     "ie": {
       "7": "polyfilled",
@@ -774,15 +726,33 @@
       "10": "native",
       "11": "native",
       "13": "native",
-      "14": "native"
+      "14": "native",
+      "15": "native"
     },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native"
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
     }
   },
   "Date.prototype.toISOString": {
@@ -792,32 +762,7 @@
       "42": "native",
       "46": "native",
       "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "native",
-      "10": "native",
-      "11": "native",
-      "13": "native",
-      "14": "native"
+      "58": "native"
     },
     "firefox": {
       "30": "native",
@@ -826,7 +771,42 @@
       "42": "native",
       "44": "native",
       "49": "native",
-      "52": "native"
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
     }
   },
   "Document": {
@@ -836,22 +816,16 @@
       "42": "native",
       "46": "native",
       "48": "native",
-      "54": "native"
+      "58": "native"
     },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
     },
     "ie": {
       "7": "polyfilled",
@@ -860,15 +834,33 @@
       "10": "native",
       "11": "native",
       "13": "native",
-      "14": "native"
+      "14": "native",
+      "15": "native"
     },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native"
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
     }
   },
   "Element": {
@@ -878,22 +870,16 @@
       "42": "native",
       "46": "native",
       "48": "native",
-      "54": "native"
+      "58": "native"
     },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
     },
     "ie": {
       "7": "polyfilled",
@@ -902,15 +888,33 @@
       "10": "native",
       "11": "native",
       "13": "native",
-      "14": "native"
+      "14": "native",
+      "15": "native"
     },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native"
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
     }
   },
   "Element.prototype.cloneNode": {
@@ -920,5779 +924,51 @@
       "42": "native",
       "46": "native",
       "48": "native",
-      "54": "native",
-      "56": "polyfilled"
+      "58": "native"
     },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
     },
     "ie": {
       "7": "missing",
       "8": "polyfilled",
       "9": "polyfilled",
       "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "polyfilled",
-      "14": "polyfilled"
-    },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "polyfilled",
-      "41": "polyfilled",
-      "42": "polyfilled",
-      "44": "polyfilled",
-      "49": "polyfilled",
-      "52": "polyfilled"
-    }
-  },
-  "Element.prototype.closest": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "polyfilled",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "polyfilled",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "polyfilled",
-      "14": "polyfilled"
-    },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "polyfilled",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "Element.prototype.matches": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "native",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "polyfilled",
-      "14": "polyfilled"
-    },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "polyfilled",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "Element.prototype.placeholder": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "missing",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "native",
       "11": "native",
       "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native"
-    }
-  },
-  "Element.prototype.remove": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "polyfilled"
+      "14": "native",
+      "15": "native"
     },
     "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "Event": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "missing",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "missing"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "missing"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "Event.focusin": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
+      "6": "native",
       "7": "native",
       "8": "native",
       "9": "native",
       "10": "native",
-      "11": "native",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "Function.name": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
       "5.1": "native"
     },
-    "ie": {
-      "7": "missing",
-      "8": "missing",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "polyfilled",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "Function.prototype.bind": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "native",
-      "10": "native",
-      "11": "native",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "HTMLDocument": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "native",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "native",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native"
-    }
-  },
-  "HTMLPictureElement": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native"
-    },
-    "ios_saf": {
-      "9.2": "polyfilled",
-      "9.1": "polyfilled"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "native",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "polyfilled",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native"
-    }
-  },
-  "Intl": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native"
-    },
-    "ios_saf": {
-      "9.2": "polyfilled",
-      "9.1": "polyfilled"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "missing",
-      "8": "missing",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "native",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native"
-    }
-  },
-  "JSON": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "native",
-      "9": "native",
-      "10": "native",
-      "11": "native",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native"
-    }
-  },
-  "Math.acosh": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "native",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "Math.asinh": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "native",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "Math.atanh": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "native",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native"
-    }
-  },
-  "Math.cbrt": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "native",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native"
-    }
-  },
-  "Math.clz32": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "native",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "Math.cosh": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "native",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native"
-    }
-  },
-  "Math.expm1": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "native",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native"
-    }
-  },
-  "Math.hypot": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "native",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native"
-    }
-  },
-  "Math.imul": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native"
-    }
-  },
-  "Math.log10": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "native",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native"
-    }
-  },
-  "Math.log1p": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "native",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native"
-    }
-  },
-  "Math.log2": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "native",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native"
-    }
-  },
-  "Math.sign": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "native",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native"
-    }
-  },
-  "Math.sinh": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "native",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native"
-    }
-  },
-  "Math.tanh": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "native",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native"
-    }
-  },
-  "Math.trunc": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "native",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native"
-    }
-  },
-  "Node.prototype.contains": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "Number.MAX_SAFE_INTEGER": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "native",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "Number.MIN_SAFE_INTEGER": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "native",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "Number.isFinite": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "Number.isNaN": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "Object.create": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "missing",
-      "10": "missing",
-      "11": "native",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "Object.defineProperties": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "native",
-      "10": "native",
-      "11": "native",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native"
-    }
-  },
-  "Object.getOwnPropertyDescriptor": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "native",
-      "10": "native",
-      "11": "native",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "Object.getOwnPropertyNames": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "native",
-      "10": "native",
-      "11": "native",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "Object.getPrototypeOf": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "native",
-      "10": "native",
-      "11": "native",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native"
-    }
-  },
-  "Object.is": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native"
-    }
-  },
-  "Object.keys": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "native",
-      "10": "native",
-      "11": "native",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "Object.setPrototypeOf": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "native",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "missing",
-      "8": "missing",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "native",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "Promise": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "native",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "missing",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "Set": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "native",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "missing",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "String.prototype.endsWith": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "polyfilled",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "polyfilled",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "String.prototype.includes": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "polyfilled",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "polyfilled",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "polyfilled",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native"
-    }
-  },
-  "String.prototype.repeat": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "polyfilled",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "polyfilled",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "String.prototype.startsWith": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "polyfilled",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "polyfilled",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native"
-    }
-  },
-  "String.prototype.trim": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "native",
-      "10": "native",
-      "11": "native",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "Symbol": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "native",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "polyfilled",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "Symbol.iterator": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "native",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "polyfilled",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "Symbol.unscopables": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "native",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "polyfilled",
-      "41": "polyfilled",
-      "42": "polyfilled",
-      "44": "polyfilled",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "UserTiming": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "polyfilled",
-      "9.1": "polyfilled"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "missing",
-      "11": "missing",
-      "13": "missing",
-      "14": "missing"
-    },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "polyfilled",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "WeakMap": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "native",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "polyfilled",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "WeakSet": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "native",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "polyfilled",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "Window": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "native",
-      "9": "native",
-      "10": "native",
-      "11": "native",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native"
-    }
-  },
-  "XMLHttpRequest": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "native",
-      "10": "native",
-      "11": "native",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "atob": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "native",
-      "11": "native",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "console": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "native",
-      "11": "native",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "console.assert": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "native",
-      "11": "native",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "console.clear": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "native",
-      "11": "native",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "polyfilled",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "console.count": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "native",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "console.debug": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "native",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "console.dir": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "native",
-      "11": "native",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "console.dirxml": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "native",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "polyfilled",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "console.error": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "native",
-      "11": "native",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "console.group": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "native",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "console.groupCollapsed": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "native",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "console.groupEnd": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "native",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "console.info": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "native",
-      "11": "native",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "console.log": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "native",
-      "11": "native",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "console.markTimeline": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "polyfilled",
-      "9.1": "polyfilled"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "polyfilled",
-      "14": "polyfilled"
-    },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "polyfilled",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "console.table": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "polyfilled",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "console.time": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "missing",
-      "9.1": "missing"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "missing",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "missing",
-      "9": "missing",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "native",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "console.timeEnd": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "native",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "console.timeStamp": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "polyfilled",
-      "14": "polyfilled"
-    },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "polyfilled",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "console.timeline": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "polyfilled",
-      "9.1": "polyfilled"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "native",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "polyfilled",
-      "14": "polyfilled"
-    },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "polyfilled",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "console.timelineEnd": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "polyfilled",
-      "9.1": "polyfilled"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "native",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "polyfilled",
-      "14": "polyfilled"
-    },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "polyfilled",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "console.trace": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "native",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "console.warn": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "native",
-      "11": "native",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "devicePixelRatio": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "native",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native"
-    }
-  },
-  "document.getElementsByClassName": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "native",
-      "10": "native",
-      "11": "native",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "document.head": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "native",
-      "10": "native",
-      "11": "native",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native"
-    }
-  },
-  "document.querySelector": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "native",
-      "9": "native",
-      "10": "native",
-      "11": "native",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "document.visibilityState": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "missing",
-      "5.1": "native",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "missing"
-    },
-    "ie": {
-      "7": "missing",
-      "8": "missing",
-      "9": "missing",
-      "10": "native",
-      "11": "native",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "fetch": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "polyfilled",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native"
-    },
-    "ios_saf": {
-      "9.2": "polyfilled",
-      "9.1": "polyfilled"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "polyfilled",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "polyfilled",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "polyfilled",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native"
-    }
-  },
-  "getComputedStyle": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "native",
-      "10": "native",
-      "11": "native",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native"
-    }
-  },
-  "localStorage": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "native",
-      "9": "native",
-      "10": "native",
-      "11": "native",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native"
-    }
-  },
-  "location.origin": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "native",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "matchMedia": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "native",
-      "11": "native",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "navigator.geolocation": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "native",
-      "10": "native",
-      "11": "native",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native"
-    }
-  },
-  "navigator.sendBeacon": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native"
-    },
-    "ios_saf": {
-      "9.2": "polyfilled",
-      "9.1": "polyfilled"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "native",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "polyfilled",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native"
-    }
-  },
-  "performance.now": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "native",
-      "11": "native",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native"
-    }
-  },
-  "requestAnimationFrame": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "native",
-      "11": "native",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "screen.orientation": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "polyfilled",
-      "42": "polyfilled",
-      "46": "polyfilled",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "polyfilled",
-      "9.1": "polyfilled"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "native",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "missing",
-      "8": "missing",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "polyfilled",
-      "14": "polyfilled"
-    },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "polyfilled",
-      "41": "polyfilled",
-      "42": "polyfilled",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "~html5-elements": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "native",
-      "10": "native",
-      "11": "native",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native"
-    }
-  },
-  "~viewport": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native"
-    }
-  },
-  "Symbol.toStringTag": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "polyfilled",
-      "42": "polyfilled",
-      "46": "polyfilled",
-      "48": "polyfilled",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "polyfilled",
-      "9.1": "polyfilled"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "polyfilled",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "polyfilled",
-      "14": "polyfilled"
-    },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "polyfilled",
-      "41": "polyfilled",
-      "42": "polyfilled",
-      "44": "polyfilled",
-      "49": "polyfilled",
-      "52": "native"
-    }
-  },
-  "setImmediate": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "polyfilled",
-      "42": "polyfilled",
-      "46": "polyfilled",
-      "48": "polyfilled",
-      "54": "polyfilled"
-    },
-    "ios_saf": {
-      "9.2": "polyfilled",
-      "9.1": "polyfilled"
-    },
     "android": {
-      "4.2": "polyfilled",
-      "5.1": "polyfilled",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "native",
-      "11": "native",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "polyfilled",
-      "41": "polyfilled",
-      "42": "polyfilled",
-      "44": "polyfilled",
-      "49": "polyfilled"
-    }
-  },
-  "Symbol.match": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "polyfilled",
-      "42": "polyfilled",
-      "46": "polyfilled",
-      "48": "polyfilled",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "polyfilled",
-      "9.1": "polyfilled"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "polyfilled",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "polyfilled",
-      "14": "polyfilled"
-    },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "polyfilled",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "String.prototype.contains": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "polyfilled",
-      "42": "polyfilled",
-      "46": "polyfilled",
-      "48": "polyfilled",
-      "54": "polyfilled"
-    },
-    "ios_saf": {
-      "9.2": "polyfilled",
-      "9.1": "polyfilled"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "polyfilled",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "polyfilled",
-      "14": "polyfilled"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "polyfilled"
-    }
-  },
-  "Symbol.isConcatSpreadable": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "polyfilled",
-      "42": "polyfilled",
-      "46": "polyfilled",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "polyfilled",
-      "9.1": "polyfilled"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "polyfilled",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "polyfilled",
-      "14": "polyfilled"
-    },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "polyfilled",
-      "41": "polyfilled",
-      "42": "polyfilled",
-      "44": "polyfilled",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "Array.prototype.values": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "polyfilled",
-      "42": "polyfilled",
-      "46": "polyfilled",
-      "48": "polyfilled",
-      "54": "polyfilled",
-      "56": "polyfilled"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "polyfilled",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "missing",
-      "8": "missing",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "polyfilled",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "polyfilled",
-      "41": "missing",
-      "42": "missing",
-      "44": "missing",
-      "49": "native",
-      "52": "polyfilled"
-    }
-  },
-  "Array.prototype.find": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "polyfilled",
-      "42": "polyfilled",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "polyfilled",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "Array.prototype.fill": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "polyfilled",
-      "42": "polyfilled",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "polyfilled",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "NodeList.prototype.@@iterator": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "polyfilled",
-      "42": "polyfilled",
-      "46": "polyfilled",
-      "48": "polyfilled",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "polyfilled",
-      "9.1": "polyfilled"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "polyfilled",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "missing",
-      "8": "missing",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "polyfilled",
-      "14": "polyfilled"
-    },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "polyfilled",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "Element.prototype.prepend": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "polyfilled",
-      "42": "polyfilled",
-      "46": "polyfilled",
-      "48": "polyfilled",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "polyfilled",
-      "9.1": "polyfilled"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "polyfilled",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "polyfilled",
-      "14": "polyfilled"
-    },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "polyfilled",
-      "41": "polyfilled",
-      "42": "polyfilled",
-      "44": "polyfilled",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "Symbol.search": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "polyfilled",
-      "42": "polyfilled",
-      "46": "polyfilled",
-      "48": "polyfilled",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "polyfilled",
-      "9.1": "polyfilled"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "polyfilled",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "polyfilled",
-      "14": "polyfilled"
-    },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "polyfilled",
-      "41": "polyfilled",
-      "42": "polyfilled",
-      "44": "polyfilled",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "Array.of": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "polyfilled",
-      "42": "polyfilled",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "polyfilled",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "Symbol.hasInstance": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "polyfilled",
-      "42": "polyfilled",
-      "46": "polyfilled",
-      "48": "polyfilled",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "polyfilled",
-      "9.1": "polyfilled"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "polyfilled",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "polyfilled",
-      "14": "polyfilled"
-    },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "polyfilled",
-      "41": "polyfilled",
-      "42": "polyfilled",
-      "44": "polyfilled",
-      "49": "polyfilled",
-      "52": "native"
-    }
-  },
-  "console.exception": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "polyfilled",
-      "42": "polyfilled",
-      "46": "polyfilled",
-      "48": "polyfilled",
-      "54": "polyfilled",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "polyfilled",
-      "9.1": "polyfilled"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "polyfilled",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "IntersectionObserver": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "polyfilled",
-      "42": "polyfilled",
-      "46": "polyfilled",
-      "48": "polyfilled",
-      "56": "polyfilled"
-    },
-    "ios_saf": {
-      "9.2": "polyfilled",
-      "9.1": "polyfilled"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "polyfilled",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "polyfilled",
-      "14": "polyfilled"
-    },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "polyfilled",
-      "41": "polyfilled",
-      "42": "polyfilled",
-      "44": "polyfilled",
-      "49": "polyfilled",
-      "52": "polyfilled"
-    }
-  },
-  "Element.prototype.replaceWith": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "polyfilled",
-      "42": "polyfilled",
-      "46": "polyfilled",
-      "48": "polyfilled",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "polyfilled",
-      "9.1": "polyfilled"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "polyfilled",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "polyfilled",
-      "14": "polyfilled"
-    },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "polyfilled",
-      "41": "polyfilled",
-      "42": "polyfilled",
-      "44": "polyfilled",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "Array.prototype.includes": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "polyfilled",
-      "42": "polyfilled",
-      "46": "polyfilled",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "polyfilled",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "polyfilled",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "polyfilled",
-      "41": "polyfilled",
-      "42": "polyfilled",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "Array.from": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "polyfilled",
-      "42": "polyfilled",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "polyfilled",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "polyfilled",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "Symbol.toPrimitive": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "polyfilled",
-      "42": "polyfilled",
-      "46": "polyfilled",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "polyfilled",
-      "9.1": "polyfilled"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "polyfilled",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "polyfilled",
-      "14": "polyfilled"
-    },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "polyfilled",
-      "41": "polyfilled",
-      "42": "polyfilled",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "Array.prototype.findIndex": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "polyfilled",
-      "42": "polyfilled",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "polyfilled",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "URL": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "polyfilled",
-      "42": "polyfilled",
-      "46": "polyfilled",
-      "48": "polyfilled",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "polyfilled",
-      "9.1": "polyfilled"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "polyfilled",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "missing",
-      "8": "missing",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "polyfilled",
-      "14": "polyfilled"
-    },
-    "firefox": {
-      "30": "missing",
-      "33": "missing",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "Symbol.split": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "polyfilled",
-      "42": "polyfilled",
-      "46": "polyfilled",
-      "48": "polyfilled",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "polyfilled",
-      "9.1": "polyfilled"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "polyfilled",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "polyfilled",
-      "14": "polyfilled"
-    },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "polyfilled",
-      "41": "polyfilled",
-      "42": "polyfilled",
-      "44": "polyfilled",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "Element.prototype.after": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "polyfilled",
-      "42": "polyfilled",
-      "46": "polyfilled",
-      "48": "polyfilled",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "polyfilled",
-      "9.1": "polyfilled"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "polyfilled",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "polyfilled",
-      "14": "polyfilled"
-    },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "polyfilled",
-      "41": "polyfilled",
-      "42": "polyfilled",
-      "44": "polyfilled",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "Symbol.replace": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "polyfilled",
-      "42": "polyfilled",
-      "46": "polyfilled",
-      "48": "polyfilled",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "polyfilled",
-      "9.1": "polyfilled"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "polyfilled",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "polyfilled",
-      "14": "polyfilled"
-    },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "polyfilled",
-      "41": "polyfilled",
-      "42": "polyfilled",
-      "44": "polyfilled",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "Element.prototype.append": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "polyfilled",
-      "42": "polyfilled",
-      "46": "polyfilled",
-      "48": "polyfilled",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "polyfilled",
-      "9.1": "polyfilled"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "polyfilled",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "polyfilled",
-      "14": "polyfilled"
-    },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "polyfilled",
-      "41": "polyfilled",
-      "42": "polyfilled",
-      "44": "polyfilled",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "Element.prototype.before": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "polyfilled",
-      "42": "polyfilled",
-      "46": "polyfilled",
-      "48": "polyfilled",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "polyfilled",
-      "9.1": "polyfilled"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "polyfilled",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "polyfilled",
-      "14": "polyfilled"
-    },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "polyfilled",
-      "41": "polyfilled",
-      "42": "polyfilled",
-      "44": "polyfilled",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "Symbol.species": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "polyfilled",
-      "42": "polyfilled",
-      "46": "polyfilled",
-      "48": "polyfilled",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "polyfilled",
-      "9.1": "polyfilled"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "polyfilled",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "polyfilled",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "Event.hashchange": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
       "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "native",
-      "10": "native",
-      "11": "native",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "Object.assign": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "polyfilled",
-      "42": "polyfilled",
-      "46": "native",
-      "48": "native",
-      "54": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "polyfilled",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "polyfilled",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native"
-    }
-  },
-  "Array.prototype.contains": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "polyfilled",
-      "42": "polyfilled",
-      "46": "polyfilled",
-      "48": "polyfilled",
-      "54": "polyfilled",
-      "56": "polyfilled"
-    },
-    "ios_saf": {
-      "9.2": "polyfilled",
-      "9.1": "polyfilled"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "polyfilled",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "polyfilled",
-      "14": "polyfilled"
-    },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "polyfilled",
-      "41": "polyfilled",
-      "42": "polyfilled",
-      "44": "polyfilled",
-      "49": "polyfilled",
-      "52": "polyfilled"
-    }
-  },
-  "Element.prototype.classList": {
-    "chrome": {
-      "35": "missing",
-      "40": "missing",
-      "42": "missing",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "missing",
-      "9.1": "missing"
-    },
-    "android": {
-      "4.2": "missing",
-      "5.1": "missing",
-      "4.4": "missing",
-      "4.3": "missing"
+      "4.4": "native"
     },
-    "safari": {
-      "8": "missing",
-      "9": "missing",
-      "5.1": "missing"
-    },
-    "ie": {
-      "7": "missing",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "missing",
-      "11": "missing",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "Object.defineProperty": {
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "missing"
-    },
     "ios_saf": {
-      "9.2": "native",
-      "9.1": "native"
-    },
-    "android": {
-      "4.2": "native",
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "native"
-    },
-    "safari": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
       "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "missing",
-      "10": "missing",
-      "11": "missing",
-      "13": "missing",
-      "14": "missing"
-    },
-    "firefox": {
-      "30": "missing",
-      "33": "missing",
-      "41": "missing",
-      "42": "missing",
-      "44": "missing",
-      "49": "missing",
-      "52": "missing"
-    }
-  },
-  "Map": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "missing",
-      "42": "missing",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "ios_saf": {
-      "9.2": "native",
+      "10.3": "native",
       "9.1": "native"
-    },
-    "android": {
-      "4.2": "polyfilled",
-      "5.1": "missing",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "native",
-      "14": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "IntersectionObserver (timeout after 30000ms, 2 retries)": {
-    "chrome": {
-      "54": "missing"
-    }
-  },
-  "Number.isInteger": {
-    "ie": {
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "native",
-      "14": "native"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "android": {
-      "5.1": "native",
-      "4.4": "polyfilled",
-      "4.3": "polyfilled",
-      "4.2": "polyfilled"
-    },
-    "ios_saf": {
-      "9.1": "native",
-      "9.2": "native"
-    },
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "document.currentScript": {
-    "ie": {
-      "7": "missing",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "missing",
-      "13": "native",
-      "14": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "missing"
-    },
-    "android": {
-      "5.1": "native",
-      "4.4": "native",
-      "4.3": "missing",
-      "4.2": "missing"
-    },
-    "ios_saf": {
-      "9.1": "native",
-      "9.2": "native"
-    },
-    "chrome": {
-      "35": "native",
-      "40": "native",
-      "42": "native",
-      "46": "native",
-      "48": "native",
-      "54": "native",
-      "56": "native"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    }
-  },
-  "HTMLCanvasElement.prototype.toBlob": {
-    "ios_saf": {
-      "9.2": "polyfilled",
-      "9.1": "polyfilled"
-    },
-    "android": {
-      "4.2": "missing",
-      "4.3": "missing",
-      "5.1": "polyfilled",
-      "4.4": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "5.1": "missing"
-    },
-    "ie": {
-      "7": "missing",
-      "8": "missing",
-      "9": "missing",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "polyfilled",
-      "14": "polyfilled"
-    },
-    "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
-      "52": "native"
-    },
-    "chrome": {
-      "35": "polyfilled",
-      "40": "polyfilled",
-      "42": "polyfilled",
-      "46": "polyfilled",
-      "48": "polyfilled",
-      "54": "native",
-      "56": "native"
     }
   },
   "Element.prototype.dataset": {
@@ -6702,8 +978,7 @@
       "42": "native",
       "46": "native",
       "48": "native",
-      "54": "native",
-      "56": "native"
+      "58": "native"
     },
     "firefox": {
       "30": "native",
@@ -6712,7 +987,7 @@
       "42": "native",
       "44": "native",
       "49": "native",
-      "52": "native"
+      "53": "native"
     },
     "ie": {
       "7": "missing",
@@ -6721,22 +996,735 @@
       "10": "polyfilled",
       "11": "native",
       "13": "native",
-      "14": "native"
+      "14": "native",
+      "15": "native"
     },
     "safari": {
+      "6": "native",
+      "7": "native",
       "8": "native",
       "9": "native",
+      "10": "native",
       "5.1": "native"
     },
     "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
       "5.1": "native",
-      "4.4": "native",
-      "4.3": "native",
-      "4.2": "native"
+      "4.4": "native"
     },
     "ios_saf": {
-      "9.1": "native",
-      "9.2": "native"
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "Element.prototype.matches": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "polyfilled",
+      "14": "polyfilled",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "Element.prototype.placeholder": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "missing",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "native",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "Element.prototype.remove": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "Event": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "missing"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "Event.focusin": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "Event.hashchange": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "EventSource": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "polyfilled",
+      "14": "polyfilled",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "missing",
+      "9": "missing",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "missing"
+    }
+  },
+  "Function.name": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "missing",
+      "8": "missing",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "Function.prototype.bind": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "HTMLDocument": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "native",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "Intl": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "missing",
+      "8": "missing",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "polyfilled"
+    }
+  },
+  "JSON": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "Math.imul": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
     }
   },
   "MutationObserver": {
@@ -6746,7 +1734,7 @@
       "42": "native",
       "46": "native",
       "48": "native",
-      "54": "native"
+      "58": "native"
     },
     "firefox": {
       "30": "native",
@@ -6754,28 +1742,366 @@
       "41": "native",
       "42": "native",
       "44": "native",
-      "49": "native"
-    },
-    "safari": {
-      "8": "native",
-      "9": "native",
-      "5.1": "native"
-    },
-    "android": {
-      "4.3": "native",
-      "4.4": "native",
-      "4.2": "native"
+      "49": "native",
+      "53": "native"
     },
     "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
       "7": "native",
       "8": "native",
       "9": "native",
       "10": "native",
-      "11": "native",
-      "13": "native",
-      "14": "native"
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
     },
     "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "Node.prototype.contains": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "Number.MAX_SAFE_INTEGER": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "Number.MIN_SAFE_INTEGER": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "Number.isFinite": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "Number.isInteger": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "Number.isNaN": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
       "9.1": "native"
     }
   },
@@ -6786,8 +2112,7 @@
       "42": "native",
       "46": "native",
       "48": "native",
-      "54": "native",
-      "56": "native"
+      "58": "native"
     },
     "firefox": {
       "30": "native",
@@ -6796,17 +2121,7 @@
       "42": "native",
       "44": "native",
       "49": "native",
-      "52": "native"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "android": {
-      "4.3": "polyfilled",
-      "4.4": "polyfilled",
-      "4.2": "polyfilled"
+      "53": "native"
     },
     "ie": {
       "7": "polyfilled",
@@ -6815,9 +2130,32 @@
       "10": "polyfilled",
       "11": "polyfilled",
       "13": "native",
-      "14": "native"
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
     },
     "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
       "9.1": "native"
     }
   },
@@ -6828,8 +2166,7 @@
       "42": "native",
       "46": "native",
       "48": "native",
-      "54": "native",
-      "56": "native"
+      "58": "native"
     },
     "firefox": {
       "30": "native",
@@ -6838,17 +2175,7 @@
       "42": "native",
       "44": "native",
       "49": "native",
-      "52": "native"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "native",
-      "5.1": "polyfilled"
-    },
-    "android": {
-      "4.3": "polyfilled",
-      "4.4": "polyfilled",
-      "4.2": "polyfilled"
+      "53": "native"
     },
     "ie": {
       "7": "polyfilled",
@@ -6857,9 +2184,4028 @@
       "10": "polyfilled",
       "11": "polyfilled",
       "13": "native",
-      "14": "native"
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
     },
     "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "Object.create": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "missing",
+      "10": "missing",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "Object.defineProperties": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "Object.defineProperty": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "missing"
+    },
+    "firefox": {
+      "30": "missing",
+      "33": "missing",
+      "41": "missing",
+      "42": "missing",
+      "44": "missing",
+      "49": "missing",
+      "53": "missing"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "missing",
+      "10": "missing",
+      "11": "missing",
+      "13": "missing",
+      "14": "missing",
+      "15": "missing"
+    },
+    "safari": {
+      "6": "missing",
+      "7": "missing",
+      "8": "native",
+      "9": "native",
+      "10": "missing",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "missing",
+      "6": "missing",
+      "7": "missing",
+      "7.1": "missing",
+      "5.1": "missing",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "missing",
+      "5": "missing",
+      "6": "missing",
+      "7": "missing",
+      "8": "missing",
+      "10.3": "missing",
+      "9.1": "native"
+    }
+  },
+  "Object.getOwnPropertyDescriptor": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "Object.getOwnPropertyNames": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "Object.getPrototypeOf": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "Object.is": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "Object.keys": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "Object.setPrototypeOf": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "missing",
+      "8": "missing",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "Promise": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "missing",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "String.prototype.trim": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "UserTiming": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "missing",
+      "11": "missing",
+      "13": "missing",
+      "14": "missing",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "polyfilled"
+    }
+  },
+  "Window": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "XMLHttpRequest": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "atob": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "native",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "console": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "native",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "console.assert": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "native",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "console.clear": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "native",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "console.count": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "console.debug": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "console.dir": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "native",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "console.dirxml": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "console.error": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "native",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "console.group": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "console.groupCollapsed": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "console.groupEnd": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "console.info": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "native",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "console.log": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "native",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "console.markTimeline": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "polyfilled",
+      "14": "polyfilled",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "polyfilled"
+    }
+  },
+  "console.table": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "console.time": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "missing",
+      "9": "missing",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "missing"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "missing"
+    }
+  },
+  "console.timeEnd": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "console.timeStamp": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "polyfilled",
+      "14": "polyfilled",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "console.timeline": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "polyfilled",
+      "14": "polyfilled",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "polyfilled"
+    }
+  },
+  "console.timelineEnd": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "polyfilled",
+      "14": "polyfilled",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "polyfilled"
+    }
+  },
+  "console.trace": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "console.warn": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "native",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "devicePixelRatio": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "document.currentScript": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "missing",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "missing",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "missing"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "document.getElementsByClassName": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "document.head": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "document.querySelector": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "document.visibilityState": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "missing",
+      "8": "missing",
+      "9": "missing",
+      "10": "native",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "missing"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "getComputedStyle": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "localStorage": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "location.origin": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "matchMedia": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "native",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "navigator.geolocation": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "performance.now": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "native",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "requestAnimationFrame": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "native",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "~html5-elements": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "~viewport": {
+    "chrome": {
+      "35": "native",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "native"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "native"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "WeakMap": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "navigator.sendBeacon": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "polyfilled"
+    }
+  },
+  "Math.asinh": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "String.prototype.@@iterator": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "missing",
+      "8": "missing",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "WeakSet": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "HTMLCanvasElement.prototype.toBlob": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "polyfilled",
+      "42": "polyfilled",
+      "46": "polyfilled",
+      "48": "polyfilled",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "missing",
+      "8": "missing",
+      "9": "missing",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "polyfilled",
+      "14": "polyfilled",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "native",
+      "5.1": "missing"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "polyfilled"
+    }
+  },
+  "HTMLPictureElement": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "polyfilled"
+    }
+  },
+  "Math.cbrt": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "Symbol.split": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "polyfilled",
+      "42": "polyfilled",
+      "46": "polyfilled",
+      "48": "polyfilled",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "polyfilled",
+      "42": "polyfilled",
+      "44": "polyfilled",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "polyfilled",
+      "14": "polyfilled",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "polyfilled"
+    }
+  },
+  "Symbol.replace": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "polyfilled",
+      "42": "polyfilled",
+      "46": "polyfilled",
+      "48": "polyfilled",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "polyfilled",
+      "42": "polyfilled",
+      "44": "polyfilled",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "polyfilled",
+      "14": "polyfilled",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "polyfilled"
+    }
+  },
+  "Element.prototype.replaceWith": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "polyfilled",
+      "42": "polyfilled",
+      "46": "polyfilled",
+      "48": "polyfilled",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "polyfilled",
+      "42": "polyfilled",
+      "44": "polyfilled",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "polyfilled",
+      "14": "polyfilled",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "polyfilled"
+    }
+  },
+  "String.prototype.startsWith": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "polyfilled",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "Array.prototype.entries": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "missing",
+      "8": "missing",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "missing",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "Symbol.match": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "polyfilled",
+      "42": "polyfilled",
+      "46": "polyfilled",
+      "48": "polyfilled",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "polyfilled",
+      "14": "polyfilled",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "polyfilled"
+    }
+  },
+  "String.prototype.endsWith": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "polyfilled",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "Symbol.isConcatSpreadable": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "polyfilled",
+      "42": "polyfilled",
+      "46": "polyfilled",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "polyfilled",
+      "42": "polyfilled",
+      "44": "polyfilled",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "polyfilled",
+      "14": "polyfilled",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "polyfilled"
+    }
+  },
+  "Math.log2": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "Array.prototype.find": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "polyfilled",
+      "42": "polyfilled",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "Math.tanh": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "NodeList.prototype.@@iterator": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "polyfilled",
+      "42": "polyfilled",
+      "46": "polyfilled",
+      "48": "polyfilled",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "missing",
+      "8": "missing",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "polyfilled",
+      "14": "polyfilled",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "polyfilled"
+    }
+  },
+  "Array.prototype.includes": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "polyfilled",
+      "42": "polyfilled",
+      "46": "polyfilled",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "polyfilled",
+      "42": "polyfilled",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "Math.expm1": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
       "9.1": "native"
     }
   },
@@ -6870,8 +6216,7 @@
       "42": "polyfilled",
       "46": "polyfilled",
       "48": "polyfilled",
-      "54": "polyfilled",
-      "56": "polyfilled"
+      "58": "polyfilled"
     },
     "firefox": {
       "30": "polyfilled",
@@ -6880,17 +6225,7 @@
       "42": "polyfilled",
       "44": "polyfilled",
       "49": "polyfilled",
-      "52": "polyfilled"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "5.1": "missing"
-    },
-    "android": {
-      "4.3": "missing",
-      "4.4": "missing",
-      "4.2": "missing"
+      "53": "polyfilled"
     },
     "ie": {
       "7": "missing",
@@ -6899,21 +6234,205 @@
       "10": "missing",
       "11": "missing",
       "13": "polyfilled",
-      "14": "polyfilled"
+      "14": "polyfilled",
+      "15": "polyfilled"
+    },
+    "safari": {
+      "6": "polyfilled",
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "5.1": "missing"
+    },
+    "android": {
+      "5": "polyfilled",
+      "6": "polyfilled",
+      "7": "polyfilled",
+      "7.1": "polyfilled",
+      "5.1": "polyfilled",
+      "4.4": "missing"
     },
     "ios_saf": {
+      "4": "polyfilled",
+      "5": "polyfilled",
+      "6": "polyfilled",
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "10.3": "polyfilled",
       "9.1": "polyfilled"
     }
   },
-  "Object.entries": {
+  "DOMTokenList.prototype.@@iterator": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "polyfilled",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "missing",
+      "8": "missing",
+      "9": "missing",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "polyfilled",
+      "14": "polyfilled",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "polyfilled"
+    }
+  },
+  "Math.atanh": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "Array.prototype.values": {
     "chrome": {
       "35": "polyfilled",
       "40": "polyfilled",
       "42": "polyfilled",
       "46": "polyfilled",
       "48": "polyfilled",
-      "54": "native",
-      "56": "native"
+      "58": "polyfilled"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "missing",
+      "42": "missing",
+      "44": "missing",
+      "49": "native",
+      "53": "polyfilled"
+    },
+    "ie": {
+      "7": "missing",
+      "8": "missing",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "polyfilled"
+    },
+    "safari": {
+      "6": "polyfilled",
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "polyfilled",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "polyfilled",
+      "6": "polyfilled",
+      "7": "polyfilled",
+      "7.1": "polyfilled",
+      "5.1": "polyfilled",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "polyfilled",
+      "5": "polyfilled",
+      "6": "polyfilled",
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "10.3": "polyfilled",
+      "9.1": "native"
+    }
+  },
+  "Element.prototype.after": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "polyfilled",
+      "42": "polyfilled",
+      "46": "polyfilled",
+      "48": "polyfilled",
+      "58": "native"
     },
     "firefox": {
       "30": "polyfilled",
@@ -6922,59 +6441,743 @@
       "42": "polyfilled",
       "44": "polyfilled",
       "49": "native",
-      "52": "native"
-    },
-    "safari": {
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "5.1": "polyfilled"
-    },
-    "android": {
-      "4.3": "polyfilled",
-      "4.4": "polyfilled",
-      "4.2": "polyfilled"
+      "53": "native"
     },
     "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
       "9": "polyfilled",
       "10": "polyfilled",
       "11": "polyfilled",
       "13": "polyfilled",
-      "14": "native"
+      "14": "polyfilled",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
     },
     "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
       "9.1": "polyfilled"
     }
   },
-  "Object.entries (timeout after 30000ms, 2 retries)": {
-    "ie": {
-      "7": "missing",
-      "8": "missing"
-    }
-  },
-  "String.prototype.@@iterator": {
+  "Math.log10": {
     "chrome": {
       "35": "polyfilled",
       "40": "native",
       "42": "native",
       "46": "native",
       "48": "native",
-      "56": "native"
+      "58": "native"
     },
     "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
       "42": "native",
       "44": "native",
       "49": "native",
-      "52": "native"
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
     },
     "safari": {
-      "8": "polyfilled",
+      "6": "native",
+      "7": "native",
+      "8": "native",
       "9": "native",
+      "10": "native",
       "5.1": "polyfilled"
     },
     "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
       "4.4": "polyfilled"
     },
     "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "setImmediate": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "polyfilled",
+      "42": "polyfilled",
+      "46": "polyfilled",
+      "48": "polyfilled",
+      "58": "polyfilled"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "polyfilled",
+      "42": "polyfilled",
+      "44": "polyfilled",
+      "49": "polyfilled",
+      "53": "polyfilled"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "native",
+      "11": "native",
+      "13": "native",
+      "14": "native",
+      "15": "polyfilled"
+    },
+    "safari": {
+      "6": "polyfilled",
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "polyfilled",
+      "6": "polyfilled",
+      "7": "polyfilled",
+      "7.1": "polyfilled",
+      "5.1": "polyfilled",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "polyfilled",
+      "5": "polyfilled",
+      "6": "polyfilled",
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "10.3": "polyfilled",
+      "9.1": "polyfilled"
+    }
+  },
+  "Math.cosh": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "String.prototype.contains": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "polyfilled",
+      "42": "polyfilled",
+      "46": "polyfilled",
+      "48": "polyfilled",
+      "58": "polyfilled"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "polyfilled",
+      "53": "polyfilled"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "polyfilled",
+      "14": "polyfilled",
+      "15": "polyfilled"
+    },
+    "safari": {
+      "6": "polyfilled",
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "polyfilled",
+      "6": "polyfilled",
+      "7": "polyfilled",
+      "7.1": "polyfilled",
+      "5.1": "polyfilled",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "polyfilled",
+      "5": "polyfilled",
+      "6": "polyfilled",
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "10.3": "polyfilled",
+      "9.1": "polyfilled"
+    }
+  },
+  "console.exception": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "polyfilled",
+      "42": "polyfilled",
+      "46": "polyfilled",
+      "48": "polyfilled",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "polyfilled"
+    }
+  },
+  "Math.clz32": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "Math.sign": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "Map": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "missing",
+      "42": "missing",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "5.1": "missing"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "Set": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "missing",
+      "33": "missing",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "5.1": "missing"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "IntersectionObserver": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "polyfilled",
+      "42": "polyfilled",
+      "46": "polyfilled",
+      "48": "polyfilled",
+      "58": "polyfilled"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "polyfilled",
+      "42": "polyfilled",
+      "44": "polyfilled",
+      "49": "polyfilled",
+      "53": "polyfilled"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "polyfilled",
+      "14": "polyfilled",
+      "15": "polyfilled"
+    },
+    "safari": {
+      "6": "polyfilled",
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "polyfilled",
+      "6": "polyfilled",
+      "7": "polyfilled",
+      "7.1": "polyfilled",
+      "5.1": "polyfilled",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "polyfilled",
+      "5": "polyfilled",
+      "6": "polyfilled",
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "10.3": "polyfilled",
+      "9.1": "polyfilled"
+    }
+  },
+  "Math.acosh": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "Symbol": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "Math.trunc": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
       "9.1": "native"
     }
   },
@@ -6985,24 +7188,483 @@
       "42": "polyfilled",
       "46": "polyfilled",
       "48": "polyfilled",
-      "56": "native"
+      "58": "native"
     },
     "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "polyfilled",
       "42": "polyfilled",
       "44": "polyfilled",
       "49": "native",
-      "52": "native"
+      "53": "native"
     },
-    "safari": {
+    "ie": {
+      "7": "polyfilled",
       "8": "polyfilled",
       "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "native",
       "5.1": "polyfilled"
     },
     "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
       "4.4": "polyfilled"
     },
     "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
       "9.1": "polyfilled"
+    }
+  },
+  "URL": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "polyfilled",
+      "42": "polyfilled",
+      "46": "polyfilled",
+      "48": "polyfilled",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "missing",
+      "33": "missing",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "missing",
+      "8": "missing",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "polyfilled",
+      "14": "polyfilled",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "polyfilled"
+    }
+  },
+  "String.fromCodePoint": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "polyfilled",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "Object.assign": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "polyfilled",
+      "42": "polyfilled",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "Symbol.iterator": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "Math.hypot": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "Element.prototype.prepend": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "polyfilled",
+      "42": "polyfilled",
+      "46": "polyfilled",
+      "48": "polyfilled",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "polyfilled",
+      "42": "polyfilled",
+      "44": "polyfilled",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "polyfilled",
+      "14": "polyfilled",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "polyfilled"
+    }
+  },
+  "Element.prototype.append": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "polyfilled",
+      "42": "polyfilled",
+      "46": "polyfilled",
+      "48": "polyfilled",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "polyfilled",
+      "42": "polyfilled",
+      "44": "polyfilled",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "polyfilled",
+      "14": "polyfilled",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "polyfilled"
+    }
+  },
+  "Array.prototype.keys": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "missing",
+      "8": "missing",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "missing",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
     }
   },
   "String.prototype.padStart": {
@@ -7012,24 +7674,105 @@
       "42": "polyfilled",
       "46": "polyfilled",
       "48": "polyfilled",
-      "56": "missing"
+      "58": "missing"
     },
     "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "polyfilled",
       "42": "polyfilled",
       "44": "polyfilled",
       "49": "missing",
-      "52": "polyfilled"
+      "53": "missing"
     },
-    "safari": {
+    "ie": {
+      "7": "polyfilled",
       "8": "polyfilled",
       "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "polyfilled",
+      "14": "polyfilled",
+      "15": "missing"
+    },
+    "safari": {
+      "6": "missing",
+      "7": "missing",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "missing",
       "5.1": "polyfilled"
     },
     "android": {
+      "5": "missing",
+      "6": "missing",
+      "7": "missing",
+      "7.1": "missing",
+      "5.1": "missing",
       "4.4": "polyfilled"
     },
     "ios_saf": {
+      "4": "missing",
+      "5": "missing",
+      "6": "missing",
+      "7": "missing",
+      "8": "missing",
+      "10.3": "missing",
       "9.1": "polyfilled"
+    }
+  },
+  "Array.prototype.findIndex": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "polyfilled",
+      "42": "polyfilled",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
     }
   },
   "String.prototype.padEnd": {
@@ -7039,24 +7782,1243 @@
       "42": "polyfilled",
       "46": "polyfilled",
       "48": "polyfilled",
-      "56": "missing"
+      "58": "missing"
     },
     "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "polyfilled",
       "42": "polyfilled",
       "44": "polyfilled",
       "49": "missing",
-      "52": "polyfilled"
+      "53": "missing"
     },
-    "safari": {
+    "ie": {
+      "7": "polyfilled",
       "8": "polyfilled",
       "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "polyfilled",
+      "14": "polyfilled",
+      "15": "missing"
+    },
+    "safari": {
+      "6": "missing",
+      "7": "missing",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "missing",
       "5.1": "polyfilled"
     },
     "android": {
+      "5": "missing",
+      "6": "missing",
+      "7": "missing",
+      "7.1": "missing",
+      "5.1": "missing",
       "4.4": "polyfilled"
     },
     "ios_saf": {
+      "4": "missing",
+      "5": "missing",
+      "6": "missing",
+      "7": "missing",
+      "8": "missing",
+      "10.3": "missing",
       "9.1": "polyfilled"
+    }
+  },
+  "Symbol.hasInstance": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "polyfilled",
+      "42": "polyfilled",
+      "46": "polyfilled",
+      "48": "polyfilled",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "polyfilled",
+      "42": "polyfilled",
+      "44": "polyfilled",
+      "49": "polyfilled",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "polyfilled",
+      "14": "polyfilled",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "polyfilled"
+    }
+  },
+  "Array.prototype.fill": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "polyfilled",
+      "42": "polyfilled",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "Element.prototype.before": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "polyfilled",
+      "42": "polyfilled",
+      "46": "polyfilled",
+      "48": "polyfilled",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "polyfilled",
+      "42": "polyfilled",
+      "44": "polyfilled",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "polyfilled",
+      "14": "polyfilled",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "polyfilled"
+    }
+  },
+  "Array.of": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "polyfilled",
+      "42": "polyfilled",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "Object.entries": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "polyfilled",
+      "42": "polyfilled",
+      "46": "polyfilled",
+      "48": "polyfilled",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "polyfilled",
+      "42": "polyfilled",
+      "44": "polyfilled",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "polyfilled"
+    }
+  },
+  "screen.orientation": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "polyfilled",
+      "42": "polyfilled",
+      "46": "polyfilled",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "polyfilled",
+      "42": "polyfilled",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "missing",
+      "8": "missing",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "polyfilled",
+      "14": "polyfilled",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "polyfilled"
+    }
+  },
+  "Math.sinh": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "Math.log1p": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "Symbol.toStringTag": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "polyfilled",
+      "42": "polyfilled",
+      "46": "polyfilled",
+      "48": "polyfilled",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "polyfilled",
+      "42": "polyfilled",
+      "44": "polyfilled",
+      "49": "polyfilled",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "polyfilled",
+      "14": "polyfilled",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "polyfilled"
+    }
+  },
+  "Array.from": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "polyfilled",
+      "42": "polyfilled",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "Symbol.search": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "polyfilled",
+      "42": "polyfilled",
+      "46": "polyfilled",
+      "48": "polyfilled",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "polyfilled",
+      "42": "polyfilled",
+      "44": "polyfilled",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "polyfilled",
+      "14": "polyfilled",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "polyfilled"
+    }
+  },
+  "Symbol.toPrimitive": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "polyfilled",
+      "42": "polyfilled",
+      "46": "polyfilled",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "polyfilled",
+      "42": "polyfilled",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "polyfilled",
+      "14": "polyfilled",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "polyfilled"
+    }
+  },
+  "String.prototype.includes": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "polyfilled",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "Element.prototype.closest": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "polyfilled",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "polyfilled",
+      "14": "polyfilled",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "Symbol.unscopables": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "polyfilled",
+      "42": "polyfilled",
+      "44": "polyfilled",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "Array.prototype.@@iterator": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "missing",
+      "42": "missing",
+      "44": "missing",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "missing",
+      "8": "missing",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "WebAnimations": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "native",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "polyfilled",
+      "42": "polyfilled",
+      "44": "polyfilled",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "missing",
+      "8": "missing",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "polyfilled",
+      "14": "polyfilled",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "polyfilled"
+    }
+  },
+  "fetch": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "polyfilled",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "polyfilled"
+    }
+  },
+  "Symbol.species": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "polyfilled",
+      "42": "polyfilled",
+      "46": "polyfilled",
+      "48": "polyfilled",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "polyfilled"
+    }
+  },
+  "String.prototype.repeat": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "polyfilled",
+      "42": "native",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "polyfilled",
+      "9": "native",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "native"
+    }
+  },
+  "Array.prototype.contains": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "polyfilled",
+      "42": "polyfilled",
+      "46": "polyfilled",
+      "48": "polyfilled",
+      "58": "polyfilled"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "polyfilled",
+      "42": "polyfilled",
+      "44": "polyfilled",
+      "49": "polyfilled",
+      "53": "polyfilled"
+    },
+    "ie": {
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "polyfilled",
+      "14": "polyfilled",
+      "15": "polyfilled"
+    },
+    "safari": {
+      "6": "polyfilled",
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "polyfilled",
+      "6": "polyfilled",
+      "7": "polyfilled",
+      "7.1": "polyfilled",
+      "5.1": "polyfilled",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "polyfilled",
+      "5": "polyfilled",
+      "6": "polyfilled",
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "10.3": "polyfilled",
+      "9.1": "polyfilled"
+    }
+  },
+  "Element.prototype.classList": {
+    "chrome": {
+      "35": "missing",
+      "40": "missing",
+      "42": "missing",
+      "46": "native",
+      "48": "native",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "native",
+      "33": "native",
+      "41": "native",
+      "42": "native",
+      "44": "native",
+      "49": "native",
+      "53": "native"
+    },
+    "ie": {
+      "7": "missing",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "missing",
+      "11": "missing",
+      "13": "native",
+      "14": "native",
+      "15": "native"
+    },
+    "safari": {
+      "6": "native",
+      "7": "native",
+      "8": "missing",
+      "9": "missing",
+      "10": "native",
+      "5.1": "missing"
+    },
+    "android": {
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "7.1": "native",
+      "5.1": "native",
+      "4.4": "missing"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "missing"
+    }
+  },
+  "Object.entries (timeout after 30000ms, 2 retries)": {
+    "ie": {
+      "7": "missing",
+      "8": "missing"
     }
   }
 }


### PR DESCRIPTION
This file is automatically generated by running `npm run compatgen`. The file is used to populate the data on https://polyfill.io/v2/docs/features/.

Not much reviewing needs to be done of the change, a basic review that nothing odd has changed (E.G. Latest version of Chrome marked to require polyfills for all features) should be enough.