### PR TITLE
Removed unused dependencies (Fixes #1229)

### DIFF
--- a/polyfills/Promise/config.json
+++ b/polyfills/Promise/config.json
@@ -22,11 +22,6 @@
 		"safari": "* - 7",
 		"firefox_mob": "6 - 28"
 	},
-	"dependencies": [
-		"setImmediate",
-		"Array.isArray",
-		"Event"
-	],
 	"notes": [
 		"In IE8, the `catch` & `finally` method cannot be invoked directly since they are reserved words.  Instead, use `[\"catch\"]` and `[\"finally\"]` if intend to run your code in IE8"
 	],


### PR DESCRIPTION
The `Promise` polyfill is IE5+ compatible (according to project description) and does not depend on any other polyfill.