### PR TITLE
Docs: Fix feature search

### DIFF
--- a/docs/assets/js/ui.js
+++ b/docs/assets/js/ui.js
@@ -20,9 +20,9 @@ function initDemos() {
 function initCharts() {
 	var drawFns = [];
 
-	if (document.getElementById('chart-requests')) {
-		google.charts.load('current', {'packages':['corechart']});
-	}
+	if (!document.getElementById('chart-requests') || !google || !google.charts) return;
+
+	google.charts.load('current', {'packages':['corechart']});
 
 	google.charts.setOnLoadCallback(function() {
 		var chartel = document.getElementById('chart-requests');


### PR DESCRIPTION
This fixes the feature search, which is broken since a couple of weeks. `google.charts` complained, that `.load()` should always be called before `.setOnLoadCallback()` and threw an error, which prevented all following code to be executed.

I also added a guard which checks whether `google' and `google.charts` exists - just to be safe.