### PR TITLE
Removed unused dependencies (Fixes #1229)

### DIFF
--- a/polyfills/Promise/config.json
+++ b/polyfills/Promise/config.json
@@ -22,11 +22,6 @@
 		"safari": "* - 7",
 		"firefox_mob": "6 - 28"
 	},
-	"dependencies": [
-		"setImmediate",
-		"Array.isArray",
-		"Event"
-	],
 	"notes": [
 		"In IE8, the `catch` & `finally` method cannot be invoked directly since they are reserved words.  Instead, use `[\"catch\"]` and `[\"finally\"]` if intend to run your code in IE8"
 	],

--- a/test/node/lib/test_index.js
+++ b/test/node/lib/test_index.js
@@ -64,8 +64,7 @@ describe("polyfillio", () => {
 					uaString: 'chrome/30'
 				}).then(result => assert.deepEqual(setsToArrays(result), {
 					fetch: { flags: [] },
-					Promise: { flags: [], aliasOf: [ 'fetch' ] },
-					setImmediate: { flags: [], aliasOf: [ 'Promise', 'fetch' ] }
+					Promise: { flags: [], aliasOf: [ 'fetch' ] }
 				})),
 				polyfillio.getPolyfills({
 					features: {


### PR DESCRIPTION
The `Promise` polyfill is IE5+ compatible (according to project description) and does not depend on any other polyfill.