### PR TITLE
Stop serving IntersectionObserver polyfill to Edge 15

### DIFF
--- a/polyfills/IntersectionObserver/config.json
+++ b/polyfills/IntersectionObserver/config.json
@@ -7,7 +7,7 @@
 		"chrome": "<51",
 		"firefox": "*",
 		"firefox_mob": "47 - *",
-		"ie": "7 - *",
+		"ie": "7 - 14",
 		"ie_mob": "11 - *",
 		"ios_saf": "7 - *",
 		"op_mini": "17 - *",


### PR DESCRIPTION
I have tested this myself, by requesting only the polyfill with `features=IntersectionObserver`, in Edge 15:

![screen shot 2017-07-04 at 10 35 48](https://user-images.githubusercontent.com/1769951/27822072-b1088bb8-60a4-11e7-8e41-7a1a4d2d6fdf.png)

IO is supported natively by Edge 15: [caniuse link](http://caniuse.com/#feat=intersectionobserver).

And of course I tested my own code that uses IO in Edge 15.

(I agree with the Contribution Terms).