### PR TITLE
Add polyfill for KeyboardEvent.prototype.key

### DIFF
--- a/polyfills/KeyboardEvent/prototype/key/config.json
+++ b/polyfills/KeyboardEvent/prototype/key/config.json
@@ -1,0 +1,29 @@
+{
+	"aliases": [
+	
+	],
+	"browsers": {
+		"android": "*",
+		"bb": "*",
+		"chrome": "<51",
+		"firefox": "<23",
+		"firefox_mob": "<54",
+		"ie": "<9",
+		"ie_mob": "<10",
+		"ios_chr": "*",
+		"ios_saf": "<10.3",
+		"opera": "<38",
+		"op_mini": "*",
+		"safari": "<10.1",
+		"samsung_mob": "<5"
+	},
+	"dependencies": [
+		"Array.isArray",
+		"Object.defineProperty"
+	],
+	"spec": "https://w3c.github.io/uievents/#events-keyboardevents",
+	"docs": "https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key",
+	"notes": [
+		"This polyfill is derived from work of Chris Van Wiemeersch which is [published under the **Creative Commons Zero v1.0 Universal** license (CC0 1.0 Universal; Public Domain Dedication)](https://github.com/cvan/keyboardevent-key-polyfill)"
+	]
+}

--- a/polyfills/KeyboardEvent/prototype/key/detect.js
+++ b/polyfills/KeyboardEvent/prototype/key/detect.js
@@ -1,0 +1,1 @@
+'KeyboardEvent' in this && 'key' in KeyboardEvent.prototype

--- a/polyfills/KeyboardEvent/prototype/key/polyfill.js
+++ b/polyfills/KeyboardEvent/prototype/key/polyfill.js
@@ -1,0 +1,98 @@
+(function () {
+	
+	var keys = {
+		3: 'Cancel',
+		6: 'Help',
+		8: 'Backspace',
+		9: 'Tab',
+		12: 'Clear',
+		13: 'Enter',
+		16: 'Shift',
+		17: 'Control',
+		18: 'Alt',
+		19: 'Pause',
+		20: 'CapsLock',
+		27: 'Escape',
+		28: 'Convert',
+		29: 'NonConvert',
+		30: 'Accept',
+		31: 'ModeChange',
+		32: ' ',
+		33: 'PageUp',
+		34: 'PageDown',
+		35: 'End',
+		36: 'Home',
+		37: 'ArrowLeft',
+		38: 'ArrowUp',
+		39: 'ArrowRight',
+		40: 'ArrowDown',
+		41: 'Select',
+		42: 'Print',
+		43: 'Execute',
+		44: 'PrintScreen',
+		45: 'Insert',
+		46: 'Delete',
+		48: ['0', ')'],
+		49: ['1', '!'],
+		50: ['2', '@'],
+		51: ['3', '#'],
+		52: ['4', '$'],
+		53: ['5', '%'],
+		54: ['6', '^'],
+		55: ['7', '&'],
+		56: ['8', '*'],
+		57: ['9', '('],
+		91: 'OS',
+		93: 'ContextMenu',
+		144: 'NumLock',
+		145: 'ScrollLock',
+		181: 'VolumeMute',
+		182: 'VolumeDown',
+		183: 'VolumeUp',
+		186: [';', ':'],
+		187: ['=', '+'],
+		188: [',', '<'],
+		189: ['-', '_'],
+		190: ['.', '>'],
+		191: ['/', '?'],
+		192: ['`', '~'],
+		219: ['[', '{'],
+		220: ['\\', '|'],
+		221: [']', '}'],
+		222: ["'", '"'],
+		224: 'Meta',
+		225: 'AltGraph',
+		246: 'Attn',
+		247: 'CrSel',
+		248: 'ExSel',
+		249: 'EraseEof',
+		250: 'Play',
+		251: 'ZoomOut'
+	};
+	
+	// Function keys (F1-24).
+	var i;
+	for (i = 1; i < 25; i++) {
+		keys[111 + i] = 'F' + i;
+	}
+	
+	// Printable ASCII characters.
+	var letter = '';
+	for (i = 65; i < 91; i++) {
+		letter = String.fromCharCode(i);
+		keys[i] = [letter.toLowerCase(), letter.toUpperCase()];
+	}
+	
+	Object.defineProperty(KeyboardEvent.prototype, 'key', {
+		get: function () {
+			var key = keys[this.which || this.keyCode];
+			
+			if (Array.isArray(key)) {
+				key = key[+this.shiftKey];
+			}
+			
+			return key;
+		}
+	});
+	
+})();


### PR DESCRIPTION
Since KeyboardEvent.which, KeyboardEvent.keyIdentifier, KeyboardEvent.keyCode are all marked as deprecated or non-standard, add a polyfill for the new (draft) KeyboardEvent.key property.

See https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key