### PR TITLE
[fix] add `append(...args)` to fragments too

### DIFF
--- a/polyfills/Element/prototype/append/config.json
+++ b/polyfills/Element/prototype/append/config.json
@@ -22,6 +22,7 @@
 	},
 	"dependencies": [
 		"Document",
+		"DocumentFragment",
 		"Element",
 		"_mutation"
 	],

--- a/polyfills/Element/prototype/append/polyfill.js
+++ b/polyfills/Element/prototype/append/polyfill.js
@@ -1,3 +1,3 @@
-Document.prototype.append = Element.prototype.append = function append() {
+Document.prototype.append = Element.prototype.append = DocumentFragment.prototype.append = function append() {
 	this.appendChild(_mutation(arguments));
 };


### PR DESCRIPTION
Specifications make `append` available for document fragments too.

It's easy to fail a feature detection via `'append' in document` assuming `append` can be then used via `document.createDocumentFragment().append(...)` too.

This change fixes the issue and avoid conflicts with other libraries.