### PR TITLE
No versions of IE support toBlob

### DIFF
--- a/polyfills/HTMLCanvasElement/prototype/toBlob/config.json
+++ b/polyfills/HTMLCanvasElement/prototype/toBlob/config.json
@@ -6,7 +6,7 @@
 		"chrome": "<50",
 		"firefox": "<19",
 		"safari": "*",
-		"ie": "*",
+		"ie": "10-11",
 		"opera": "*"
 	},
 	"dependencies": [

--- a/polyfills/HTMLCanvasElement/prototype/toBlob/config.json
+++ b/polyfills/HTMLCanvasElement/prototype/toBlob/config.json
@@ -6,7 +6,7 @@
 		"chrome": "<50",
 		"firefox": "<19",
 		"safari": "*",
-		"ie": "10",
+		"ie": "*",
 		"opera": "*"
 	},
 	"dependencies": [


### PR DESCRIPTION
IE11 doesn't and that's the last IE version ever.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/financial-times/polyfill-service/1258)
<!-- Reviewable:end -->
