### PR TITLE
Add DocumentFragment polyfill

### DIFF
--- a/polyfills/DocumentFragment/config.json
+++ b/polyfills/DocumentFragment/config.json
@@ -1,0 +1,20 @@
+{
+	"aliases": [],
+	"browsers": {
+		"android": "<3",
+		"firefox": "<4",
+		"ios_chr": "<4",
+		"ios_saf": "<4",
+		"ie": "<9",
+		"ie_mob": "<9",
+		"opera": "<11",
+		"op_mini": "<11",
+		"safari": "<4",
+		"firefox_mob": "<4",
+		"samsung_mob": "<3"
+	},
+	"dependencies": [],
+	"docs": "https://developer.mozilla.org/en-US/docs/Web/API/DocumentFragment",
+	"spec": "https://dom.spec.whatwg.org/#interface-documentfragment",
+	"notes": []
+}

--- a/polyfills/DocumentFragment/detect.js
+++ b/polyfills/DocumentFragment/detect.js
@@ -1,0 +1,1 @@
+'DocumentFragment' in this && this.DocumentFragment === document.createDocumentFragment().constructor

--- a/polyfills/DocumentFragment/polyfill.js
+++ b/polyfills/DocumentFragment/polyfill.js
@@ -1,0 +1,1 @@
+this.DocumentFragment = document.createDocumentFragment().constructor;

--- a/polyfills/DocumentFragment/tests.js
+++ b/polyfills/DocumentFragment/tests.js
@@ -1,0 +1,6 @@
+/* eslint-env mocha, browser*/
+/* global proclaim, it */
+
+it('is the DocumentFragment constructor', function () {
+	proclaim.equal(self.DocumentFragment, document.createDocumentFragment().constructor);
+});


### PR DESCRIPTION
This polyfill allows us to lay the foundation to add polyfills for missing DocumentFragment methods such as [`append`](https://github.com/Financial-Times/polyfill-service/pull/) and letting all of those polyfills work on IE7 and IE8 as well as some old Safari and Firefox versions.