### PR TITLE
String.prototype.padEnd.length should be 1

### DIFF
--- a/polyfills/String/prototype/padEnd/polyfill.js
+++ b/polyfills/String/prototype/padEnd/polyfill.js
@@ -2,10 +2,10 @@
 	Object.defineProperty(String.prototype, 'padEnd', {
 		configurable: true,
 		enumerable: false,
-		value: function padEnd (targetLength, padString) {
+		value: function padEnd (targetLength) {
 			targetLength = targetLength | 0;
 			if (targetLength <= this.length) return String(this);
-			padString = String(padString || " ");
+			var padString = String(arguments[1] || " ");
 			var repeat = Math.ceil((targetLength - this.length) / padString.length);
 			while (repeat--) {
 				padString += padString;

--- a/polyfills/String/prototype/padEnd/tests.js
+++ b/polyfills/String/prototype/padEnd/tests.js
@@ -6,7 +6,7 @@ it('has correct instance', function () {
 });
 
 it('has correct argument length', function () {
-	proclaim.equal(String.prototype.padEnd.length, 2);
+	proclaim.equal(String.prototype.padEnd.length, 1);
 });
 
 it('works with strings', function () {


### PR DESCRIPTION
2nd argument is optional which means it should not count towards function's length property.

Our live test suite shows this test failing in latest Chrome Stable -- https://polyfill.io/test/tests?mode=targeted&grep=String%5C.prototype%5C.padEnd