### PR TITLE
String.prototype.padStart.length should be 1

### DIFF
--- a/polyfills/String/prototype/padStart/polyfill.js
+++ b/polyfills/String/prototype/padStart/polyfill.js
@@ -2,10 +2,10 @@
 	Object.defineProperty(String.prototype, 'padStart', {
 		configurable: true,
 		enumerable: false,
-		value: function padStart (targetLength, padString) {
+		value: function padStart (targetLength) {
 			targetLength = targetLength | 0;
 			if (targetLength <= this.length) return String(this);
-			padString = String(padString || " ");
+			var padString = String(arguments[1] || " ");
 			var repeat = Math.ceil((targetLength - this.length) / padString.length);
 			while (repeat--) {
 				padString += padString;

--- a/polyfills/String/prototype/padStart/tests.js
+++ b/polyfills/String/prototype/padStart/tests.js
@@ -6,7 +6,7 @@ it('has correct instance', function () {
 });
 
 it('has correct argument length', function () {
-	proclaim.equal(String.prototype.padStart.length, 2);
+	proclaim.equal(String.prototype.padStart.length, 1);
 });
 
 it('works with strings', function () {


### PR DESCRIPTION
2nd argument is optional which means it should not count towards function's length property.

Our live test suite shows this test failing in latest Chrome Stable -- https://polyfill.io/test/tests?mode=targeted&grep=String%5C.prototype%5C.padStart