### PR TITLE
For `Element.prototype.before` and `Element.prototype.after` - Let viableNextSibling be context object’s first following sibling not in nodes, and null otherwise.

### DIFF
--- a/polyfills/Element/prototype/after/config.json
+++ b/polyfills/Element/prototype/after/config.json
@@ -23,6 +23,7 @@
 	"dependencies": [
 		"Document",
 		"Element",
+		"Array.prototype.indexOf",
 		"_mutation"
 	],
 	"spec": "http://dom.spec.whatwg.org/#dom-childnode-after",

--- a/polyfills/Element/prototype/after/polyfill.js
+++ b/polyfills/Element/prototype/after/polyfill.js
@@ -1,6 +1,18 @@
 Document.prototype.after = Element.prototype.after = function after() {
 	if (this.parentNode) {
-		this.parentNode.insertBefore(_mutation(arguments), this.nextSibling);
+		var args = Array.prototype.slice.call(arguments),
+				viableNextSibling = this.nextSibling,
+				idx = viableNextSibling ? args.indexOf(viableNextSibling) : -1;
+
+		while (idx !== -1) {
+			viableNextSibling = viableNextSibling.nextSibling;
+			if (!viableNextSibling) {
+				break;
+			}
+			idx = args.indexOf(viableNextSibling);
+		}
+		
+		this.parentNode.insertBefore(_mutation(arguments), viableNextSibling);
 	}
 };
 

--- a/polyfills/Element/prototype/before/config.json
+++ b/polyfills/Element/prototype/before/config.json
@@ -23,6 +23,7 @@
 	"dependencies": [
 		"Document",
 		"Element",
+		"Array.prototype.indexOf",
 		"_mutation"
 	],
 	"spec": "http://dom.spec.whatwg.org/#dom-childnode-before",

--- a/polyfills/Element/prototype/before/polyfill.js
+++ b/polyfills/Element/prototype/before/polyfill.js
@@ -1,6 +1,21 @@
 Document.prototype.before = Element.prototype.before = function before() {
 	if (this.parentNode) {
-		this.parentNode.insertBefore(_mutation(arguments), this);
+		var args = Array.prototype.slice.call(arguments),
+			viablePreviousSibling = this.previousSibling,
+			idx = viablePreviousSibling ? args.indexOf(viablePreviousSibling) : -1;
+
+		while (idx !== -1) {
+			viablePreviousSibling = viablePreviousSibling.previousSibling;
+			if (!viablePreviousSibling) {
+				break;
+			}
+			idx = args.indexOf(viablePreviousSibling);
+		}
+
+		this.parentNode.insertBefore(
+			_mutation(arguments),
+			viablePreviousSibling ? viablePreviousSibling.nextSibling : this.parentNode.firstChild
+		);
 	}
 };
 


### PR DESCRIPTION
https://dom.spec.whatwg.org/#dom-childnode-after point 3.

possibly .before and .replaceWith too