### PR TITLE
Serve requestAnimationFrame to all android browser versions

### DIFF
--- a/polyfills/requestAnimationFrame/config.json
+++ b/polyfills/requestAnimationFrame/config.json
@@ -9,7 +9,7 @@
 		"modernizr:requestanimationframe"
 	],
 	"browsers": {
-		"android": "<4.4",
+		"android": "*",
 		"bb": "7",
 		"chrome": "1 - 23",
 		"ie": "6 - 9",


### PR DESCRIPTION
Android 4.4 and later are using chrome browser, except a few terminals some with a browser bundled into it with an older version of the renderer.
When Chome/xxx is in the user agent in Android 4.4 it's a chrome browser, else the browser doesn't support requestAnimationFrame

Here are examples of user agents:

- `Mozilla/5.0 (Linux; U; Android 4.4.4; fr-fr; GT-I9305 Build/KTU84P) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30`
- `Mozilla/5.0 (Linux; U; Android 4.4.4; fr-fr; SAMSUNG SM-G357FZ/G357FZXXU1AOJ1 Build/KTU84P) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30`
- `Mozilla/5.0 (Linux; Android 4.4.2; Android SDK built for x86 Build/KK) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36`

fixes: #1247 