### PR TITLE
[fix] add `append(...args)` to fragments too

### DIFF
--- a/polyfills/DocumentFragment/config.json
+++ b/polyfills/DocumentFragment/config.json
@@ -5,7 +5,7 @@
 		"firefox": "<4",
 		"ios_chr": "<4",
 		"ios_saf": "<4",
-		"ie": "8-9",
+		"ie": "8 - 9",
 		"ie_mob": "<9",
 		"opera": "<11",
 		"op_mini": "<11",

--- a/polyfills/DocumentFragment/config.json
+++ b/polyfills/DocumentFragment/config.json
@@ -5,7 +5,7 @@
 		"firefox": "<4",
 		"ios_chr": "<4",
 		"ios_saf": "<4",
-		"ie": "<9",
+		"ie": "8-9",
 		"ie_mob": "<9",
 		"opera": "<11",
 		"op_mini": "<11",

--- a/polyfills/DocumentFragment/prototype/append/config.json
+++ b/polyfills/DocumentFragment/prototype/append/config.json
@@ -1,0 +1,29 @@
+{
+	"aliases": [
+		"default-3.4",
+		"default-3.5",
+		"default-3.6",
+		"default"
+	],
+	"browsers": {
+		"android": "*",
+		"bb": "*",
+		"chrome": "<54",
+		"firefox": "<49",
+		"ios_chr": "*",
+		"ios_saf": "<10",
+		"ie": "6 - *",
+		"ie_mob": "10 - *",
+		"opera": "*",
+		"op_mini": "*",
+		"safari": "<10",
+		"firefox_mob": "<49",
+		"samsung_mob": "*"
+	},
+	"dependencies": [
+		"Document",
+		"Element",
+		"_mutation"
+	],
+	"spec": "http://dom.spec.whatwg.org/#dom-parentnode-append"
+}

--- a/polyfills/DocumentFragment/prototype/append/config.json
+++ b/polyfills/DocumentFragment/prototype/append/config.json
@@ -12,7 +12,7 @@
 		"firefox": "<49",
 		"ios_chr": "*",
 		"ios_saf": "<10",
-		"ie": "6 - *",
+		"ie": "8 - *",
 		"ie_mob": "10 - *",
 		"opera": "*",
 		"op_mini": "*",

--- a/polyfills/DocumentFragment/prototype/append/config.json
+++ b/polyfills/DocumentFragment/prototype/append/config.json
@@ -22,6 +22,7 @@
 	},
 	"dependencies": [
 		"Document",
+		"DocumentFragment",
 		"Element",
 		"_mutation"
 	],

--- a/polyfills/DocumentFragment/prototype/append/detect.js
+++ b/polyfills/DocumentFragment/prototype/append/detect.js
@@ -1,0 +1,1 @@
+'DocumentFragment' in this && 'append' in DocumentFragment.prototype

--- a/polyfills/DocumentFragment/prototype/append/polyfill.js
+++ b/polyfills/DocumentFragment/prototype/append/polyfill.js
@@ -1,0 +1,3 @@
+DocumentFragment.prototype.append = function append() {
+	this.appendChild(_mutation(arguments));
+};

--- a/polyfills/DocumentFragment/prototype/append/tests.js
+++ b/polyfills/DocumentFragment/prototype/append/tests.js
@@ -1,0 +1,31 @@
+/* eslint-env mocha, browser*/
+/* global proclaim, it */
+
+var fragment;
+
+function nameOf(fn) {
+	return Function.prototype.toString.call(fn).match(/function\s*([^\s]*)\(/)[1];
+}
+
+beforeEach(function () {
+	fragment = document.createDocumentFragment();
+});
+
+it('has correct instance', function () {
+	proclaim.isInstanceOf(fragment.append, Function);
+});
+
+it('has correct name', function () {
+	proclaim.equal(nameOf(fragment.append), 'append');
+});
+
+it('has correct argument length', function () {
+	proclaim.equal(fragment.append.length, 0);
+});
+
+it('can append elements', function () {
+	var child = document.createElement('div');
+	fragment.append(child);
+	proclaim.equal(fragment.childNodes[0], child);
+	proclaim.equal(fragment.childNodes.length, 1);
+});


### PR DESCRIPTION
Specifications make append available for document fragments too.

It's easy to fail a feature detection via 'append' in document
assuming append can be then used via document.createDocumentFragment().append(...) too.

This change fixes the issue and avoid conflicts with other libraries.