### PR TITLE
Polyfill Array.prototype.@@iterator on Safari 9

### DIFF
--- a/polyfills/Array/prototype/@@iterator/config.json
+++ b/polyfills/Array/prototype/@@iterator/config.json
@@ -8,9 +8,9 @@
 		"ie_mob": "9 - 12",
 		"firefox": "<38",
 		"chrome": "<49",
-		"safari": "<9",
+		"safari": "<10",
 		"android": "<5.1",
-		"ios_saf": "<9",
+		"ios_saf": "<10",
 		"opera": "<25",
 		"samsung_mob": "<5"
 	},


### PR DESCRIPTION
Got several error reports in our tracker from iOS users with the following UA.
```
Mozilla/5.0 (iPhone; CPU iPhone OS 9_2_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13D15 Safari/601.1
```
http://caniuse.com/#search=iterator