### PR TITLE
To avoid an error where console is undefined, check that console exists before checking a console method exists

### DIFF
--- a/polyfills/console/assert/detect.js
+++ b/polyfills/console/assert/detect.js
@@ -1,1 +1,1 @@
-'assert' in this.console
+'console' in this && 'assert' in this.console

--- a/polyfills/console/clear/detect.js
+++ b/polyfills/console/clear/detect.js
@@ -1,1 +1,1 @@
-'clear' in this.console
+'console' in this && 'clear' in this.console

--- a/polyfills/console/count/detect.js
+++ b/polyfills/console/count/detect.js
@@ -1,1 +1,1 @@
-'count' in this.console
+'console' in this && 'count' in this.console

--- a/polyfills/console/debug/detect.js
+++ b/polyfills/console/debug/detect.js
@@ -1,1 +1,1 @@
-'debug' in this.console
+'console' in this && 'debug' in this.console

--- a/polyfills/console/dir/detect.js
+++ b/polyfills/console/dir/detect.js
@@ -1,1 +1,1 @@
-'dir' in this.console
+'console' in this && 'dir' in this.console

--- a/polyfills/console/dirxml/detect.js
+++ b/polyfills/console/dirxml/detect.js
@@ -1,1 +1,1 @@
-'dirxml' in this.console
+'console' in this && 'dirxml' in this.console

--- a/polyfills/console/error/detect.js
+++ b/polyfills/console/error/detect.js
@@ -1,1 +1,1 @@
-'error' in this.console
+'console' in this && 'error' in this.console

--- a/polyfills/console/exception/detect.js
+++ b/polyfills/console/exception/detect.js
@@ -1,1 +1,1 @@
-'exception' in this.console
+'console' in this && 'exception' in this.console

--- a/polyfills/console/group/detect.js
+++ b/polyfills/console/group/detect.js
@@ -1,1 +1,1 @@
-'group' in this.console
+'console' in this && 'group' in this.console

--- a/polyfills/console/groupCollapsed/detect.js
+++ b/polyfills/console/groupCollapsed/detect.js
@@ -1,1 +1,1 @@
-'groupCollapsed' in this.console
+'console' in this && 'groupCollapsed' in this.console

--- a/polyfills/console/groupEnd/detect.js
+++ b/polyfills/console/groupEnd/detect.js
@@ -1,1 +1,1 @@
-'groupEnd' in this.console
+'console' in this && 'groupEnd' in this.console

--- a/polyfills/console/info/detect.js
+++ b/polyfills/console/info/detect.js
@@ -1,1 +1,1 @@
-'info' in this.console
+'console' in this && 'info' in this.console

--- a/polyfills/console/log/detect.js
+++ b/polyfills/console/log/detect.js
@@ -1,1 +1,1 @@
-'log' in this.console
+'console' in this && 'log' in this.console

--- a/polyfills/console/markTimeline/detect.js
+++ b/polyfills/console/markTimeline/detect.js
@@ -1,1 +1,1 @@
-'markTimeline' in this.console
+'console' in this && 'markTimeline' in this.console

--- a/polyfills/console/profile/detect.js
+++ b/polyfills/console/profile/detect.js
@@ -1,1 +1,1 @@
-'profile' in this.console
+'console' in this && 'profile' in this.console

--- a/polyfills/console/profileEnd/detect.js
+++ b/polyfills/console/profileEnd/detect.js
@@ -1,1 +1,1 @@
-'profileEnd' in this.console
+'console' in this && 'profileEnd' in this.console

--- a/polyfills/console/profiles/detect.js
+++ b/polyfills/console/profiles/detect.js
@@ -1,1 +1,1 @@
-'profiles' in this.console
+'console' in this && 'profiles' in this.console

--- a/polyfills/console/table/detect.js
+++ b/polyfills/console/table/detect.js
@@ -1,1 +1,1 @@
-'table' in this.console
+'console' in this && 'table' in this.console

--- a/polyfills/console/time/detect.js
+++ b/polyfills/console/time/detect.js
@@ -1,1 +1,1 @@
-'time' in this.console
+'console' in this && 'time' in this.console

--- a/polyfills/console/timeEnd/detect.js
+++ b/polyfills/console/timeEnd/detect.js
@@ -1,1 +1,1 @@
-'timeEnd' in this.console
+'console' in this && 'timeEnd' in this.console

--- a/polyfills/console/timeStamp/detect.js
+++ b/polyfills/console/timeStamp/detect.js
@@ -1,1 +1,1 @@
-'timeStamp' in this.console
+'console' in this && 'timeStamp' in this.console

--- a/polyfills/console/timeline/detect.js
+++ b/polyfills/console/timeline/detect.js
@@ -1,1 +1,1 @@
-'timeline' in this.console
+'console' in this && 'timeline' in this.console

--- a/polyfills/console/timelineEnd/detect.js
+++ b/polyfills/console/timelineEnd/detect.js
@@ -1,1 +1,1 @@
-'timelineEnd' in this.console
+'console' in this && 'timelineEnd' in this.console

--- a/polyfills/console/trace/detect.js
+++ b/polyfills/console/trace/detect.js
@@ -1,1 +1,1 @@
-'trace' in this.console
+'console' in this && 'trace' in this.console

--- a/polyfills/console/warn/detect.js
+++ b/polyfills/console/warn/detect.js
@@ -1,1 +1,1 @@
-'warn' in this.console
+'console' in this && 'warn' in this.console


### PR DESCRIPTION
I've updated all the console method detection scripts to first check that console actually exists. If console does not exist the detection script will return false.