### PR TITLE
Set the age header to 0 before sending the request back to the browser

### DIFF
--- a/vcl/main.vcl
+++ b/vcl/main.vcl
@@ -122,6 +122,8 @@ sub vcl_deliver {
 		set resp.http.Debug-Host = req.http.Host;
 		set resp.http.Debug-X-Original-Host = req.http.X-Original-Host;
 	}
+	
+	unset resp.http.Age;
 
 	return(deliver);
 }

--- a/vcl/main.vcl
+++ b/vcl/main.vcl
@@ -123,7 +123,7 @@ sub vcl_deliver {
 		set resp.http.Debug-X-Original-Host = req.http.X-Original-Host;
 	}
 	
-	unset resp.http.Age;
+	set resp.http.Age = 0;
 
 	return(deliver);
 }


### PR DESCRIPTION
Fixes #1276 

This should be safe as it is after the `restart` call inside of vcl_deliver.