### PR TITLE
Remove sourcemapURL comments from polyfills

### DIFF
--- a/tasks/node/buildsources.js
+++ b/tasks/node/buildsources.js
@@ -216,7 +216,7 @@ class Polyfill {
 	}
 
 	removeSourceMaps(source) {
-		var re = /^\/\/#\ssourceMappingURL(.+)$/gm;
+		const re = /^\/\/#\ssourceMappingURL(.+)$/gm;
 
 		return { raw: source.raw.replace(re, ''), min: source.min.replace(re, '') };
 	}

--- a/tasks/node/buildsources.js
+++ b/tasks/node/buildsources.js
@@ -159,6 +159,7 @@ class Polyfill {
 					error
 				};
 			})
+			.then(this.removeSourceMaps)
 			.then(sources => {
 				this.sources = sources;
 			});
@@ -212,6 +213,12 @@ class Polyfill {
 
 			return { raw, min: minified.code };
 		}
+	}
+
+	removeSourceMaps(source) {
+		var re = /^\/\/#\ssourceMappingURL(.+)$/gm;
+
+		return { raw: source.raw.replace(re, ''), min: source.min.replace(re, '') };
 	}
 
 	writeOutput(root) {

--- a/test/integration/v2/api.js
+++ b/test/integration/v2/api.js
@@ -21,6 +21,7 @@ describe('GET /v2/polyfill.js', function() {
 		return this.request.expect(response => {
 			assert.isString(response.text);
 			assert.doesNotThrow(() => new vm.Script(response.text));
+			assert.notMatch(response.text, /\/\/#\ssourceMappingURL(.+)/);
 		});
 	});
 });
@@ -36,6 +37,7 @@ describe('GET /v2/polyfill.js?callback=AAA&callback=BBB', function() {
 		return this.request.expect(response => {
 			assert.isString(response.text);
 			assert.doesNotThrow(() => new vm.Script(response.text));
+			assert.notMatch(response.text, /\/\/#\ssourceMappingURL(.+)/);
 		});
 	});
 });
@@ -51,6 +53,7 @@ describe('GET /v2/polyfill.min.js', function() {
 		return this.request.expect(response => {
 			assert.isString(response.text);
 			assert.doesNotThrow(() => new vm.Script(response.text));
+			assert.notMatch(response.text, /\/\/#\ssourceMappingURL(.+)/);
 		});
 	});
 });
@@ -69,6 +72,7 @@ describe('GET /v2/polyfill.js?features=all&ua=non-existent-ua&unknown=polyfill&f
 			assert.isString(response.text);
 			// vm.Script will cause the event loop to become blocked whilst it parses the large response
 			assert.doesNotThrow(() => new vm.Script(response.text));
+			assert.notMatch(response.text, /\/\/#\ssourceMappingURL(.+)/);
 		});
 	});
 });
@@ -85,6 +89,7 @@ describe('GET /v2/polyfill.min.js?features=all&ua=non-existent-ua&unknown=polyfi
 			assert.isString(response.text);
 			// vm.Script will cause the event loop to become blocked whilst it parses the large response
 			assert.doesNotThrow(() => new vm.Script(response.text));
+			assert.notMatch(response.text, /\/\/#\ssourceMappingURL(.+)/);
 		});
 	});
 });


### PR DESCRIPTION
Fixes #1244 

Before this fix:

```
> npm run test-integration
  142 passing
  2 failing

  1) GET /v2/polyfill.js?features=all&ua=non-existent-ua&unknown=polyfill&flags=gated&rum=1 responds with valid javascript:
     AssertionError: '/* Polyfill service DEVELOPMENT MODE - for live use set NODE_ENV to \'production\'\n * For detailed credits and licence informa… !match /\/\/#\ssourceMappingURL(.+)/

  2) GET /v2/polyfill.min.js?features=all&ua=non-existent-ua&unknown=polyfill&flags=gated&rum=1 responds with valid javascript:
     AssertionError: '/* Disable minification (remove `.min` from URL path) for more info */\n\n(function(undefined) {if (!(// In IE8, defineProperty… !match /\/\/#\ssourceMappingURL(.+)/
```

After this fix:
```
> npm run test-integration
  144 passing (24s)
```