### PR TITLE
Set Symbol.toStringTag to be writable to make this polyfill spec compliant

### DIFF
--- a/polyfills/_Iterator/polyfill.js
+++ b/polyfills/_Iterator/polyfill.js
@@ -173,7 +173,7 @@ var Iterator = (function () { // eslint-disable-line no-unused-vars
 		value: 'Iterator',
 		configurable: false,
 		enumerable: false,
-		writable: false
+		writable: true
 	});
 
 	return Iterator;


### PR DESCRIPTION
 and to work with generator polyfills such the the regenerator library by Facebook #1156