### PR TITLE
Alias modern opera to version of chrome they are using

### DIFF
--- a/lib/UA.js
+++ b/lib/UA.js
@@ -107,6 +107,37 @@ const aliases = {
 		"14.2": ["chrome", 32],
 		"13.12": ["chrome", 30],
 		"13.10": ["chrome", 28]
+	},
+
+	"opera": {
+		"20": ["chrome", 33],
+		"21": ["chrome", 34],
+		"22": ["chrome", 35],
+		"23": ["chrome", 36],
+		"24": ["chrome", 37],
+		"25": ["chrome", 38],
+		"26": ["chrome", 39],
+		"27": ["chrome", 40],
+		"28": ["chrome", 41],
+		"29": ["chrome", 42],
+		"30": ["chrome", 43],
+		"31": ["chrome", 44],
+		"32": ["chrome", 45],
+		"33": ["chrome", 46],
+		"34": ["chrome", 47],
+		"35": ["chrome", 48],
+		"36": ["chrome", 49],
+		"37": ["chrome", 50],
+		"38": ["chrome", 51],
+		"39": ["chrome", 52],
+		"40": ["chrome", 53],
+		"41": ["chrome", 54],
+		"42": ["chrome", 55],
+		"43": ["chrome", 56],
+		"44": ["chrome", 57],
+		"45": ["chrome", 58],
+		"46": ["chrome", 59],
+		"47": ["chrome", 60]
 	}
 };
 

--- a/test/unit/lib/UA.js
+++ b/test/unit/lib/UA.js
@@ -159,14 +159,14 @@ describe("lib/UA", function () {
 				const android = new UA("Mozilla/5.0 (Linux; U; Android 3.0.1; en-us; GT-P7510 Build/HRI83) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13");
 				assert.equal(android.ua.family, 'android');
 
-				const opera = new UA("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.10 Safari/537.36 OPR/27.0.1689.22 (Edition developer)");
-				assert.equal(opera.ua.family, 'opera');
-
 				const chrome = new UA("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36");
 				assert.equal(chrome.ua.family, 'chrome');
 			});
 
 			it('uses alias for browser family name if alias exists', () => {
+				const opera = new UA("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.10 Safari/537.36 OPR/27.0.1689.22 (Edition developer)");
+				assert.equal(opera.ua.family, 'chrome');
+
 				const blackberryWebKit = new UA("Mozilla/5.0 (BB10; Touch) AppleWebKit/537.3+ (KHTML, like Gecko) Version/10.0.9.388 Mobile Safari/537.3+");
 				assert.equal(blackberryWebKit.ua.family, "bb");
 


### PR DESCRIPTION
This is based on conversations in another PR -- https://github.com/Financial-Times/polyfill-service/pull/1294#issuecomment-328085319

>Opera implements chromium and webkit directly and without changes by version number, so that a feature that is implemented for example in chromium 54 is implemented in Opera 41 according to their [release history](https://en.wikipedia.org/wiki/History_of_the_Opera_web_browser#Opera_2017).