### PR TITLE
Revert "Remove codepaths which are never executed"

### DIFF
--- a/polyfills/Array/prototype/every/polyfill.js
+++ b/polyfills/Array/prototype/every/polyfill.js
@@ -10,7 +10,7 @@ Array.prototype.every = function every(callback) {
 	var
 	object = Object(this),
 	scope = arguments[1],
-	arraylike = object,
+	arraylike = object instanceof String ? object.split('') : object,
 	length = Number(arraylike.length) || 0,
 	index = -1;
 

--- a/polyfills/Array/prototype/filter/polyfill.js
+++ b/polyfills/Array/prototype/filter/polyfill.js
@@ -10,7 +10,7 @@ Array.prototype.filter = function filter(callback) {
 	var
 	object = Object(this),
 	scope = arguments[1],
-	arraylike = object,
+	arraylike = object instanceof String ? object.split('') : object,
 	length = Math.max(Math.min(arraylike.length, 9007199254740991), 0) || 0,
 	index = -1,
 	result = [],

--- a/polyfills/Array/prototype/find/polyfill.js
+++ b/polyfills/Array/prototype/find/polyfill.js
@@ -12,7 +12,7 @@ Object.defineProperty(Array.prototype, 'find', {
 		var
 		object = Object(this),
 		scope = arguments[1],
-		arraylike = object,
+		arraylike = object instanceof String ? object.split('') : object,
 		length = Math.max(Math.min(arraylike.length, 9007199254740991), 0) || 0,
 		index = -1,
 		element;

--- a/polyfills/Array/prototype/findIndex/polyfill.js
+++ b/polyfills/Array/prototype/findIndex/polyfill.js
@@ -12,7 +12,7 @@ Object.defineProperty(Array.prototype, 'findIndex', {
 		var
 		object = Object(this),
 		scope = arguments[1],
-		arraylike = object,
+		arraylike = object instanceof String ? object.split('') : object,
 		length = Math.max(Math.min(arraylike.length, 9007199254740991), 0) || 0,
 		index = -1;
 

--- a/polyfills/Array/prototype/forEach/polyfill.js
+++ b/polyfills/Array/prototype/forEach/polyfill.js
@@ -10,7 +10,7 @@ Array.prototype.forEach = function forEach(callback) {
 	var
 	object = Object(this),
 	scope = arguments[1],
-	arraylike = object,
+	arraylike = object instanceof String ? object.split('') : object,
 	length = Math.max(Math.min(arraylike.length, 9007199254740991), 0) || 0,
 	index = -1;
 

--- a/polyfills/Array/prototype/map/polyfill.js
+++ b/polyfills/Array/prototype/map/polyfill.js
@@ -10,7 +10,7 @@ Array.prototype.map = function map(callback) {
 	var
 	object = Object(this),
 	scope = arguments[1],
-	arraylike = object,
+	arraylike = object instanceof String ? object.split('') : object,
 	length = Math.max(Math.min(arraylike.length, 9007199254740991), 0) || 0,
 	index = -1,
 	result = [];

--- a/polyfills/Array/prototype/reduce/polyfill.js
+++ b/polyfills/Array/prototype/reduce/polyfill.js
@@ -9,7 +9,7 @@ Array.prototype.reduce = function reduce(callback) {
 
 	var
 	object = Object(this),
-	arraylike = object,
+	arraylike = object instanceof String ? object.split('') : object,
 	length = Math.max(Math.min(arraylike.length, 9007199254740991), 0) || 0,
 	index = -1,
 	previousValue;

--- a/polyfills/Array/prototype/reduceRight/polyfill.js
+++ b/polyfills/Array/prototype/reduceRight/polyfill.js
@@ -9,7 +9,7 @@ Array.prototype.reduceRight = function reduceRight(callback) {
 
 	var
 	object = Object(this),
-	arraylike = object,
+	arraylike = object instanceof String ? object.split('') : object,
 	length = -1,
 	index = Math.max(Math.min(arraylike.length, 9007199254740991), 0) || 0,
 	previousValue;

--- a/polyfills/Array/prototype/some/polyfill.js
+++ b/polyfills/Array/prototype/some/polyfill.js
@@ -10,7 +10,7 @@ Array.prototype.some = function some(callback) {
 	var
 	object = Object(this),
 	scope = arguments[1],
-	arraylike = object,
+	arraylike = object instanceof String ? object.split('') : object,
 	length = Math.max(Math.min(arraylike.length, 9007199254740991), 0) || 0,
 	index = -1;
 


### PR DESCRIPTION
Reverts Financial-Times/polyfill-service#1325

I thought this would be `false`
```
Object("this") instanceof String // true
```
From the spec:
> When the Object function is called with one argument value, and the value neither is null nor undefined, and is supplied, return ToObject(value)

>The abstract operation ToObject(argument), if Type of argument is String, return a new String object whose [[StringData]] internal slot is set to argument.

Turns out in IE8, index based lookups on String objects made via Object construction return undefined.
```
Object('this')[0] // undefined
String('this')[0] // 't'
Object(String('this'))[0] // undefined
```