### PR TITLE
Add privacy-policy and T&Cs pages

### DIFF
--- a/docs/nav.html
+++ b/docs/nav.html
@@ -31,5 +31,11 @@
 				</ul>
 				{{/ifPrefix}}
 			</li>
+			<li{{sectionHighlight pageName "privacy-policy"}}>
+				<a href="/v{{apiversion}}/docs/privacy-policy">Privacy Policy</a>
+			</li>
+			<li{{sectionHighlight pageName "terms"}}>
+				<a href="/v{{apiversion}}/docs/terms">Terms and Conditions</a>
+			</li>
 		</ul>
 	</div>

--- a/docs/privacy-policy.html
+++ b/docs/privacy-policy.html
@@ -1,0 +1,155 @@
+{{>header}} {{>nav this}}
+
+<div class="o-techdocs-main o-techdocs-content">
+
+	<h1>Privacy Policy</h1>
+	<p>
+		The Financial Times Limited (“<strong>FT</strong>”, “<strong>we</strong>”, “<strong>us</strong>”) is committed to safeguarding the privacy of our users.
+	</p>
+	<p>
+		We treat personal information in accordance with the following principles:
+	</p>
+	<ul>
+		<li>We will be transparent with users about the types of information we are collecting and what we are allowed to use it for.</li>
+		<li>We will not use the information we collect for other purposes without permission or notification (unless we have a lawful basis or are legally required to do so).</li>
+		<li>We will use appropriate technical and organisational measures to secure the information that we collect.</li>
+		<li>We will respect our users’ rights to privacy, including the right not to receive marketing from us.</li>
+	</ul>
+	<p>
+		This Privacy Policy applies to:
+	</p>
+	<ul>
+		<li>the Polyfill.io website (“<strong>Site</strong>”); and/or</li>
+		<li>the public instance of the Polyfill Service made available by us, as described on the Site (“<strong>Service</strong>”):</li>
+	</ul>
+	<p>
+		This Site and the Service are referred to together as “<strong>Polyfill.io</strong>”.
+	</p>
+	<p>
+		We collect and use information in different ways for the Site and the Service. This Privacy Policy sets out details of these different ways in which we collect and use information.
+	</p>
+
+
+	<h3 id="what-information-do-we-collect-from-the-service">What information do we collect from the Service?</h3>
+	<p>
+		The Service is a hosted instance of software known as Polyfill Service. Polyfill Service provides snippets of code, called “polyfills”, that allows websites operated by FT and by others to provide a consistent experience across different browsers. When you load a web page which uses Polyfill Service, your browser will download any polyfills required in order to present the web page successfully in your browser.
+	</p>
+	<p>
+		In order to provide the polyfills, the Service receives from your browser certain technical information including:
+	</p>
+	<ul>
+		<li>browser details;</li>
+		<li>connection details (such as your IP address which can identify your approximate location and/or name of your ISP);</li>
+		<li>the URL of the web page which has made the request to the Service.</li>
+	</ul>
+	<p>
+		We use that information to determine which polyfills are required by your browser. We then retain only the following information:
+	</p>
+	<ul>
+		<li>the domain of the web page which has made the request to the Service;</li>
+		<li>the user agent string for your browser;</li>
+		<li>the set of polyfills that were requested by the web page.</li>
+	</ul>
+	<p>
+		The information we retain cannot identify you. We retain it in order to identify which websites are using the Service and whether any websites are abusing the Service.
+	</p>
+	<p>
+		The website which uses the polyfills is not subject to this privacy policy. We are not responsible for third party websites’ content, use of personal information, or security practices.
+	</p>
+
+
+	<h3 id='what-information-do-we-collect-from-the-users-of-this-site'>What information do we collect from the users of this Site?</h3>
+	<p>
+		The information we collect about you if you are browsing this Site may include:
+	</p>
+	<ul>
+		<li>Details relating to your visit to the Site - such as browser details, time and date of access, usage statistics such as frequency and duration of use, connection details (such as your IP address which can identify your approximate location and/or name of your ISP), and the details of the site from which you have linked to us.</li>
+		<li>Details that assist us with improving Site usability, our ability to provide technical support, and aggregated statistical reporting - such as user movements, page scrolling, mouse clicks and text entered (but excluding financial information such as debit or credit card details).</li>
+	</ul>
+	<p>
+		Please see the <a href="https://help.ft.com/help/legal-privacy/cookies/">FT cookie policy</a> for more details.
+	</p>
+
+
+	<h3 id="why-do-we-collect-information-about-users-of-this-site">Why do we collect information about users of this Site?</h3>
+	<p>
+		We collect information about users of the Site for three main reasons:
+	</p>
+	<ul>
+		<li>to help monitor and improve the Site;</li>
+		<li>to monitor compliance with the <a href="/v2/docs/terms">Polyfill.io Terms and Conditions</a>; and</li>
+		<li>to provide information about the Site.</li>
+	</ul>
+	<p>
+		We also use information in aggregate form (so that no individual user is identified by name) for purposes that include:
+	</p>
+	<ul>
+		<li>helping strategic development;</li>
+		<li>auditing usage of the Site and demonstrating usage to third parties.</li>
+	</ul>
+
+
+	<h3 id="how-does-this-privacy-policy-apply-to-you">How does this privacy policy apply to you?</h3>
+	<p>
+		By using the Site you are accepting and consenting to the practices described in this policy. The Site may contain links to third party sites which are not subject to this privacy policy. We are not responsible for their content, use of personal information, or security practices.
+	</p>
+
+
+	<h3 id='who-we-share-your-information-with'>Who we share your information with</h3>
+	<p>
+		We may share your information with organisations that provide services on our behalf, such as those that host the Site or the Service, solely for the purposes of their providing those services to us.
+	</p>
+	<p>
+		We may also disclose your information to comply with applicable laws, court orders or other valid legal processes, and to enforce or apply the <a href="/v2/docs/terms">Polyfill.io Terms and Conditions</a> or any of our other rights.
+	</p>
+	<p>
+		Your information is an important asset of our businesses and, as such, we may transfer or disclose it to any successor (or potential successor) of any FT business, or any acquirer (or potential acquirer) of all or part of the assets of any FT business.
+	</p>
+
+
+	<h3 id='how-we-keep-your-information-secure'>How we keep your information secure</h3>
+	<p>
+		We have appropriate technical and administrative security measures in place to help ensure that individuals’ information is protected against unauthorised or accidental access, use, alteration, or loss.
+	</p>
+	<p>
+		Although we endeavour to create secure and reliable Services, we cannot guarantee the security of any information transmitted via the Internet.
+	</p>
+
+
+	<h3 id='information-about-children'>Information about children</h3>
+	<p>
+		Polyfill.io is not intended for children under 16 years of age. We do not intentionally collect any information from such children and we will delete any such details on request by the parent or guardian.
+	</p>
+
+
+	<h3 id='use-of-cookies'>Use of cookies</h3>
+	<p>
+		We use cookies and similar tools on the Site as described in the <a href="https://help.ft.com/help/legal-privacy/cookies/">FT cookie policy</a>.
+	</p>
+
+
+	<h3 id='how-to-amend-or-access-any-of-your-information'>How to amend or access any of your information</h3>
+	<p>
+		If you wish to amend any of the personal data that we hold about you, please contact <a href="mailto:privacy.officer@ft.com">privacy.officer@ft.com</a>.
+	</p>
+	<p>
+		You may request a copy of the personal information that relevant FT entities hold about you by contacting the Privacy Officer by email at <a href="mailto:privacy.officer@ft.com">privacy.officer@ft.com</a> or writing to: Company Secretary The Financial Times Ltd, Number One Southwark Bridge, London, SE1 9HL United Kingdom. We may charge the statutory allowable fee for provision of this information.
+	</p>
+
+
+	<h3 id='transfers-outside-the-european-economic-area-(eea)'>Transfers outside the European Economic Area (EEA)</h3>
+	<p>
+		Your information may be transferred to, and stored at, a destination outside the EEA. It may also be processed by staff operating outside the EEA who work for us or for one of our suppliers. By using the Site, you are deemed to consent to the transfer of your information to a location outside the EEA.
+	</p>
+
+
+	<h3 id='changes-to-this-privacy-policy'>Changes to this privacy policy</h3>
+	<p>
+		This policy is effective from 1 September 2017.
+	</p>
+	<p>
+		Any changes we may make to this privacy policy will be posted on this page. If changes are significant, we may choose to indicate clearly on the Polyfill.io home page that the policy has been updated. Your continued use of the Site after we make changes is deemed to be acceptance of those changes, so please check for any updates regularly.
+	</p>
+</div>
+
+{{>footer}}

--- a/docs/terms.html
+++ b/docs/terms.html
@@ -1,0 +1,132 @@
+{{>header}} {{>nav this}}
+
+<div class="o-techdocs-main o-techdocs-content">
+
+	<h1>Terms and Conditions</h1>
+
+	<h3 id="who-we-are-and-how-to-contact-us">Who we are and how to contact us</h3>
+	<p>
+		<a href="https://polyfill.io/">Polyfill.io</a> is operated as a community service by The Financial Times Limited (“we”, “us”). We are registered in England and Wales under company number 00227590 and have our registered office (and main trading address) at Number One Southwark Bridge, London, SE1 9HL. Our VAT number is GB226162332.
+	</p>
+
+
+	<h3 id='by-using-Polyfill.io-you-agree-to-our-terms'>By using Polyfill.io you agree to our terms</h3>
+	<p>
+		These terms apply to “<strong>Polyfill.io</strong>”, which means:
+	</p>
+	<ul>
+		<li>the Polyfill.io website (“<strong>Site</strong>”); and/or</li>
+		<li>the public instance of the Polyfill Service made available by us, as described on the Site.</li>
+	</ul>
+	<p>
+		By using Polyfill.io you confirm that you accept these terms of use and that you agree to comply with them. If you do not agree to these terms, you must not use Polyfill.io.
+	</p>
+	<p>
+		We recommend that you print or save a copy of these terms for future reference. <strong>Please note that these terms contain provisions which limit or exclude our liability to you, in particular as set out in the section headed “Our responsibility for loss or damage suffered by you”.</strong>
+	</p>
+
+
+	<h3 id="There-are-other-terms-that-may-apply-to-you">There are other terms that may apply to you</h3>
+	<p>
+		These terms of use refer to the following additional terms, which also apply to your use of Polyfill.io:
+	</p>
+	<ul>
+		<li>The <a href="/v2/docs/privacy-policy">Polyfill.io privacy policy</a>, which sets out the terms on which we process any personal data we collect from you or as a result of your use of Polyfill.io (including our logging of use of Polyfill.io). If you do not agree to the terms of that privacy policy then you must not use Polyfill.io, and you should consider hosting the <a href="https://github.com/Financial-Times/polyfill-service">Polyfill Service code</a> yourself.</li>
+		<li>The <a href="https://help.ft.com/help/legal-privacy/cookies/">FT cookie policy</a>, which sets out information about the cookies on the Site.</li>
+	</ul>
+
+
+	<h3 id="polyfill.io-are-provided-as-is-and-without-any-sla">Polyfill.io are provided as-is and without any SLA</h3>
+	<p>
+		Polyfill.io is made available free of charge.
+	</p>
+	<p>
+		We do not guarantee that Polyfill.io, or any content on them, will always be available or be uninterrupted. We may suspend or withdraw or restrict the availability of all or any part of Polyfill.io for business and operational reasons.
+	</p>
+	<p>
+		We do not provide any service level agreement or any other performance commitments for Polyfill.io. We are not able to participate in any technical due diligence or other procurement process that your organisation may have.
+	</p>
+	<p>
+		If you require an SLA or guaranteed levels of resilience for Polyfill.io, then you are free to obtain your own copy of the Polyfill Service code from our <a href="https://github.com/Financial-Times/polyfill-service">GitHub repository</a>. The Polyfill Service code is licensed under the MIT License. You can then make your own arrangements for hosting.
+	</p>
+
+
+	<h3 id='do-not-rely-on-information-on-this-site'>Do not rely on information on this site</h3>
+	<p>
+		The content on the Site is provided for general information only. It is not intended to amount to advice on which you should rely.
+	</p>
+	<p>
+		Although we make reasonable efforts to update the information on Polyfill.io, we make no representations, warranties or guarantees, whether express or implied, that the content on Polyfill.io is accurate, complete or up to date.
+	</p>
+
+
+	<h3 id='our-responsibility-for-loss-or-damage-suffered-by-you'>Our responsibility for loss or damage suffered by you</h3>
+	<p>
+		<strong>
+			We do not exclude or limit in any way our liability to you where it would be unlawful to do so. This includes liability for death or personal injury caused by our negligence or the negligence of our employees, agents or subcontractors and for fraud or fraudulent misrepresentation.
+		</strong>
+	</p>
+	<p>
+		<strong>
+			We exclude all implied conditions, warranties, representations or other terms that may apply to Polyfill.io or any content on them.
+		</strong>
+	</p>
+	<p>
+		<strong>
+			We will not be liable to you for any loss or damage, whether in contract, tort (including negligence), breach of statutory duty, or otherwise, even if foreseeable, arising under or in connection with:
+		</strong>
+	</p>
+	<ul>
+		<li><strong>use of, or inability to use, Polyfill.io; or</strong></li>
+		<li><strong>use of or reliance on any content displayed on Polyfill.io.</strong></li>
+	</ul>
+	<p>
+		<strong>
+			In particular, we will not be liable for:
+		</strong>
+	</p>
+	<ul>
+		<li><strong>loss of profits, sales, business, or revenue;</strong></li>
+		<li><strong>business interruption;</strong></li>
+		<li><strong>loss of anticipated savings;</strong></li>
+		<li><strong>loss of business opportunity, goodwill or reputation; or</strong></li>
+		<li><strong>any indirect or consequential loss or damage.</strong></li>
+	</ul>
+	<p>
+		<strong>
+			By using Polyfill.io, you agree that the above exclusions of liability are reasonable. You accept that it is always possible for you to host your own copy of the <a href="https://github.com/Financial-Times/polyfill-service">Polyfill Service code</a>, and that your use of Polyfill.io is therefore entirely at your own risk.
+		</strong>
+	</p>
+
+
+	<h3 id='we-are-not-responsible-for-viruses-and-you-must-not-introduce-them'>We are not responsible for viruses and you must not introduce them</h3>
+	<p>
+		We do not guarantee that Polyfill.io will be secure or free from bugs or viruses.
+	</p>
+	<p>
+		You are responsible for configuring your information technology, computer programs and platform to access Polyfill.io. You should use your own virus protection software.
+	</p>
+	<p>
+		You must not misuse Polyfill.io by knowingly introducing viruses, trojans, worms, logic bombs or other material that is malicious or technologically harmful. You must not attempt to gain unauthorised access to Polyfill.io, the server on which Polyfill.io are stored or any server, computer or database connected to Polyfill.io. You must not attack Polyfill.io via a denial-of-service attack or a distributed denial-of service attack. By breaching this provision, you would commit a criminal offence under the Computer Misuse Act 1990. We will report any such breach to the relevant law enforcement authorities and we will co-operate with those authorities by disclosing your identity to them. In the event of such a breach, your right to use Polyfill.io will cease immediately.
+	</p>
+
+
+	<h3 id='we-may-make-changes-to-these-terms'>We may make changes to these terms</h3>
+	<p>
+		We amend these terms from time to time. You should check these terms regularly to ensure you understand the terms that apply at that time.
+	</p>
+
+
+	<h3 id='we-may-make-changes-to-polyfill.io'>We may make changes to Polyfill.io</h3>
+	<p>
+		We may update and change Polyfill.io from time to time. We will aim to post details of the most significant changes on the Site.
+	</p>
+
+
+	<h3 id='which-countrys-laws-apply-to-any-dispute'>Which country’s laws apply to any dispute?</h3>
+	<p>
+		These terms of use, their subject matter and their formation (and any non-contractual disputes or claims) are governed by English law. You and we both agree to the exclusive jurisdiction of the courts of England and Wales.
+	</p>
+</div>
+
+{{>footer}}


### PR DESCRIPTION
The [privacy policy](https://polyfill.io/v2/docs/privacy-policy) outlines what data we collect about requests to https://polyfill.io and what we do with that data. 

The [terms of service](https://polyfill.io/v2/docs/terms) document describes what you can expect from us when you use https://polyfill.io on your site, and the actions you as a user might take that would cause us to revoke your access to https://polyfill.io.