### PR TITLE
fix(UA): add alias for modern yandex

### DIFF
--- a/lib/UA.js
+++ b/lib/UA.js
@@ -106,7 +106,8 @@ const aliases = {
 		"14.4": ["chrome", 33],
 		"14.2": ["chrome", 32],
 		"13.12": ["chrome", 30],
-		"13.10": ["chrome", 28]
+		"13.10": ["chrome", 28],
+		"17.9": ["chrome", 60]
 	},
 
 	"opera": {


### PR DESCRIPTION
The user agent for Yandex (most recent version) is `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.113 YaBrowser/17.9.1.888 Yowser/2.5 Safari/537.36`, which seems to be recognised as "unknown" for now. This causes it to fail when unknown=polyfill

>  * UA detected: other/0.0.0 (unknown/unsupported; using policy `unknown=polyfill`)

see also https://github.com/yarnpkg/website/issues/674#issuecomment-335529923