### PR TITLE
update js-polyfill to get opera mini url fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3077,9 +3077,9 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "js-polyfills": {
-      "version": "0.1.33",
-      "resolved": "https://registry.npmjs.org/js-polyfills/-/js-polyfills-0.1.33.tgz",
-      "integrity": "sha1-XjmsHTTvHfSWQjMpviJ2EuY8O2s="
+      "version": "0.1.40",
+      "resolved": "https://registry.npmjs.org/js-polyfills/-/js-polyfills-0.1.40.tgz",
+      "integrity": "sha1-DyQD+eyW0ub2ppAGswJKgh+z+xQ="
     },
     "js-tokens": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "iltorb": "^2.0.1",
     "intersection-observer": "^0.4.1",
     "intl": "^1.2.5",
-    "js-polyfills": "^0.1.33",
+    "js-polyfills": "^0.1.40",
     "json3": "^3.3.2",
     "lazystream": "^1.0.0",
     "lodash": "^4.17.4",


### PR DESCRIPTION
Fixes bad implementation spotted in #1349 

<img width="719" alt="" src="https://user-images.githubusercontent.com/1569131/32199667-86bfc424-bdc5-11e7-9223-3acb629aefd8.png">
