### PR TITLE
Custom Elements polyfill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ npm-debug.log
 /polyfills/Array/of/polyfill.js
 /polyfills/atob/polyfill.js
 /polyfills/AudioContext/polyfill.js
+/polyfills/customElements/polyfill.js
 /polyfills/EventSource/polyfill.js
 /polyfills/HTMLPictureElement/polyfill.js
 /polyfills/Intl/polyfill.js

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ npm-debug.log
 /polyfills/atob/polyfill.js
 /polyfills/AudioContext/polyfill.js
 /polyfills/customElements/polyfill.js
+/polyfills/customElements/~native-shim/polyfill.js
 /polyfills/EventSource/polyfill.js
 /polyfills/HTMLPictureElement/polyfill.js
 /polyfills/Intl/polyfill.js

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "node": "6.11.1 - 8"
   },
   "dependencies": {
-    "@webcomponents/custom-elements": "github:webcomponents/custom-elements#v1.0.0-alpha.4",
+    "@webcomponents/custom-elements": "github:webcomponents/custom-elements#v1.0.0-rc.1",
     "Base64": "^1.0.0",
     "accepts": "^1.3.4",
     "array.of": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "node": "6.11.1 - 8"
   },
   "dependencies": {
-    "@webcomponents/custom-elements": "^1.0.0-alpha.3",
+    "@webcomponents/custom-elements": "github:webcomponents/custom-elements#v1.0.0-alpha.4",
     "Base64": "^1.0.0",
     "accepts": "^1.3.4",
     "array.of": "^0.1.1",
@@ -122,6 +122,7 @@
     "zlib": "^1.0.5"
   },
   "devDependencies": {
+    "babili": "0.0.11",
     "browserstack-local": "^1.3.0",
     "eslint": "^4.9.0",
     "fastly": "Financial-Times/fastly#v2.6.0",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "node": "6.11.1 - 8"
   },
   "dependencies": {
+    "@webcomponents/custom-elements": "^1.0.0-alpha.3",
     "Base64": "^1.0.0",
     "accepts": "^1.3.4",
     "array.of": "^0.1.1",

--- a/polyfills/customElements/config.json
+++ b/polyfills/customElements/config.json
@@ -14,15 +14,16 @@
 	"dependencies": [
 		"Promise"
 	],
-	"spec": "https://html.spec.whatwg.org/multipage/scripting.html#custom-elements",
-	"docs": "https://developer.mozilla.org/en-US/docs/Web/Web_Components/Custom_Elements",
 	"install": {
 		"module": "@webcomponents/custom-elements",
 		"paths": ["custom-elements.min.js"]
 	},
 	"license": "BSD-3-Clause",
+	"docs": "https://developer.mozilla.org/en-US/docs/Web/Web_Components/Custom_Elements",
 	"repo": "https://github.com/webcomponents/custom-elements",
+	"spec": "https://html.spec.whatwg.org/multipage/scripting.html#custom-elements",
 	"notes": [
-		"The [known bugs and limitations](https://github.com/webcomponents/custom-elements#known-bugs-and-limitations) of the polyfill should be reviewed before using it."
+		"The [known bugs and limitations](https://github.com/webcomponents/custom-elements#known-bugs-and-limitations) of the polyfill should be reviewed before using it.",
+		"Note that by default, `customElements` requires that elements are defined using native ES6 classes; ES5-style classes, or transpilied classes, will not work. If support for ES5 classes is required, `customElements.~native-shim` should be used instead."
 	]
 }

--- a/polyfills/customElements/config.json
+++ b/polyfills/customElements/config.json
@@ -1,0 +1,26 @@
+{
+	"browsers": {
+		"android": "*",
+		"chrome": "<54",
+		"firefox": "*",
+		"firefox_mob": "*",
+		"ie": "*",
+		"ie_mob": "*",
+		"ios_saf": "*",
+		"opera": "<43",
+		"safari": "<10.1",
+		"samsung_mob": "*"
+	},
+	"spec": "https://html.spec.whatwg.org/multipage/scripting.html#custom-elements",
+	"docs": "https://developer.mozilla.org/en-US/docs/Web/Web_Components/Custom_Elements",
+	"install": {
+		"module": "@webcomponents/custom-elements",
+		"paths": ["custom-elements.min.js"]
+	},
+	"license": "BSD-3-Clause",
+	"repo": "https://github.com/webcomponents/custom-elements",
+	"notes": [
+		"Make sure that you review the [known bugs and limitations](https://github.com/webcomponents/custom-elements#known-bugs-and-limitations) of the polyfill before using it.",
+		"Also, if you're using ES2015 modules that are transpiled to ES5, make sure to include the native shim mention in the polyfill's README."
+	]
+}

--- a/polyfills/customElements/config.json
+++ b/polyfills/customElements/config.json
@@ -11,6 +11,9 @@
 		"safari": "<10.1",
 		"samsung_mob": "*"
 	},
+	"dependencies": [
+		"Promise"
+	],
 	"spec": "https://html.spec.whatwg.org/multipage/scripting.html#custom-elements",
 	"docs": "https://developer.mozilla.org/en-US/docs/Web/Web_Components/Custom_Elements",
 	"install": {

--- a/polyfills/customElements/config.json
+++ b/polyfills/customElements/config.json
@@ -23,7 +23,6 @@
 	"license": "BSD-3-Clause",
 	"repo": "https://github.com/webcomponents/custom-elements",
 	"notes": [
-		"The [known bugs and limitations](https://github.com/webcomponents/custom-elements#known-bugs-and-limitations) of the polyfill should be reviewed before using it.",
-		"When using ES2015 classes that are transpiled to ES5, the native shim mentioned in the [polyfill's README](https://github.com/webcomponents/custom-elements#es5-vs-es2015) must also be included, to provide compatibility with native implementations of `customElements.define`."
+		"The [known bugs and limitations](https://github.com/webcomponents/custom-elements#known-bugs-and-limitations) of the polyfill should be reviewed before using it."
 	]
 }

--- a/polyfills/customElements/config.json
+++ b/polyfills/customElements/config.json
@@ -24,6 +24,6 @@
 	"spec": "https://html.spec.whatwg.org/multipage/scripting.html#custom-elements",
 	"notes": [
 		"The [known bugs and limitations](https://github.com/webcomponents/custom-elements#known-bugs-and-limitations) of the polyfill should be reviewed before using it.",
-		"Note that by default, `customElements` requires that elements are defined using native ES6 classes; ES5-style classes, or transpilied classes, will not work. If support for ES5 classes is required, `customElements.~native-shim` should be used instead."
+		"Note that native implementations of `customElements` requires that elements are defined using native ES6 classes; ES5-style classes, or transpilied classes, will not work. If support for ES5 classes is required, request `customElements.~native-shim` feature as well."
 	]
 }

--- a/polyfills/customElements/config.json
+++ b/polyfills/customElements/config.json
@@ -4,11 +4,11 @@
 		"chrome": "<54",
 		"firefox": "*",
 		"firefox_mob": "*",
-		"ie": "*",
+		"ie": ">10",
 		"ie_mob": "*",
-		"ios_saf": "<10.1",
+		"ios_saf": "<10.1 >=9",
 		"opera": "<41",
-		"safari": "<10.1",
+		"safari": "<10.1 >=9",
 		"samsung_mob": "*"
 	},
 	"dependencies": [

--- a/polyfills/customElements/config.json
+++ b/polyfills/customElements/config.json
@@ -6,8 +6,8 @@
 		"firefox_mob": "*",
 		"ie": "*",
 		"ie_mob": "*",
-		"ios_saf": "*",
-		"opera": "<43",
+		"ios_saf": "<10.1",
+		"opera": "<41",
 		"safari": "<10.1",
 		"samsung_mob": "*"
 	},

--- a/polyfills/customElements/config.json
+++ b/polyfills/customElements/config.json
@@ -20,7 +20,7 @@
 	"license": "BSD-3-Clause",
 	"repo": "https://github.com/webcomponents/custom-elements",
 	"notes": [
-		"Make sure that you review the [known bugs and limitations](https://github.com/webcomponents/custom-elements#known-bugs-and-limitations) of the polyfill before using it.",
-		"Also, if you're using ES2015 modules that are transpiled to ES5, make sure to include the native shim mention in the polyfill's README."
+		"The [known bugs and limitations](https://github.com/webcomponents/custom-elements#known-bugs-and-limitations) of the polyfill should be reviewed before using it.",
+		"When using ES2015 classes that are transpiled to ES5, the native shim mentioned in the [polyfill's README](https://github.com/webcomponents/custom-elements#es5-vs-es2015) must also be included, to provide compatibility with native implementations of `customElements.define`."
 	]
 }

--- a/polyfills/customElements/detect.js
+++ b/polyfills/customElements/detect.js
@@ -1,3 +1,1 @@
-(function() {
-	return window.customElements;
-}())
+'customElements' in this

--- a/polyfills/customElements/detect.js
+++ b/polyfills/customElements/detect.js
@@ -1,0 +1,3 @@
+(function() {
+	return window.customElements;
+}())

--- a/polyfills/customElements/tests.js
+++ b/polyfills/customElements/tests.js
@@ -1,74 +1,41 @@
 /* eslint-env mocha, browser */
 /* global proclaim */
 
-/**
- * Resolve on the next "tick", so that the custom elements can be initialized
- * before the assertions happen
- *
- * This is not necssary when the polyfill is not active, but is necessary with the polyfill
- *
- * @return {Promise} resolves after the current event loop finishes
- */
-function pause() {
-	return new Promise(function(resolve) {
-		setTimeout(resolve, 0);
-	});
-}
+describe('customElements', function() {
+	var XFoo;
 
-describe('defining custom elements', function() {
 	before(function() {
-		customElements.define('x-foo', class extends HTMLElement {
-			static get is() {
-				return 'x-foo';
-			}
-		});
+		XFoo = function XFoo() {
+			return HTMLElement.apply(this, arguments);
+		};
+
+		XFoo.__proto__ = HTMLElement;
+		XFoo.prototype = Object.create(HTMLElement.prototype);
+		XFoo.prototype.constructor = XFoo;
+
+		customElements.define('x-foo', XFoo);
 	});
 
 	it('can define a new custom element', function() {
-		const el = document.createElement('x-foo');
+		var el = document.createElement('x-foo');
 		proclaim.isInstanceOf(el, HTMLElement);
-		proclaim.equal(el.tagName, 'X-FOO');
+		proclaim.isInstanceOf(el, XFoo);
 	});
-});
-
-describe('using custom elements', function() {
-	before(function() {
-		customElements.define('x-foo-b', class extends HTMLElement {
-			constructor() {
-				super();
-
-				const shadow = this.attachShadow({mode: 'open'});
-				shadow.innerHTML = `
-					Hello, world!
-					<slot></slot>
-				`;
-			}
-		});
-	});
-
+	
 	it('can insert a custom element into the DOM', function() {
-		const p = document.createElement('p');
-		p.innerHTML = `
-			<x-foo-b></x-foo-b>
-		`;
+		var p = document.createElement('p');
+		var xFooInstance;
 
-		return pause().then(function() {
-			proclaim.equal(p.textContent.trim(), '');
-			proclaim.equal(p.querySelector('x-foo-b').shadowRoot.textContent.trim(), 'Hello, world!');
-		});
+		p.innerHTML = '<x-foo></x-foo>';
+
+		xFooInstance = p.querySelector('x-foo');
+		proclaim.isInstanceOf(xFooInstance, XFoo);
 	});
 
-	it('can slot content into a custom element', function() {
-		const p = document.createElement('p');
-		p.innerHTML = `
-			<x-foo-b>
-				Some inner text
-			</x-foo-b>
-		`;
-
-		return pause().then(function() {
-			proclaim.equal(p.textContent.trim(), 'Some inner text');
-			proclaim.equal(p.querySelector('x-foo-b').shadowRoot.textContent.trim(), 'Hello, world!');
-		});
+	it('can create a custom element from constructor', function() {
+		var xFooInstance = new XFoo();
+		proclaim.isInstanceOf(xFooInstance, HTMLElement);
+		proclaim.isInstanceOf(xFooInstance, XFoo);
 	});
+	
 });

--- a/polyfills/customElements/tests.js
+++ b/polyfills/customElements/tests.js
@@ -1,0 +1,17 @@
+/* eslint-env mocha, browser */
+/* global proclaim, it */
+
+// Test borrowed from:
+// https://github.com/webcomponents/custom-elements/blob/1b2ad174411aab7cccb8231214399bb033dd5d49/tests/html/shim.html#L27
+it('can create a custom HTML tag', function() {
+	customElements.define('x-foo', class extends HTMLElement {
+		static get is() {
+			return 'x-foo';
+		}
+	});
+
+	const el = document.createElement('x-foo');
+	proclaim.isInstanceOf(el, HTMLElement);
+	proclaim.equal(el.tagName, 'X-FOO');
+});
+

--- a/polyfills/customElements/tests.js
+++ b/polyfills/customElements/tests.js
@@ -1,17 +1,74 @@
 /* eslint-env mocha, browser */
-/* global proclaim, it */
+/* global proclaim */
 
-// Test borrowed from:
-// https://github.com/webcomponents/custom-elements/blob/1b2ad174411aab7cccb8231214399bb033dd5d49/tests/html/shim.html#L27
-it('can create a custom HTML tag', function() {
-	customElements.define('x-foo', class extends HTMLElement {
-		static get is() {
-			return 'x-foo';
-		}
+/**
+ * Resolve on the next "tick", so that the custom elements can be initialized
+ * before the assertions happen
+ *
+ * This is not necssary when the polyfill is not active, but is necessary with the polyfill
+ *
+ * @return {Promise} resolves after the current event loop finishes
+ */
+function pause() {
+	return new Promise(function(resolve) {
+		setTimeout(resolve, 0);
+	});
+}
+
+describe('defining custom elements', function() {
+	before(function() {
+		customElements.define('x-foo', class extends HTMLElement {
+			static get is() {
+				return 'x-foo';
+			}
+		});
 	});
 
-	const el = document.createElement('x-foo');
-	proclaim.isInstanceOf(el, HTMLElement);
-	proclaim.equal(el.tagName, 'X-FOO');
+	it('can define a new custom element', function() {
+		const el = document.createElement('x-foo');
+		proclaim.isInstanceOf(el, HTMLElement);
+		proclaim.equal(el.tagName, 'X-FOO');
+	});
 });
 
+describe('using custom elements', function() {
+	before(function() {
+		customElements.define('x-foo-b', class extends HTMLElement {
+			constructor() {
+				super();
+
+				const shadow = this.attachShadow({mode: 'open'});
+				shadow.innerHTML = `
+					Hello, world!
+					<slot></slot>
+				`;
+			}
+		});
+	});
+
+	it('can insert a custom element into the DOM', function() {
+		const p = document.createElement('p');
+		p.innerHTML = `
+			<x-foo-b></x-foo-b>
+		`;
+
+		return pause().then(function() {
+			proclaim.equal(p.textContent.trim(), '');
+			proclaim.equal(p.querySelector('x-foo-b').shadowRoot.textContent.trim(), 'Hello, world!');
+		});
+	});
+
+	it('can slot content into a custom element', function() {
+		const p = document.createElement('p');
+		p.innerHTML = `
+			<x-foo-b>
+				Some inner text
+			</x-foo-b>
+		`;
+
+		return pause().then(function() {
+			proclaim.equal(p.textContent.trim(), 'Some inner text');
+			proclaim.equal(p.querySelector('x-foo-b').shadowRoot.textContent.trim(), 'Hello, world!');
+		});
+	});
+});

--- a/polyfills/customElements/~native-shim/config.json
+++ b/polyfills/customElements/~native-shim/config.json
@@ -1,0 +1,32 @@
+{
+	"browsers": {
+		"android": "*",
+		"chrome": "*",
+		"firefox": "*",
+		"firefox_mob": "*",
+		"ie": "*",
+		"ie_mob": "*",
+		"ios_saf": "*",
+		"opera": "*",
+		"safari": "*",
+		"samsung_mob": "*"
+	},
+	"dependencies": [
+		"Map",
+		"customElements"
+	],
+	"docs": "https://developer.mozilla.org/en-US/docs/Web/Web_Components/Custom_Elements",
+	"build": {
+		"minify": false
+	},
+	"install": {
+		"module": "@webcomponents/custom-elements",
+		"paths": ["src/native-shim.js"],
+		"postinstall": "update.task.js"
+	},
+	"license": "BSD-3-Clause",
+	"repo": "https://github.com/webcomponents/custom-elements#es5-vs-es2015",
+	"notes": [
+		"The native shim is required when using `customElements.define` with an ES5-style class. It is included by default with the `customElements` polyfill since most users won't be sending ES6 classes to the browser."
+	]
+}

--- a/polyfills/customElements/~native-shim/config.json
+++ b/polyfills/customElements/~native-shim/config.json
@@ -1,7 +1,8 @@
 {
 	"browsers": {
 		"chrome": ">=54",
-		"opera": ">=43",
+		"opera": ">=41",
+		"ios_saf": ">=10.1",
 		"safari": ">=10.1"
 	},
 	"dependencies": [

--- a/polyfills/customElements/~native-shim/config.json
+++ b/polyfills/customElements/~native-shim/config.json
@@ -15,7 +15,6 @@
 		"Map",
 		"customElements"
 	],
-	"docs": "https://developer.mozilla.org/en-US/docs/Web/Web_Components/Custom_Elements",
 	"build": {
 		"minify": false
 	},
@@ -25,8 +24,10 @@
 		"postinstall": "update.task.js"
 	},
 	"license": "BSD-3-Clause",
-	"repo": "https://github.com/webcomponents/custom-elements#es5-vs-es2015",
+	"docs": "https://github.com/webcomponents/custom-elements#es5-vs-es2015",
+	"repo": "https://github.com/webcomponents/custom-elements",
+	"spec": "https://html.spec.whatwg.org/multipage/scripting.html#custom-elements",
 	"notes": [
-		"The native shim is required when using `customElements.define` with an ES5-style class. It is included by default with the `customElements` polyfill since most users won't be sending ES6 classes to the browser."
+		"The native shim is required when using `customElements.define` with an ES5-style class. If classes are defined directly in ES6 and not transpiled, `customElements` must be used _without_ the `native-shim`."
 	]
 }

--- a/polyfills/customElements/~native-shim/config.json
+++ b/polyfills/customElements/~native-shim/config.json
@@ -1,15 +1,8 @@
 {
 	"browsers": {
-		"android": "*",
-		"chrome": "*",
-		"firefox": "*",
-		"firefox_mob": "*",
-		"ie": "*",
-		"ie_mob": "*",
-		"ios_saf": "*",
-		"opera": "*",
-		"safari": "*",
-		"samsung_mob": "*"
+		"chrome": ">=54",
+		"opera": ">=43",
+		"safari": ">=10.1"
 	},
 	"dependencies": [
 		"Map",

--- a/polyfills/customElements/~native-shim/tests.js
+++ b/polyfills/customElements/~native-shim/tests.js
@@ -1,0 +1,47 @@
+/* eslint-env mocha, browser */
+/* global proclaim */
+
+// Tests borrowed from the shim's own tests
+// https://github.com/webcomponents/custom-elements/blob/master/tests/html/shim.html
+describe('creating a webcomponent with an ES5 class', function() {
+	it('works with createElement()', function() {
+		function ES5Element1() {
+			return HTMLElement.apply(this);
+		}
+		ES5Element1.prototype = Object.create(HTMLElement.prototype);
+		ES5Element1.prototype.constructor = ES5Element1;
+		customElements.define('es5-element-1', ES5Element1);
+		const el = document.createElement('es5-element-1');
+		proclaim.isInstanceOf(el, ES5Element1);
+		proclaim.isInstanceOf(el, HTMLElement);
+		proclaim.equal(el.tagName, 'ES5-ELEMENT-1');
+	});
+
+	it('works with user-called constructors', function() {
+		function ES5Element2() {
+			return HTMLElement.apply(this);
+		}
+		ES5Element2.prototype = Object.create(HTMLElement.prototype);
+		ES5Element2.prototype.constructor = ES5Element2;
+		customElements.define('es5-element-2', ES5Element2);
+		const el = new ES5Element2();
+		proclaim.isInstanceOf(el, ES5Element2);
+		proclaim.isInstanceOf(el, HTMLElement);
+		proclaim.equal(el.tagName, 'ES5-ELEMENT-2');
+	});
+
+	it('works with parser created elements', function() {
+		function ES5Element3() {
+			return HTMLElement.apply(this);
+		}
+		ES5Element3.prototype = Object.create(HTMLElement.prototype);
+		ES5Element3.prototype.constructor = ES5Element3;
+		customElements.define('es5-element-3', ES5Element3);
+		const container = document.createElement('div');
+		container.innerHTML = '<es5-element-3></es5-element-3>';
+		const el = container.querySelector('es5-element-3');
+		proclaim.isInstanceOf(el, ES5Element3);
+		proclaim.isInstanceOf(el, HTMLElement);
+		proclaim.equal(el.tagName, 'ES5-ELEMENT-3');
+	});
+});

--- a/polyfills/customElements/~native-shim/update.task.js
+++ b/polyfills/customElements/~native-shim/update.task.js
@@ -1,0 +1,22 @@
+/* eslint-env node */
+
+// Minify the file with Babili, since we do not want to transpile from
+// ES6 -> ES5 since Uglify can't handle that yet
+
+const { join } = require('path');
+const { readFileSync, writeFileSync } = require('fs');
+
+const babel = require('babel-core');
+
+const polyfillPath = join(__dirname, 'polyfill.js');
+
+const sourceFile = readFileSync(polyfillPath);
+const transpiled = babel.transform(sourceFile, {
+	presets: ['babili']
+});
+
+// Only evaluate the code if it can handle ES6 and the polyfill hasn't been loaded
+// If `CustomElementRegistry` is defined, then the browser has native element support
+const outputCode = `window.customElements && CustomElementRegistry && eval("${transpiled.code}");`;
+
+writeFileSync(polyfillPath, outputCode);


### PR DESCRIPTION
This builds off @alexflorisca PR #1101 to support `customElements`. As per the discussion over there, it adds in two new features, `customElements` and `customElements.~native-shim`.

The `customElements` polyfill will be loaded in browsers that don't support Custom Elements, and the `native-shim` will be loaded only on browsers that _do_ Custom Elements, as it's used to allow ES5 classes with the native Custom Element Registry. So if you're using ES5 code and want to work on all browsers, you'd request `features=customElements,customElements.~native-shim`

Differences from #1101:

- I've updated the browser support in `native-shim` to be only the browsers that support CEs natively
- I've updated the browser support in `customElements` to Opera 41 (as per this [ChromeStatus](https://www.chromestatus.com/feature/4696261944934400) page) and iOS Mobile Safari 10.1
- Re-written the tests for `customElements` so that the tests passed on IE, and removed tests that included Shadow DOM

Few questions:

- The [official support](https://github.com/webcomponents/webcomponentsjs#browser-support) for the CE polyfill is IE11+, Safari 9+ and all evergreens. Given that, should we update the browser config to target only explicitly supported browsers? It does note that support for older browsers may be possible with older polyfills (`MutationObserver`, `Map`, `Set` etc.) though it doesn't specify exactly which polyfills / how to make it work, so it would be difficult to guarantee. 
- To get the `customElements` tests working on IE11, I had to rewrite them using ES5 Functions instead of ES6 classes. Is it an issue that it doesn't test ES6 classes anymore?
- The `customElements` polyfill has feature detection inbuilt, which can be overridden, is it worth overriding this in a `postinstall` task, in case the user has used an `always` flag?

Let me know if there's anything else needed! :)

