### PR TITLE
updates HTMLPictureElement config

### DIFF
--- a/polyfills/HTMLPictureElement/config.json
+++ b/polyfills/HTMLPictureElement/config.json
@@ -1,12 +1,12 @@
 {
 	"browsers": {
-		"ie": "7 - *",
+		"ie": "7 - 12",
 		"ie_mob": "10 - *",
 		"firefox": "4 - 37",
 		"opera": "11.6 - 29",
-		"safari": "6 - *",
+		"safari": "6 - 9",
 		"chrome": "* - 38",
-		"ios_saf": "*",
+		"ios_saf": "* - 9.2",
 		"firefox_mob": "4 - 37",
 		"bb": "7 - 10",
 		"android": "<52"


### PR DESCRIPTION
ie 13, safari 9.1 and ios_saf 9.3 have shipped support for the `Picture` Element. This updates the polyfill config accordingly.

according to http://caniuse.com/#search=srcset there is a bug in Edge 13/14/15 that shows distorted images if `srcset` (that is also covered by this polyfill afaik) is used. Probably the polyfill cannot help in this case, so I guess it does no harm to not deliver it to Edge 13/14/15.