### PR TITLE
Do not set XMLHttpRequest.responseType in navigator.sendBeacon

### DIFF
--- a/polyfills/navigator/sendBeacon/polyfill.js
+++ b/polyfills/navigator/sendBeacon/polyfill.js
@@ -5,7 +5,6 @@ this.navigator.sendBeacon = function sendBeacon(url, data) {
 	xhr.setRequestHeader('Accept', '*/*');
 	if (typeof data === 'string') {
 		xhr.setRequestHeader('Content-Type', 'text/plain;charset=UTF-8');
-		xhr.responseType = 'text/plain';
 	} else if (Object.prototype.toString.call(data) === '[object Blob]') {
 		if (data.type) {
 			xhr.setRequestHeader('Content-Type', data.type);


### PR DESCRIPTION
Setting the `responseType` property to `'text/plain'` causes an `InvalidAccessError` in (at least) some versions of MS Edge. According to [the MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/responseType), setting `responseType` on a syncronous request isn't permitted.

(`text/plain` doesn't appear to be a valid value for `responseType`, and `text` is the default anyway, so this change shouldn't affect anything).