### PR TITLE
`Event.focusin` is supported in Firefox and Firefox Mobile since Version 52

### DIFF
--- a/docs/assets/compat.json
+++ b/docs/assets/compat.json
@@ -1305,12 +1305,12 @@
       "58": "native"
     },
     "firefox": {
-      "30": "native",
-      "33": "native",
-      "41": "native",
-      "42": "native",
-      "44": "native",
-      "49": "native",
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "polyfilled",
+      "42": "polyfilled",
+      "44": "polyfilled",
+      "49": "polyfilled",
       "53": "native"
     },
     "ie": {

--- a/polyfills/Event/focusin/config.json
+++ b/polyfills/Event/focusin/config.json
@@ -7,8 +7,8 @@
 		"default"
 	],
 	"browsers": {
-		"firefox": "6 - *",
-		"firefox_mob": "6 - *"
+		"firefox": "<52",
+		"firefox_mob": "<52"
 	},
 	"dependencies": [
 		"Event"


### PR DESCRIPTION
Fixes https://github.com/Financial-Times/polyfill-service/issues/1379

See
https://developer.mozilla.org/en-US/docs/Web/Events/focusin
https://developer.mozilla.org/en-US/docs/Web/Events/focusout

I agree to the Contribution terms.