### PR TITLE
Add `iterable` support for `Map` and `Set` iterators.

### DIFF
--- a/polyfills/Map/polyfill.js
+++ b/polyfills/Map/polyfill.js
@@ -121,12 +121,20 @@
 		this.size = this._size = 0;
 	};
 	Map.prototype['values'] = function() {
-		return makeIterator(this, function(i) { return this._values[i]; });
+		var iterator = makeIterator(this, function(i) { return this._values[i]; });
+		iterator[Symbol.iterator] = this.values;
+		return iterator;
 	};
 	Map.prototype['keys'] = function() {
-		return makeIterator(this, function(i) { return decodeKey(this._keys[i]); });
+		var iterator = makeIterator(this, function(i) { return decodeKey(this._keys[i]); });
+		iterator[Symbol.iterator] = this.keys;
+		return iterator;
 	};
-	Map.prototype['entries'] =
+	Map.prototype['entries'] = function() {
+		var iterator = makeIterator(this, function(i) { return [decodeKey(this._keys[i]), this._values[i]]; });
+		iterator[Symbol.iterator] = this.entries;
+		return iterator;
+	};
 	Map.prototype[Symbol.iterator] = function() {
 		return makeIterator(this, function(i) { return [decodeKey(this._keys[i]), this._values[i]]; });
 	};

--- a/polyfills/Map/tests.js
+++ b/polyfills/Map/tests.js
@@ -157,6 +157,13 @@ it("exhibits correct iterator behaviour", function () {
 	proclaim.equal(lastResult.value, void 0);
 });
 
+it("implements iterable for all iterators", function () {
+	proclaim.isDefined(o.values()[Symbol.iterator]);
+	proclaim.isDefined(o.keys()[Symbol.iterator]);
+	proclaim.isDefined(o[Symbol.iterator]);
+	proclaim.isDefined(o.entries()[Symbol.iterator]);
+});
+
 it("implements .forEach()", function () {
 	var o = new Map();
 	o.set("key 0", 0);

--- a/polyfills/Set/polyfill.js
+++ b/polyfills/Set/polyfill.js
@@ -73,12 +73,18 @@
 		this.size = this._size = 0;
 	};
 	Set.prototype['values'] =
-	Set.prototype['keys'] =
+	Set.prototype['keys'] = function() {
+		var iterator = makeIterator(this, function(i) { return decodeVal(this._values[i]); });
+		iterator[Symbol.iterator] = this.keys;
+		return iterator;
+	};
 	Set.prototype[Symbol.iterator] = function() {
 		return makeIterator(this, function(i) { return decodeVal(this._values[i]); });
 	};
 	Set.prototype['entries'] = function() {
-		return makeIterator(this, function(i) { return [decodeVal(this._values[i]), decodeVal(this._values[i])]; });
+		var iterator = makeIterator(this, function(i) { return [decodeVal(this._values[i]), decodeVal(this._values[i])]; });
+		iterator[Symbol.iterator] = this.entries;
+		return iterator;
 	};
 	Set.prototype['forEach'] = function(callbackFn, thisArg) {
 		thisArg = thisArg || global;

--- a/polyfills/Set/tests.js
+++ b/polyfills/Set/tests.js
@@ -106,8 +106,11 @@ it("exhibits correct iterator behaviour", function () {
 	proclaim.equal(lastResult.value, void 0);
 });
 
-it("implements @@iterator() as an alias for .values()", function () {
-	proclaim.equal(o.values, o[Symbol.iterator]);
+it("implements iterable for all iterators", function () {
+	proclaim.isDefined(o.values()[Symbol.iterator]);
+	proclaim.isDefined(o.keys()[Symbol.iterator]);
+	proclaim.isDefined(o[Symbol.iterator]);
+	proclaim.isDefined(o.entries()[Symbol.iterator]);
 });
 
 it("implements .forEach()", function () {


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols

In IE11 `new Map().values()[Symbol.iterator]` is `undefined` without this patch. This means you can't use Map values in `for…of` loops.