### PR TITLE
Update engines to node 9

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "license": "CC0-1.0",
   "engines": {
-    "node": "6.11.1 - 8"
+    "node": "6.11.1 - 9"
   },
   "dependencies": {
     "Base64": "^1.0.0",


### PR DESCRIPTION
Node 9 is out since 10/31 and is working fine for me, but the package restriction breaks builds. (I have to force npm to `--ignore-engines`). 