### PR TITLE
Update for Samsung Internet 6.2

### DIFF
--- a/polyfills/Array/prototype/find/config.json
+++ b/polyfills/Array/prototype/find/config.json
@@ -16,7 +16,7 @@
 		"ios_chr": "* - 8.0",
 		"android": "*",
 		"firefox_mob": "3.6 - 24",
-		"samsung_mob": "*"
+		"samsung_mob": "<6"
 	},
 	"dependencies": [
 		"Object.defineProperty"

--- a/polyfills/DocumentFragment/prototype/append/config.json
+++ b/polyfills/DocumentFragment/prototype/append/config.json
@@ -18,7 +18,7 @@
 		"op_mini": "*",
 		"safari": "<10",
 		"firefox_mob": "<49",
-		"samsung_mob": "*"
+		"samsung_mob": "<6"
 	},
 	"dependencies": [
 		"Document",

--- a/polyfills/DocumentFragment/prototype/prepend/config.json
+++ b/polyfills/DocumentFragment/prototype/prepend/config.json
@@ -18,7 +18,7 @@
 		"op_mini": "*",
 		"safari": "<10",
 		"firefox_mob": "<49",
-		"samsung_mob": "*"
+		"samsung_mob": "<6"
 	},
 	"dependencies": [
 		"Document",

--- a/polyfills/Element/prototype/after/config.json
+++ b/polyfills/Element/prototype/after/config.json
@@ -18,7 +18,7 @@
 		"op_mini": "*",
 		"safari": "<10",
 		"firefox_mob": "<49",
-		"samsung_mob": "*"
+		"samsung_mob": "<6"
 	},
 	"dependencies": [
 		"Document",

--- a/polyfills/Element/prototype/append/config.json
+++ b/polyfills/Element/prototype/append/config.json
@@ -18,7 +18,7 @@
 		"op_mini": "*",
 		"safari": "<10",
 		"firefox_mob": "<49",
-		"samsung_mob": "*"
+		"samsung_mob": "<6"
 	},
 	"dependencies": [
 		"Document",

--- a/polyfills/Element/prototype/before/config.json
+++ b/polyfills/Element/prototype/before/config.json
@@ -18,7 +18,7 @@
 		"op_mini": "*",
 		"safari": "<10",
 		"firefox_mob": "<49",
-		"samsung_mob": "*"
+		"samsung_mob": "<6"
 	},
 	"dependencies": [
 		"Document",

--- a/polyfills/Element/prototype/prepend/config.json
+++ b/polyfills/Element/prototype/prepend/config.json
@@ -18,7 +18,7 @@
 		"op_mini": "*",
 		"safari": "<10",
 		"firefox_mob": "<49",
-		"samsung_mob": "*"
+		"samsung_mob": "<6"
 	},
 	"dependencies": [
 		"Document",

--- a/polyfills/Element/prototype/replaceWith/config.json
+++ b/polyfills/Element/prototype/replaceWith/config.json
@@ -18,7 +18,7 @@
 		"op_mini": "*",
 		"safari": "<10",
 		"firefox_mob": "<49",
-		"samsung_mob": "*"
+		"samsung_mob": "<6"
 	},
 	"dependencies": [
 		"Document",

--- a/polyfills/IntersectionObserver/config.json
+++ b/polyfills/IntersectionObserver/config.json
@@ -13,7 +13,7 @@
 		"op_mini": "17 - *",
 		"opera": "*",
 		"safari": "6 - *",
-		"samsung_mob": "*"
+		"samsung_mob": "<6"
 	},
 	"dependencies": [
 		"getComputedStyle",

--- a/polyfills/Intl/config.json
+++ b/polyfills/Intl/config.json
@@ -9,7 +9,7 @@
 		"safari": "<10",
 		"ios_saf": "<10",
 		"firefox_mob": "*",
-		"samsung_mob": "*"
+		"samsung_mob": "<6"
 	},
 	"dependencies": [],
 	"build": {

--- a/polyfills/Object/entries/config.json
+++ b/polyfills/Object/entries/config.json
@@ -15,7 +15,7 @@
 		"opera": "*",
 		"op_mob": "*",
 		"op_mini": "*",
-		"samsung_mob": "*",
+		"samsung_mob": "<6",
 		"bb": "*"
 	},
 	"dependencies": [

--- a/polyfills/Object/freeze/config.json
+++ b/polyfills/Object/freeze/config.json
@@ -14,7 +14,7 @@
 		"opera": "<12",
 		"op_mob": "*",
 		"op_mini": "*",
-		"samsung_mob": "*",
+		"samsung_mob": "<6",
 		"bb": "*"
 	},
 	"dependencies": [

--- a/polyfills/Object/values/config.json
+++ b/polyfills/Object/values/config.json
@@ -15,7 +15,7 @@
 		"opera": "*",
 		"op_mob": "*",
 		"op_mini": "*",
-		"samsung_mob": "*",
+		"samsung_mob": "<6",
 		"bb": "*"
 	},
 	"dependencies": [

--- a/polyfills/_DOMTokenList/config.json
+++ b/polyfills/_DOMTokenList/config.json
@@ -11,7 +11,8 @@
 		"opera": "*",
 		"op_mini": "*",
 		"safari": "*",
-		"firefox_mob": "*"
+		"firefox_mob": "*",
+		"samsung_mob": "*"
 	},
 	"dependencies": [
 		"Object.defineProperty"


### PR DESCRIPTION
Fixes #1388 

Update the tests after unning on Samsung Internet 6.2 which has the Chromium v56 Engine, with some features from 57.

!! Note for Maintainer !!

Could not run tests, project was refusing to run. Even after running `npm run build` successfully.

Ubuntu Linux, Error: `Cannot find module './build/bindings/iltorb.node'` 