### PR TITLE
build the polyfills after installing the project as we ingore the `__dist` directory from npm and git

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "test-vcl": "mocha test/vcl --recursive --timeout 10000 --slow 2000",
     "test": "npm run build && npm run test-node && npm run test-node-unit && npm run test-integration && npm run test-browser-quick",
     "compatgen": "npm run build && npm run test-node && npm run test-browser-compat && node tasks/node/compattable",
-    "prepublish": "npm run build",
+    "postinstall": "npm run build",
     "deploy": "git push git@heroku.com:ft-polyfill-service-qa.git master && git push git@heroku.com:ft-polyfill-service-us-qa.git master && npm run deploy-vcl -- --env=qa && NODE_ENV=\"qa\" npm run purge-cdn",
     "deploy-vcl": "node tasks/node/deployvcl",
     "deploy-lambda": "node tasks/node/deploylambda",


### PR DESCRIPTION
We stopped having a separate `.npmignore` file because it was confusing contributors to this project about what to place in `.gitignore` and what to place in `.npmignore`. We only have a `.gitignore` now.

This introduced the issue where the `__dist` directory was no longer being published to npm, since it is in our `.gitignore` file. [ #1360 , #1363 ]

Instead of publishing the folder to npm, we can create the folder after the package is installed from npm onto the machine. 