### PR TITLE
Use native Object.defineProperty for POJSOs when needed

### DIFF
--- a/polyfills/Object/defineProperty/polyfill.js
+++ b/polyfills/Object/defineProperty/polyfill.js
@@ -7,7 +7,8 @@
 	Object.defineProperty = function defineProperty(object, property, descriptor) {
 
 		// Where native support exists, assume it
-		if (nativeDefineProperty && (object === window || object === document || object === Element.prototype || object instanceof Element)) {
+		if (nativeDefineProperty && (object === window || object === document || object === Element.prototype
+				|| object instanceof Element || !object.__defineGetter__ || !object.__defineSetter__)) {
 			return nativeDefineProperty(object, property, descriptor);
 		}
 


### PR DESCRIPTION
Plain old JS objects without __defineGetter__ or __defineSetter__ should use the native Object.defineProperty() function to prevent undefined function exception.

See: [issue #1399](https://github.com/Financial-Times/polyfill-service/issues/1399) for more detail.