### PR TITLE
Improve the Map polyfills spec compliance

### DIFF
--- a/polyfills/Map/polyfill.js
+++ b/polyfills/Map/polyfill.js
@@ -122,21 +122,19 @@
 	};
 	Map.prototype['values'] = function() {
 		var iterator = makeIterator(this, function(i) { return this._values[i]; });
-		iterator[Symbol.iterator] = this.values;
+		iterator[Symbol.iterator] = this.values.bind(this);
 		return iterator;
 	};
 	Map.prototype['keys'] = function() {
 		var iterator = makeIterator(this, function(i) { return decodeKey(this._keys[i]); });
-		iterator[Symbol.iterator] = this.keys;
+		iterator[Symbol.iterator] = this.keys.bind(this);
 		return iterator;
 	};
+	Map.prototype[Symbol.iterator] =
 	Map.prototype['entries'] = function() {
 		var iterator = makeIterator(this, function(i) { return [decodeKey(this._keys[i]), this._values[i]]; });
-		iterator[Symbol.iterator] = this.entries;
+		iterator[Symbol.iterator] = this.entries.bind(this);
 		return iterator;
-	};
-	Map.prototype[Symbol.iterator] = function() {
-		return makeIterator(this, function(i) { return [decodeKey(this._keys[i]), this._values[i]]; });
 	};
 	Map.prototype['forEach'] = function(callbackFn, thisArg) {
 		thisArg = thisArg || global;

--- a/polyfills/Map/tests.js
+++ b/polyfills/Map/tests.js
@@ -165,13 +165,53 @@ describe('Map', function() {
 		proclaim.equal(lastResult.value, void 0);
 	});
 
-	it("implements iterable for all iterators", function () {
-		var o = new Map();
-		proclaim.isDefined(o.values()[Symbol.iterator]);
-		proclaim.isDefined(o.keys()[Symbol.iterator]);
-		proclaim.isDefined(o[Symbol.iterator]);
-		proclaim.isDefined(o.entries()[Symbol.iterator]);
-	});
+	if ('Symbol' in window && 'iterator' in Symbol) {
+		it('Map.prototype[Symbol.iterator] is an alias to Map.prototype.entries', function () {
+			proclaim.strictEqual(Map.prototype[Symbol.iterator], Map.prototype.entries);
+		});
+
+		it("implements iterable for all iterators", function () {
+			var o = new Map([["1", 1], ["2", 2], ["3", 3]]);
+			var valuesIteratorFactory = o.values()[Symbol.iterator];
+			proclaim.isFunction(valuesIteratorFactory);
+			var valuesIterator = valuesIteratorFactory();
+			proclaim.isObject(valuesIterator);
+			var v = valuesIterator.next();
+			proclaim.equal(v.value, 1);
+			v = valuesIterator.next();
+			proclaim.equal(v.value, 2);
+			v = valuesIterator.next();
+			proclaim.equal(v.value, 3);
+			v = valuesIterator.next();
+			proclaim.equal(v.done, true);
+
+			var keysIteratorFactory = o.keys()[Symbol.iterator];
+			proclaim.isFunction(keysIteratorFactory);
+			var keysIterator = keysIteratorFactory();
+			proclaim.isObject(keysIterator);
+			var k = keysIterator.next();
+			proclaim.equal(k.value, "1");
+			k = keysIterator.next();
+			proclaim.equal(k.value, "2");
+			k = keysIterator.next();
+			proclaim.equal(k.value, "3");
+			k = keysIterator.next();
+			proclaim.equal(k.done, true);
+
+			var entriesIteratorFactory = o.entries()[Symbol.iterator];
+			proclaim.isFunction(entriesIteratorFactory);
+			var entriesIterator = entriesIteratorFactory();
+			proclaim.isObject(entriesIterator);
+			var e = entriesIterator.next();
+			proclaim.deepEqual(e.value, [1,"1"]);
+			e = entriesIterator.next();
+			proclaim.deepEqual(e.value, [2,"2"]);
+			e = entriesIterator.next();
+			proclaim.deepEqual(e.value, [3,"3"]);
+			e = entriesIterator.next();
+			proclaim.equal(e.done, true);
+		});
+	}
 
 	it("implements .forEach()", function () {
 		var o = new Map();

--- a/polyfills/Map/tests.js
+++ b/polyfills/Map/tests.js
@@ -1,261 +1,263 @@
 /* eslint-env mocha, browser */
 /* global proclaim */
 
-var o, generic, callback;
+describe('Map', function() {
+	var o, generic, callback;
 
-beforeEach(function() {
-	if ('Map' in window) o = new Map();
-	generic = {};
-	callback = function () {};
-});
-
-it("has valid constructor", function () {
-	proclaim.isInstanceOf(new Map, Map);
-	proclaim.isInstanceOf(new Map(), Map);
-	proclaim.equal((new Map()).constructor, Map);
-	proclaim.equal((new Map()).constructor.name, "Map");
-	if ("__proto__" in {}) {
-		proclaim.equal((new Map).__proto__.isPrototypeOf(new Map()), true);
-		proclaim.equal((new Map).__proto__ === Map.prototype, true);
-	}
-});
-
-it ("can be pre-populated", function() {
-	var a = 1;
-	var b = {};
-	var c = new Map();
-	var m = new Map([[1,1], [b,2], [c, 3]]);
-	proclaim.equal(m.has(a), true);
-	proclaim.equal(m.has(b), true);
-	proclaim.equal(m.has(c), true);
-	proclaim.equal(m.size, 3);
-
-	var d = new Map(m);
-	proclaim.equal(d.has(a), true);
-	proclaim.equal(d.has(b), true);
-	proclaim.equal(d.has(c), true);
-	proclaim.equal(d.size, 3);
-});
-
-it("implements .size()", function () {
-	proclaim.equal(o.size, 0);
-	o.set("a", "a");
-	proclaim.equal(o.size, 1);
-	o["delete"]("a"); // Use square-bracket syntax to avoid a reserved word in old browsers
-	proclaim.equal(o.size, 0);
-});
-
-it("implements .has()", function () {
-	proclaim.equal(o.has(callback), false);
-	o.set(callback, generic);
-	proclaim.equal(o.has(callback), true);
-});
-
-it("implements .get()", function () {
-	o.set(callback, generic);
-	proclaim.equal(o.get(callback, 123), generic);
-	proclaim.equal(o.get(callback), generic);
-});
-
-it("implements .set()", function () {
-	o.set(callback, generic);
-	proclaim.equal(o.get(callback), generic);
-	o.set(callback, callback);
-	proclaim.equal(o.get(callback), callback);
-	o.set(callback, o);
-	proclaim.equal(o.get(callback), o);
-	o.set(o, callback);
-	proclaim.equal(o.get(o), callback);
-	o.set(NaN, generic);
-	proclaim.ok(o.has(NaN));
-	proclaim.equal(o.get(NaN), generic);
-	o.set("key", undefined);
-	proclaim.ok(o.has("key"));
-	proclaim.equal(o.get("key"), undefined);
-
-	proclaim.ok(!o.has(-0));
-	proclaim.ok(!o.has(0));
-	o.set(-0, callback);
-	proclaim.ok(o.has(-0));
-	proclaim.ok(o.has(0));
-	proclaim.equal(o.get(-0), callback);
-	proclaim.equal(o.get(0), callback); // Native impl fails in IE11
-	o.set(0, generic);
-	proclaim.ok(o.has(-0));
-	proclaim.ok(o.has(0));
-	proclaim.equal(o.get(-0), generic);
-	proclaim.equal(o.get(0), generic);
-});
-
-it("implements .delete()", function () {
-	o.set(callback, generic);
-	o.set(generic, callback);
-	o.set(o, callback);
-	proclaim.equal(o.has(callback) && o.has(generic) && o.has(o), true);
-	o["delete"](callback);
-	o["delete"](generic);
-	o["delete"](o);
-	proclaim.equal(!o.has(callback) && !o.has(generic) && !o.has(o), true);
-	proclaim.ok(o["delete"](o) === false);
-	o.set(o, callback);
-	proclaim.ok(o["delete"](o));
-});
-
-it("does not throw an error when a non-object key is used", function () {
-	proclaim.doesNotThrow(function() {
-		o.set("key", o);
+	beforeEach(function() {
+		if ('Map' in window) o = new Map();
+		generic = {};
+		callback = function () {};
 	});
-});
 
-it("exhibits correct iterator behaviour", function () {
-	// test that things get returned in insertion order as per the specs
-	o = new Map([["1", 1], ["2", 2], ["3", 3]]);
-	var keys = o.keys();
-	var values = o.values();
-	var k = keys.next();
-	var v = values.next();
-	proclaim.equal(k.value, "1");
-	proclaim.equal(v.value, 1);
-	o['delete']("2");
-	k = keys.next();
-	v = values.next();
-	proclaim.equal(k.value, "3");
-	proclaim.equal(v.value, 3);
-	// insertion of previously-removed item goes to the end
-	o.set("2", 2);
-	k = keys.next();
-	v = values.next();
-	proclaim.equal(k.value, "2");
-	proclaim.equal(v.value, 2);
-	// when called again, new iterator starts from beginning
-	var entriesagain = o.entries();
-	proclaim.equal(entriesagain.next().value[0], "1");
-	proclaim.equal(entriesagain.next().value[0], "3");
-	proclaim.equal(entriesagain.next().value[0], "2");
-	// after a iterator is finished, don't return any more elements
-	k = keys.next();
-	v = values.next();
-	proclaim.equal(k.done, true);
-	proclaim.equal(v.done, true);
-	k = keys.next();
-	v = values.next();
-	proclaim.equal(k.done, true);
-	proclaim.equal(v.done, true);
-	o.set("4", 4);
-	k = keys.next();
-	v = values.next();
-	proclaim.equal(k.done, true);
-	proclaim.equal(v.done, true);
-	// new element shows up in iterators that didn't yet finish
-	proclaim.equal(entriesagain.next().value[0], "4");
-	proclaim.equal(entriesagain.next().done, true);
-	// value is present but undefined when done is true, so that Array.from and other noncompliant
-	// interfaces recognize it as a valid iterator
-	var lastResult = entriesagain.next();
-	proclaim.equal(lastResult.done, true);
-	proclaim.ok(lastResult.hasOwnProperty('value'));
-	proclaim.equal(lastResult.value, void 0);
-});
-
-it("implements iterable for all iterators", function () {
-	proclaim.isDefined(o.values()[Symbol.iterator]);
-	proclaim.isDefined(o.keys()[Symbol.iterator]);
-	proclaim.isDefined(o[Symbol.iterator]);
-	proclaim.isDefined(o.entries()[Symbol.iterator]);
-});
-
-it("implements .forEach()", function () {
-	var o = new Map();
-	o.set("key 0", 0);
-	o.set("key 1", 1);
-	o.forEach(function (value, key, obj) {
-		proclaim.equal(key, "key " + value);
-		proclaim.equal(obj, o);
-		// even if dropped, keeps looping
-		o["delete"](key);
-	});
-	proclaim.equal(o.size, 0);
-});
-
-it("supports mutations during forEach loops", function () {
-	var o = new Map([["0", 0], ["1", 1], ["2", 2]]), seen = [];
-	o.forEach(function (value, key, obj) {
-		seen += ','+value;
-		proclaim.equal(obj, o);
-		proclaim.equal(""+value, key);
-		// mutations work as expected
-		if (value === 1) {
-			o['delete']("0"); // remove from before current index
-			o['delete']("2"); // remove from after current index
-			o.set("3", 3); // insertion
-		} else if (value === 3) {
-			o.set("0", 0); // insertion at the end
+	it("has valid constructor", function () {
+		proclaim.isInstanceOf(new Map, Map);
+		proclaim.isInstanceOf(new Map(), Map);
+		proclaim.equal((new Map()).constructor, Map);
+		proclaim.equal((new Map()).constructor.name, "Map");
+		if ("__proto__" in {}) {
+			proclaim.equal((new Map).__proto__.isPrototypeOf(new Map()), true);
+			proclaim.equal((new Map).__proto__ === Map.prototype, true);
 		}
 	});
-	proclaim.equal(seen, ",0,1,3,0");
-});
 
-it("implements .clear()", function(){
-	var o = new Map();
-	o.set(1, '1');
-	o.set(2, '2');
-	o.set(3, '3');
-	o.clear();
-	proclaim.equal(o.size, 0);
-});
+	it ("can be pre-populated", function() {
+		var a = 1;
+		var b = {};
+		var c = new Map();
+		var m = new Map([[1,1], [b,2], [c, 3]]);
+		proclaim.equal(m.has(a), true);
+		proclaim.equal(m.has(b), true);
+		proclaim.equal(m.has(c), true);
+		proclaim.equal(m.size, 3);
 
-it("allows set after clear", function(){
-	var o = new Map();
-	o.set(1, '1');
-	o.clear();
-	proclaim.equal(o.size, 0);
-	o.set(2, '2');
-	proclaim.equal(o.size, 1);
-	proclaim.equal(o.get(2), '2');
-});
-
-// https://github.com/Financial-Times/polyfill-service/issues/1299
-it("does not call callback if all items are deleted", function () {
-	var x = new Map();
-	x.set(42, 'hi');
-	x["delete"](42);
-	var executed = false;
-	x.forEach(function () {
-		executed = true;
+		var d = new Map(m);
+		proclaim.equal(d.has(a), true);
+		proclaim.equal(d.has(b), true);
+		proclaim.equal(d.has(c), true);
+		proclaim.equal(d.size, 3);
 	});
 
-	proclaim.equal(executed, false);
-});
-
-// https://github.com/Financial-Times/polyfill-service/issues/1299
-it("calls callback correct number of times when items were deleted from map", function () {
-	var x = new Map();
-	x.set(42, 'hi');
-	x.set(43, 'bye');
-	x["delete"](43);
-	var callCount = 0;
-	x.forEach(function () {
-		callCount = callCount + 1;
+	it("implements .size()", function () {
+		proclaim.equal(o.size, 0);
+		o.set("a", "a");
+		proclaim.equal(o.size, 1);
+		o["delete"]("a"); // Use square-bracket syntax to avoid a reserved word in old browsers
+		proclaim.equal(o.size, 0);
 	});
 
-	proclaim.equal(callCount, 1);
-
-	var z = new Map();
-	z.set(42, 'hi');
-	z.set(43, 'bye');
-	z.set(44, 'bye');
-	z.set(45, 'bye');
-	z.set(46, 'bye');
-	z.set(47, 'bye');
-	z["delete"](43);
-	z["delete"](44);
-	z["delete"](45);
-	z["delete"](46);
-	z["delete"](47);
-	callCount = 0;
-	z.forEach(function () {
-		callCount = callCount + 1;
+	it("implements .has()", function () {
+		proclaim.equal(o.has(callback), false);
+		o.set(callback, generic);
+		proclaim.equal(o.has(callback), true);
 	});
 
-	proclaim.equal(callCount, 1);
+	it("implements .get()", function () {
+		o.set(callback, generic);
+		proclaim.equal(o.get(callback, 123), generic);
+		proclaim.equal(o.get(callback), generic);
+	});
+
+	it("implements .set()", function () {
+		o.set(callback, generic);
+		proclaim.equal(o.get(callback), generic);
+		o.set(callback, callback);
+		proclaim.equal(o.get(callback), callback);
+		o.set(callback, o);
+		proclaim.equal(o.get(callback), o);
+		o.set(o, callback);
+		proclaim.equal(o.get(o), callback);
+		o.set(NaN, generic);
+		proclaim.ok(o.has(NaN));
+		proclaim.equal(o.get(NaN), generic);
+		o.set("key", undefined);
+		proclaim.ok(o.has("key"));
+		proclaim.equal(o.get("key"), undefined);
+
+		proclaim.ok(!o.has(-0));
+		proclaim.ok(!o.has(0));
+		o.set(-0, callback);
+		proclaim.ok(o.has(-0));
+		proclaim.ok(o.has(0));
+		proclaim.equal(o.get(-0), callback);
+		proclaim.equal(o.get(0), callback); // Native impl fails in IE11
+		o.set(0, generic);
+		proclaim.ok(o.has(-0));
+		proclaim.ok(o.has(0));
+		proclaim.equal(o.get(-0), generic);
+		proclaim.equal(o.get(0), generic);
+	});
+
+	it("implements .delete()", function () {
+		o.set(callback, generic);
+		o.set(generic, callback);
+		o.set(o, callback);
+		proclaim.equal(o.has(callback) && o.has(generic) && o.has(o), true);
+		o["delete"](callback);
+		o["delete"](generic);
+		o["delete"](o);
+		proclaim.equal(!o.has(callback) && !o.has(generic) && !o.has(o), true);
+		proclaim.ok(o["delete"](o) === false);
+		o.set(o, callback);
+		proclaim.ok(o["delete"](o));
+	});
+
+	it("does not throw an error when a non-object key is used", function () {
+		proclaim.doesNotThrow(function() {
+			o.set("key", o);
+		});
+	});
+
+	it("exhibits correct iterator behaviour", function () {
+		// test that things get returned in insertion order as per the specs
+		o = new Map([["1", 1], ["2", 2], ["3", 3]]);
+		var keys = o.keys();
+		var values = o.values();
+		var k = keys.next();
+		var v = values.next();
+		proclaim.equal(k.value, "1");
+		proclaim.equal(v.value, 1);
+		o['delete']("2");
+		k = keys.next();
+		v = values.next();
+		proclaim.equal(k.value, "3");
+		proclaim.equal(v.value, 3);
+		// insertion of previously-removed item goes to the end
+		o.set("2", 2);
+		k = keys.next();
+		v = values.next();
+		proclaim.equal(k.value, "2");
+		proclaim.equal(v.value, 2);
+		// when called again, new iterator starts from beginning
+		var entriesagain = o.entries();
+		proclaim.equal(entriesagain.next().value[0], "1");
+		proclaim.equal(entriesagain.next().value[0], "3");
+		proclaim.equal(entriesagain.next().value[0], "2");
+		// after a iterator is finished, don't return any more elements
+		k = keys.next();
+		v = values.next();
+		proclaim.equal(k.done, true);
+		proclaim.equal(v.done, true);
+		k = keys.next();
+		v = values.next();
+		proclaim.equal(k.done, true);
+		proclaim.equal(v.done, true);
+		o.set("4", 4);
+		k = keys.next();
+		v = values.next();
+		proclaim.equal(k.done, true);
+		proclaim.equal(v.done, true);
+		// new element shows up in iterators that didn't yet finish
+		proclaim.equal(entriesagain.next().value[0], "4");
+		proclaim.equal(entriesagain.next().done, true);
+		// value is present but undefined when done is true, so that Array.from and other noncompliant
+		// interfaces recognize it as a valid iterator
+		var lastResult = entriesagain.next();
+		proclaim.equal(lastResult.done, true);
+		proclaim.ok(lastResult.hasOwnProperty('value'));
+		proclaim.equal(lastResult.value, void 0);
+	});
+
+	it("implements iterable for all iterators", function () {
+		proclaim.isDefined(o.values()[Symbol.iterator]);
+		proclaim.isDefined(o.keys()[Symbol.iterator]);
+		proclaim.isDefined(o[Symbol.iterator]);
+		proclaim.isDefined(o.entries()[Symbol.iterator]);
+	});
+
+	it("implements .forEach()", function () {
+		var o = new Map();
+		o.set("key 0", 0);
+		o.set("key 1", 1);
+		o.forEach(function (value, key, obj) {
+			proclaim.equal(key, "key " + value);
+			proclaim.equal(obj, o);
+			// even if dropped, keeps looping
+			o["delete"](key);
+		});
+		proclaim.equal(o.size, 0);
+	});
+
+	it("supports mutations during forEach loops", function () {
+		var o = new Map([["0", 0], ["1", 1], ["2", 2]]), seen = [];
+		o.forEach(function (value, key, obj) {
+			seen += ','+value;
+			proclaim.equal(obj, o);
+			proclaim.equal(""+value, key);
+			// mutations work as expected
+			if (value === 1) {
+				o['delete']("0"); // remove from before current index
+				o['delete']("2"); // remove from after current index
+				o.set("3", 3); // insertion
+			} else if (value === 3) {
+				o.set("0", 0); // insertion at the end
+			}
+		});
+		proclaim.equal(seen, ",0,1,3,0");
+	});
+
+	it("implements .clear()", function(){
+		var o = new Map();
+		o.set(1, '1');
+		o.set(2, '2');
+		o.set(3, '3');
+		o.clear();
+		proclaim.equal(o.size, 0);
+	});
+
+	it("allows set after clear", function(){
+		var o = new Map();
+		o.set(1, '1');
+		o.clear();
+		proclaim.equal(o.size, 0);
+		o.set(2, '2');
+		proclaim.equal(o.size, 1);
+		proclaim.equal(o.get(2), '2');
+	});
+
+	// https://github.com/Financial-Times/polyfill-service/issues/1299
+	it("does not call callback if all items are deleted", function () {
+		var x = new Map();
+		x.set(42, 'hi');
+		x["delete"](42);
+		var executed = false;
+		x.forEach(function () {
+			executed = true;
+		});
+
+		proclaim.equal(executed, false);
+	});
+
+	// https://github.com/Financial-Times/polyfill-service/issues/1299
+	it("calls callback correct number of times when items were deleted from map", function () {
+		var x = new Map();
+		x.set(42, 'hi');
+		x.set(43, 'bye');
+		x["delete"](43);
+		var callCount = 0;
+		x.forEach(function () {
+			callCount = callCount + 1;
+		});
+
+		proclaim.equal(callCount, 1);
+
+		var z = new Map();
+		z.set(42, 'hi');
+		z.set(43, 'bye');
+		z.set(44, 'bye');
+		z.set(45, 'bye');
+		z.set(46, 'bye');
+		z.set(47, 'bye');
+		z["delete"](43);
+		z["delete"](44);
+		z["delete"](45);
+		z["delete"](46);
+		z["delete"](47);
+		callCount = 0;
+		z.forEach(function () {
+			callCount = callCount + 1;
+		});
+
+		proclaim.equal(callCount, 1);
+	});
 });

--- a/polyfills/Map/tests.js
+++ b/polyfills/Map/tests.js
@@ -2,14 +2,6 @@
 /* global proclaim */
 
 describe('Map', function() {
-	var o, generic, callback;
-
-	beforeEach(function() {
-		if ('Map' in window) o = new Map();
-		generic = {};
-		callback = function () {};
-	});
-
 	it("has valid constructor", function () {
 		proclaim.isInstanceOf(new Map, Map);
 		proclaim.isInstanceOf(new Map(), Map);
@@ -39,6 +31,7 @@ describe('Map', function() {
 	});
 
 	it("implements .size()", function () {
+		var o = new Map();
 		proclaim.equal(o.size, 0);
 		o.set("a", "a");
 		proclaim.equal(o.size, 1);
@@ -47,18 +40,27 @@ describe('Map', function() {
 	});
 
 	it("implements .has()", function () {
+		var o = new Map();
+		var generic = {};
+		var callback = function () {};
 		proclaim.equal(o.has(callback), false);
 		o.set(callback, generic);
 		proclaim.equal(o.has(callback), true);
 	});
 
 	it("implements .get()", function () {
+		var o = new Map();
+		var generic = {};
+		var callback = function () {};
 		o.set(callback, generic);
 		proclaim.equal(o.get(callback, 123), generic);
 		proclaim.equal(o.get(callback), generic);
 	});
 
 	it("implements .set()", function () {
+		var o = new Map();
+		var generic = {};
+		var callback = function () {};
 		o.set(callback, generic);
 		proclaim.equal(o.get(callback), generic);
 		o.set(callback, callback);
@@ -89,6 +91,9 @@ describe('Map', function() {
 	});
 
 	it("implements .delete()", function () {
+		var o = new Map();
+		var generic = {};
+		var callback = function () {};
 		o.set(callback, generic);
 		o.set(generic, callback);
 		o.set(o, callback);
@@ -103,12 +108,14 @@ describe('Map', function() {
 	});
 
 	it("does not throw an error when a non-object key is used", function () {
+		var o = new Map();
 		proclaim.doesNotThrow(function() {
 			o.set("key", o);
 		});
 	});
 
 	it("exhibits correct iterator behaviour", function () {
+		var o = new Map();
 		// test that things get returned in insertion order as per the specs
 		o = new Map([["1", 1], ["2", 2], ["3", 3]]);
 		var keys = o.keys();
@@ -159,6 +166,7 @@ describe('Map', function() {
 	});
 
 	it("implements iterable for all iterators", function () {
+		var o = new Map();
 		proclaim.isDefined(o.values()[Symbol.iterator]);
 		proclaim.isDefined(o.keys()[Symbol.iterator]);
 		proclaim.isDefined(o[Symbol.iterator]);
@@ -166,6 +174,7 @@ describe('Map', function() {
 	});
 
 	it("implements .forEach()", function () {
+		var o = new Map();
 		var o = new Map();
 		o.set("key 0", 0);
 		o.set("key 1", 1);
@@ -179,6 +188,7 @@ describe('Map', function() {
 	});
 
 	it("supports mutations during forEach loops", function () {
+		var o = new Map();
 		var o = new Map([["0", 0], ["1", 1], ["2", 2]]), seen = [];
 		o.forEach(function (value, key, obj) {
 			seen += ','+value;
@@ -198,6 +208,7 @@ describe('Map', function() {
 
 	it("implements .clear()", function(){
 		var o = new Map();
+		var o = new Map();
 		o.set(1, '1');
 		o.set(2, '2');
 		o.set(3, '3');
@@ -206,6 +217,7 @@ describe('Map', function() {
 	});
 
 	it("allows set after clear", function(){
+		var o = new Map();
 		var o = new Map();
 		o.set(1, '1');
 		o.clear();


### PR DESCRIPTION
Probably easier to review this by ignoring whitespace changes -- https://github.com/Financial-Times/polyfill-service/pull/1413/files?w=1

- Added tests for ensuring aliases method names point to the exact same function object. 
- Added tests for the iterable support. 
- Updated the polyfill to pass the tests.