### PR TITLE
Serve Intl polyfill for Opera Mini and Blackberry

### DIFF
--- a/polyfills/Intl/config.json
+++ b/polyfills/Intl/config.json
@@ -1,10 +1,12 @@
 {
 	"browsers": {
 		"android": "<=4.3",
+		"bb": "*",
 		"ie": "9 - 10",
 		"ie_mob": "10",
 		"firefox": "<29",
 		"opera": "<15",
+		"op_mini": "*",
 		"chrome": "<=34",
 		"safari": "<10",
 		"ios_saf": "<10",


### PR DESCRIPTION
#748 Happens for us (we receive Sentry reports of errors including user agent)
So, I propose adding Intl polyfill for Blackberry and Opera Mini.

I have checked https://caniuse.com/#search=intl and it's not supported on all Blackberry and Opera Mini versions (I don't have BB device to verify, but I can confirm Opera Mini).