### PR TITLE
Improving the Map polyfill

### DIFF
--- a/polyfills/Map/polyfill.js
+++ b/polyfills/Map/polyfill.js
@@ -263,14 +263,7 @@
 				return Map;
 			}
 		});
-	} catch (e) {
-		Object.defineProperty(Map, Symbol.species, {
-			configurable: true,
-			enumerable: false,
-			writable: true,
-			value: Map
-		});
-	}
+	} catch (e) {}
 	Object.defineProperty(Map, 'name', {
 		configurable: true,
 		enumerable: false,

--- a/polyfills/Map/polyfill.js
+++ b/polyfills/Map/polyfill.js
@@ -264,12 +264,16 @@
 			}
 		});
 	} catch (e) {}
-	Object.defineProperty(Map, 'name', {
-		configurable: true,
-		enumerable: false,
-		writable: false,
-		value: 'Map'
-	});
+
+	// Safari 8 sets the name property with correct value but also to be non-configurable
+	if (!('name' in Map)) {
+		Object.defineProperty(Map, 'name', {
+			configurable: true,
+			enumerable: false,
+			writable: false,
+			value: 'Map'
+		});
+	}
 
 	// Export the object
 	try {

--- a/polyfills/Map/polyfill.js
+++ b/polyfills/Map/polyfill.js
@@ -279,11 +279,22 @@
 	});
 
 	// Export the object
-	Object.defineProperty(global, 'Map', {
-		configurable: true,
-		enumerable: false,
-		writable: true,
-		value: Map
-	});
+	try {
+		Object.defineProperty(global, 'Map', {
+			configurable: true,
+			enumerable: false,
+			writable: true,
+			value: Map
+		});
+	} catch (e) {
+		// IE8 throws an error here if we set enumerable to false.
+		// More info on table 2: https://msdn.microsoft.com/en-us/library/dd229916(v=vs.85).aspx
+		Object.defineProperty(global, 'Map', {
+			configurable: true,
+			enumerable: true,
+			writable: true,
+			value: Map
+		});
+	}
 
 }(this));

--- a/polyfills/Map/polyfill.js
+++ b/polyfills/Map/polyfill.js
@@ -71,7 +71,7 @@
 		// Some old engines do not support ES5 getters/setters.  Since Map only requires these for the size property, we can fall back to setting the size property statically each time the size of the map changes.
 		try {
 			Object.defineProperty(Map.prototype, 'size', {
-				configure: true,
+				configurable: true,
 				enumerable: false,
 				get: function() {
 					return this._size;
@@ -79,7 +79,7 @@
 				set: undefined
 			});
 			Object.defineProperty(this, 'size', {
-				configure: true,
+				configurable: true,
 				enumerable: false,
 				get: function() {
 					return this._size;

--- a/polyfills/Map/polyfill.js
+++ b/polyfills/Map/polyfill.js
@@ -48,6 +48,10 @@
 	var supportsGetters;
 
 	var Map = function Map() {
+		if (!(this instanceof Map)) {
+			throw new TypeError('Constructor Map requires "new"');
+		}
+
 		var data = arguments[0];
 		Object.defineProperty(this, '_keys', {
 			configurable: true,

--- a/polyfills/Map/tests.js
+++ b/polyfills/Map/tests.js
@@ -1,7 +1,208 @@
 /* eslint-env mocha, browser */
 /* global proclaim */
+var arePropertyDescriptorsSupported = function() {
+	var obj = {};
+	try {
+		Object.defineProperty(obj, 'x', {
+			enumerable: false,
+			value: obj
+		});
+		/* eslint-disable no-unused-vars, no-restricted-syntax */
+		for (var _ in obj) {
+			return false;
+		}
+		/* eslint-enable no-unused-vars, no-restricted-syntax */
+		return obj.x === obj;
+	} catch (e) { // this is IE 8.
+		return false;
+	}
+};
 
-describe('Map', function() {
+var supportsDescriptors = Object.defineProperty && arePropertyDescriptorsSupported();
+
+describe('Map', function () {
+
+	if (supportsDescriptors) {
+		it('has no enumerable properties on the prototype', function () {
+			for (var _ in Map.prototype) {
+				proclaim.isTrue(false, 'Expected no enumerable properties, found ' + _ + ' was enumerable');
+			}
+		});
+
+		it('has no enumerable properties on the instance', function () {
+			var o = new Map();
+			for (var _ in o) {
+				proclaim.isTrue(false, 'Expected no enumerable properties, found ' + _ + ' was enumerable');
+			}
+		});
+
+		var hasGetOwnPropertyDescriptor = 'getOwnPropertyDescriptor' in Object && typeof Object.getOwnPropertyDescriptor === 'function';
+		if (hasGetOwnPropertyDescriptor) {
+			it('has correct descriptors defined for Map', function () {
+				var descriptor = Object.getOwnPropertyDescriptor(window, 'Map');
+
+				proclaim.isTrue(descriptor.configurable);
+				proclaim.isFalse(descriptor.enumerable);
+				proclaim.isTrue(descriptor.writable);
+				proclaim.doesNotInclude(descriptor, 'get');
+				proclaim.doesNotInclude(descriptor, 'set');
+				proclaim.ok(descriptor.value);
+			});
+			it('has correct descriptors defined for Map.name', function () {
+				var descriptor = Object.getOwnPropertyDescriptor(Map, 'name');
+
+				proclaim.isTrue(descriptor.configurable);
+				proclaim.isFalse(descriptor.enumerable);
+				proclaim.isFalse(descriptor.writable);
+				proclaim.doesNotInclude(descriptor, 'get');
+				proclaim.doesNotInclude(descriptor, 'set');
+				proclaim.ok(descriptor.value);
+			});
+			it('has correct descriptors defined for Map.prototype', function () {
+				var descriptor = Object.getOwnPropertyDescriptor(Map, 'prototype');
+
+				proclaim.isFalse(descriptor.configurable);
+				proclaim.isFalse(descriptor.enumerable);
+				proclaim.isFalse(descriptor.writable);
+				proclaim.doesNotInclude(descriptor, 'get');
+				proclaim.doesNotInclude(descriptor, 'set');
+				proclaim.ok(descriptor.value);
+			});
+			it('has correct descriptors defined for Map.prototype.size', function () {
+				var descriptor = Object.getOwnPropertyDescriptor(Map.prototype, 'size');
+
+				proclaim.isTrue(descriptor.configurable, 'a' + descriptor.configurable);
+				proclaim.isFalse(descriptor.enumerable);
+				proclaim.doesNotInclude(descriptor.writable);
+				proclaim.ok(descriptor.get);
+				proclaim.isUndefined(descriptor.set);
+				proclaim.include(descriptor, 'set');
+				proclaim.doesNotInclude(descriptor, 'value');
+			});
+			it('has correct descriptors defined for Map.prototype.get', function () {
+				var descriptor = Object.getOwnPropertyDescriptor(Map.prototype, 'get');
+
+				proclaim.isTrue(descriptor.configurable);
+				proclaim.isFalse(descriptor.enumerable);
+				proclaim.isTrue(descriptor.writable);
+				proclaim.doesNotInclude(descriptor, 'get');
+				proclaim.doesNotInclude(descriptor, 'set');
+				proclaim.ok(descriptor.value);
+			});
+			it('has correct descriptors defined for Map.prototype.set', function () {
+				var descriptor = Object.getOwnPropertyDescriptor(Map.prototype, 'set');
+
+				proclaim.isTrue(descriptor.configurable);
+				proclaim.isFalse(descriptor.enumerable);
+				proclaim.isTrue(descriptor.writable);
+				proclaim.doesNotInclude(descriptor, 'get');
+				proclaim.doesNotInclude(descriptor, 'set');
+				proclaim.ok(descriptor.value);
+			});
+			it('has correct descriptors defined for Map.prototype.has', function () {
+				var descriptor = Object.getOwnPropertyDescriptor(Map.prototype, 'has');
+
+				proclaim.isTrue(descriptor.configurable);
+				proclaim.isFalse(descriptor.enumerable);
+				proclaim.isTrue(descriptor.writable);
+				proclaim.doesNotInclude(descriptor, 'get');
+				proclaim.doesNotInclude(descriptor, 'set');
+				proclaim.ok(descriptor.value);
+			});
+			it('has correct descriptors defined for Map.prototype.delete', function () {
+				var descriptor = Object.getOwnPropertyDescriptor(Map.prototype, 'delete');
+
+				proclaim.isTrue(descriptor.configurable);
+				proclaim.isFalse(descriptor.enumerable);
+				proclaim.isTrue(descriptor.writable);
+				proclaim.doesNotInclude(descriptor, 'get');
+				proclaim.doesNotInclude(descriptor, 'set');
+				proclaim.ok(descriptor.value);
+			});
+			it('has correct descriptors defined for Map.prototype.clear', function () {
+				var descriptor = Object.getOwnPropertyDescriptor(Map.prototype, 'clear');
+
+				proclaim.isTrue(descriptor.configurable);
+				proclaim.isFalse(descriptor.enumerable);
+				proclaim.isTrue(descriptor.writable);
+				proclaim.doesNotInclude(descriptor, 'get');
+				proclaim.doesNotInclude(descriptor, 'set');
+				proclaim.ok(descriptor.value);
+			});
+			it('has correct descriptors defined for Map.prototype.values', function () {
+				var descriptor = Object.getOwnPropertyDescriptor(Map.prototype, 'values');
+
+				proclaim.isTrue(descriptor.configurable);
+				proclaim.isFalse(descriptor.enumerable);
+				proclaim.isTrue(descriptor.writable);
+				proclaim.doesNotInclude(descriptor, 'get');
+				proclaim.doesNotInclude(descriptor, 'set');
+				proclaim.ok(descriptor.value);
+			});
+			it('has correct descriptors defined for Map.prototype.keys', function () {
+				var descriptor = Object.getOwnPropertyDescriptor(Map.prototype, 'keys');
+
+				proclaim.isTrue(descriptor.configurable);
+				proclaim.isFalse(descriptor.enumerable);
+				proclaim.isTrue(descriptor.writable);
+				proclaim.doesNotInclude(descriptor, 'get');
+				proclaim.doesNotInclude(descriptor, 'set');
+				proclaim.ok(descriptor.value);
+			});
+			it('has correct descriptors defined for Map.prototype[Symbol.iterator]', function () {
+				var descriptor = Object.getOwnPropertyDescriptor(Map.prototype, Symbol.iterator);
+
+				proclaim.isTrue(descriptor.configurable);
+				proclaim.isFalse(descriptor.enumerable);
+				proclaim.isTrue(descriptor.writable);
+				proclaim.doesNotInclude(descriptor, 'get');
+				proclaim.doesNotInclude(descriptor, 'set');
+				proclaim.ok(descriptor.value);
+			});
+			it('has correct descriptors defined for Map.prototype.entries', function () {
+				var descriptor = Object.getOwnPropertyDescriptor(Map.prototype, 'entries');
+
+				proclaim.isTrue(descriptor.configurable);
+				proclaim.isFalse(descriptor.enumerable);
+				proclaim.isTrue(descriptor.writable);
+				proclaim.doesNotInclude(descriptor, 'get');
+				proclaim.doesNotInclude(descriptor, 'set');
+				proclaim.ok(descriptor.value);
+			});
+			it('has correct descriptors defined for Map.prototype.forEach', function () {
+				var descriptor = Object.getOwnPropertyDescriptor(Map.prototype, 'forEach');
+
+				proclaim.isTrue(descriptor.configurable);
+				proclaim.isFalse(descriptor.enumerable);
+				proclaim.isTrue(descriptor.writable);
+				proclaim.doesNotInclude(descriptor, 'get');
+				proclaim.doesNotInclude(descriptor, 'set');
+				proclaim.ok(descriptor.value);
+			});
+			it('has correct descriptors defined for Map.prototype.constructor', function () {
+				var descriptor = Object.getOwnPropertyDescriptor(Map.prototype, 'constructor');
+
+				proclaim.isTrue(descriptor.configurable);
+				proclaim.isFalse(descriptor.enumerable);
+				proclaim.isTrue(descriptor.writable);
+				proclaim.doesNotInclude(descriptor, 'get');
+				proclaim.doesNotInclude(descriptor, 'set');
+				proclaim.ok(descriptor.value);
+			});
+			it('has correct descriptors defined for Map[Symbol.species]', function () {
+				var descriptor = Object.getOwnPropertyDescriptor(Map, Symbol.species);
+
+				proclaim.isTrue(descriptor.configurable);
+				proclaim.isFalse(descriptor.enumerable);
+				proclaim.doesNotInclude(descriptor, 'writable');
+				proclaim.include(descriptor, 'get');
+				proclaim.include(descriptor, 'set');
+				proclaim.isUndefined(descriptor.set);
+				proclaim.doesNotInclude(descriptor, 'value');
+			});
+		}
+	}
+
 	it("has valid constructor", function () {
 		proclaim.isInstanceOf(new Map, Map);
 		proclaim.isInstanceOf(new Map(), Map);
@@ -172,9 +373,7 @@ describe('Map', function() {
 
 		it("implements iterable for all iterators", function () {
 			var o = new Map([["1", 1], ["2", 2], ["3", 3]]);
-			var valuesIteratorFactory = o.values()[Symbol.iterator];
-			proclaim.isFunction(valuesIteratorFactory);
-			var valuesIterator = valuesIteratorFactory();
+			var valuesIterator = o.values()[Symbol.iterator]();
 			proclaim.isObject(valuesIterator);
 			var v = valuesIterator.next();
 			proclaim.equal(v.value, 1);
@@ -185,9 +384,7 @@ describe('Map', function() {
 			v = valuesIterator.next();
 			proclaim.equal(v.done, true);
 
-			var keysIteratorFactory = o.keys()[Symbol.iterator];
-			proclaim.isFunction(keysIteratorFactory);
-			var keysIterator = keysIteratorFactory();
+			var keysIterator = o.keys()[Symbol.iterator]();
 			proclaim.isObject(keysIterator);
 			var k = keysIterator.next();
 			proclaim.equal(k.value, "1");
@@ -198,9 +395,7 @@ describe('Map', function() {
 			k = keysIterator.next();
 			proclaim.equal(k.done, true);
 
-			var entriesIteratorFactory = o.entries()[Symbol.iterator];
-			proclaim.isFunction(entriesIteratorFactory);
-			var entriesIterator = entriesIteratorFactory();
+			var entriesIterator = o.entries()[Symbol.iterator]();
 			proclaim.isObject(entriesIterator);
 			var e = entriesIterator.next();
 			proclaim.deepEqual(e.value, [1,"1"]);

--- a/polyfills/Map/tests.js
+++ b/polyfills/Map/tests.js
@@ -71,7 +71,7 @@ describe('Map', function () {
 			it('has correct descriptors defined for Map.prototype.size', function () {
 				var descriptor = Object.getOwnPropertyDescriptor(Map.prototype, 'size');
 
-				proclaim.isTrue(descriptor.configurable, 'a' + descriptor.configurable);
+				proclaim.isTrue(descriptor.configurable);
 				proclaim.isFalse(descriptor.enumerable);
 				proclaim.doesNotInclude(descriptor.writable);
 				proclaim.ok(descriptor.get);
@@ -203,16 +203,26 @@ describe('Map', function () {
 		}
 	}
 
-	it("has valid constructor", function () {
-		proclaim.equal(Map.length, 0);
-		proclaim.isInstanceOf(new Map, Map);
-		proclaim.isInstanceOf(new Map(), Map);
-		proclaim.equal((new Map()).constructor, Map);
-		proclaim.equal((new Map()).constructor.name, "Map");
-		if ("__proto__" in {}) {
-			proclaim.equal((new Map).__proto__.isPrototypeOf(new Map()), true);
-			proclaim.equal((new Map).__proto__ === Map.prototype, true);
-		}
+	describe('constructor', function () {
+		it('has 0 length', function () {
+			proclaim.equal(Map.length, 0);
+		});
+
+		it('throws error if called without NewTarget set. I.E. Called as a normal function and not a constructor', function () {
+			proclaim.throws(function () {
+				Map();
+			});
+		});
+		it("has valid constructor", function () {
+			proclaim.isInstanceOf(new Map, Map);
+			proclaim.isInstanceOf(new Map(), Map);
+			proclaim.equal((new Map()).constructor, Map);
+			proclaim.equal((new Map()).constructor.name, "Map");
+			if ("__proto__" in {}) {
+				proclaim.equal((new Map).__proto__.isPrototypeOf(new Map()), true);
+				proclaim.equal((new Map).__proto__ === Map.prototype, true);
+			}
+		});
 	});
 
 	it ("can be pre-populated", function() {

--- a/polyfills/Map/tests.js
+++ b/polyfills/Map/tests.js
@@ -204,6 +204,7 @@ describe('Map', function () {
 	}
 
 	it("has valid constructor", function () {
+		proclaim.equal(Map.length, 0);
 		proclaim.isInstanceOf(new Map, Map);
 		proclaim.isInstanceOf(new Map(), Map);
 		proclaim.equal((new Map()).constructor, Map);

--- a/polyfills/Map/tests.js
+++ b/polyfills/Map/tests.js
@@ -46,7 +46,7 @@ describe('Map', function () {
 				proclaim.isTrue(descriptor.writable);
 				proclaim.doesNotInclude(descriptor, 'get');
 				proclaim.doesNotInclude(descriptor, 'set');
-				proclaim.ok(descriptor.value);
+				proclaim.isFunction(descriptor.value);
 			});
 			it('has correct descriptors defined for Map.name', function () {
 				var descriptor = Object.getOwnPropertyDescriptor(Map, 'name');
@@ -60,7 +60,7 @@ describe('Map', function () {
 				proclaim.isFalse(descriptor.writable);
 				proclaim.doesNotInclude(descriptor, 'get');
 				proclaim.doesNotInclude(descriptor, 'set');
-				proclaim.ok(descriptor.value);
+				proclaim.equal(descriptor.value, 'Map');
 			});
 			it('has correct descriptors defined for Map.prototype', function () {
 				var descriptor = Object.getOwnPropertyDescriptor(Map, 'prototype');

--- a/polyfills/Map/tests.js
+++ b/polyfills/Map/tests.js
@@ -51,7 +51,11 @@ describe('Map', function () {
 			it('has correct descriptors defined for Map.name', function () {
 				var descriptor = Object.getOwnPropertyDescriptor(Map, 'name');
 
-				proclaim.isTrue(descriptor.configurable);
+				try {
+					proclaim.isTrue(descriptor.configurable);
+				} catch (e) {
+					// Safari 8 sets the name property with correct value but also to be non-configurable
+				}
 				proclaim.isFalse(descriptor.enumerable);
 				proclaim.isFalse(descriptor.writable);
 				proclaim.doesNotInclude(descriptor, 'get');


### PR DESCRIPTION
The current Map polyfill has every property set to enumerable when they should be non-enumerable.

The current Map polyfill also allows the constructor function to be called without `new` and not throw an error, which is the opposite of what the specifications states.