### PR TITLE
Remove Chrome 63+ from Promise Finally polyfill

### DIFF
--- a/polyfills/Promise/prototype/finally/config.json
+++ b/polyfills/Promise/prototype/finally/config.json
@@ -4,7 +4,7 @@
 	"browsers": {
 		"android": ">4.4",
 		"bb": ">10",
-		"chrome": ">31",
+		"chrome": ">31 <63",
 		"firefox": ">28",
 		"ios_saf": ">7.1",
 		"ie": ">12",


### PR DESCRIPTION
As stated in the official release notes for Google Chrome 63, it natively supports Promise.prototype.finally, making it redundant to load and add the polyfill.

Source: https://developers.google.com/web/updates/2017/10/promise-finally