### PR TITLE
Fix Element.prototype.closest for elements inside inline SVGs

### DIFF
--- a/polyfills/Element/prototype/closest/polyfill.js
+++ b/polyfills/Element/prototype/closest/polyfill.js
@@ -3,7 +3,7 @@ Element.prototype.closest = function closest(selector) {
 
 	while (node) {
 		if (node.matches(selector)) return node;
-		else node = node.tagName === 'svg' ? node.parentNode : node.parentElement;
+		else node = node instanceof SVGElement ? node.parentNode : node.parentElement;
 	}
 
 	return null;

--- a/polyfills/Element/prototype/closest/polyfill.js
+++ b/polyfills/Element/prototype/closest/polyfill.js
@@ -3,7 +3,7 @@ Element.prototype.closest = function closest(selector) {
 
 	while (node) {
 		if (node.matches(selector)) return node;
-		else node = node instanceof SVGElement ? node.parentNode : node.parentElement;
+		else node = SVGElement && node instanceof SVGElement ? node.parentNode : node.parentElement;
 	}
 
 	return null;

--- a/polyfills/Element/prototype/closest/polyfill.js
+++ b/polyfills/Element/prototype/closest/polyfill.js
@@ -3,7 +3,7 @@ Element.prototype.closest = function closest(selector) {
 
 	while (node) {
 		if (node.matches(selector)) return node;
-		else node = SVGElement && node instanceof SVGElement ? node.parentNode : node.parentElement;
+		else node = 'SVGElement' in window && node instanceof SVGElement ? node.parentNode : node.parentElement;
 	}
 
 	return null;

--- a/polyfills/Element/prototype/closest/tests.js
+++ b/polyfills/Element/prototype/closest/tests.js
@@ -51,6 +51,22 @@ if (!!document.createElementNS && !!document.createElementNS('http://www.w3.org/
 
 		document.body.removeChild(el);
 	});
+
+	it("should find the ancestor of a <rect> inside an inline SVG element", function() {
+		var el = document.body.appendChild(document.createElement("section"));
+		el.className = 'svg-holder';
+
+		var svgElement = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+		el.appendChild(svgElement);
+
+		var rectElement = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+		svgElement.appendChild(rectElement)
+
+		var closest = rectElement.closest("section.svg-holder");
+		proclaim.equal(closest, el);
+
+		document.body.removeChild(el);
+	});
 }
 
 /* Skipped: This exception is actually thrown by querySelector, and cannot be thrown by


### PR DESCRIPTION
Fixes #1424:

All elements belonging to the SVG namespace

* do not have a `parentElement` property in IE.
* are instances of the `SVGElement`.

This PR extends the fix of #1285 to not only `<svg>` elements but all elements in the SVG namespace.