### PR TITLE
Rewrite Map polyfill to be more spec compliant

### DIFF
--- a/polyfills/Map/config.json
+++ b/polyfills/Map/config.json
@@ -23,7 +23,9 @@
 		"Symbol",
 		"Symbol.iterator",
 		"Symbol.species",
+		"Object.create",
 		"Object.defineProperty",
+		"Object.getPrototypeOf",
 		"Number.isNaN"
 	],
 	"notes": [

--- a/polyfills/Map/config.json
+++ b/polyfills/Map/config.json
@@ -19,6 +19,7 @@
 		"bb": "10 - *"
 	},
 	"dependencies": [
+		"Array.isArray",
 		"Array.prototype.indexOf",
 		"Symbol",
 		"Symbol.iterator",

--- a/polyfills/Map/polyfill.js
+++ b/polyfills/Map/polyfill.js
@@ -1,111 +1,159 @@
-(function(global) {
+(function (global) {
+	// 7.2.11. SameValueZero ( x, y )
+	var sameValueZero = function (x, y) {
+		// 1. If Type(x) is different from Type(y), return false.
+		if (typeof x !== typeof y) {
+			return false;
+		}
+		// 2. If Type(x) is Number, then
+		if (typeof x === 'number') {
+			// a. If x is NaN and y is NaN, return true.
+			if (isNaN(x) && isNaN(y)) {
+				return true;
+			}
+			// b. If x is +0 and y is -0, return true.
+			if (x === +0 && y === -0) {
+				return true;
+			}
+			// c. If x is -0 and y is +0, return true.
+			if (x === -0 && y === +0) {
+				return true;
+			}
+			// d. If x is the same Number value as y, return true.
+			if (x === y) {
+				return true;
+			}
+			// e. Return false.
+			return false;
+		}
+		// 3. Return SameValueNonNumber(x, y).
+		return x === y;
+	};
 
+	// 7.4.7. CreateIterResultObject ( value, done )
+	function createIterResultObject(value, done) {
+		// 1. Assert: Type(done) is Boolean.
+		if (typeof done !== 'boolean') {
+			throw new Error();
+		}
+		// 2. Let obj be ObjectCreate(%ObjectPrototype%).
+		var obj = {};
+		// 3. Perform CreateDataProperty(obj, "value", value).
+		obj.value = value;
+		// 4. Perform CreateDataProperty(obj, "done", done).
+		obj.done = done;
+		// 5. Return obj.
+		return obj;
+	}
+	// 9.1.13. OrdinaryCreateFromConstructor ( constructor, intrinsicDefaultProto [ , internalSlotsList ] )
+	var ordinaryCreateFromConstructor = function (constructor, intrinsicDefaultProto) { // eslint-disable-line no-unused-vars
+		var internalSlotsList = arguments[2] || {};
+		/*
+			1. Assert: intrinsicDefaultProto is a String value that is this specification's name of an intrinsic object.
+			The corresponding object must be an intrinsic that is intended to be used as the[[Prototype]] value of an object.
+		*/
+		// Polyfill.io - We ignore the above step and instead pass the intrinsic directly.
+
+		// 2. Let proto be ? GetPrototypeFromConstructor(constructor, intrinsicDefaultProto).
+		// Polyfill.io - We ignore the above step and always use the prototype of the constructor.
+		var proto = Object.getPrototypeOf(constructor);
+
+		// 3. Return ObjectCreate(proto, internalSlotsList).
+		// Polyfill.io - We do not pass internalSlotsList to Object.create because Object.create does use the default ordinary object definitions specified in 9.1.
+		var obj = Object.create(proto);
+		for (var name in internalSlotsList) {
+			if (Object.prototype.hasOwnProperty.call(internalSlotsList, name)) {
+				Object.defineProperty(obj, name, {
+					configurable: true,
+					enumerable: false,
+					writable: true,
+					value: internalSlotsList[name]
+				});
+			}
+		}
+		return obj;
+	};
 
 	// Deleted map items mess with iterator pointers, so rather than removing them mark them as deleted. Can't use undefined or null since those both valid keys so use a private symbol.
 	var undefMarker = Symbol('undef');
-
-	// NaN cannot be found in an array using indexOf, so we encode NaNs using a private symbol.
-	var NaNMarker = Symbol('NaN');
-
-	function encodeKey(key) {
-		return Number.isNaN(key) ? NaNMarker : key;
-	}
-	function decodeKey(encodedKey) {
-		return (encodedKey === NaNMarker) ? NaN : encodedKey;
-	}
-
-	function makeIterator(mapInst, getter) {
-		var nextIdx = 0;
-		var done = false;
-		return {
-			next: function() {
-				if (!mapInst.size || nextIdx === mapInst._keys.length) {
-					done = true;
-				}
-				if (!done) {
-					while (nextIdx <= mapInst._keys.length) {
-						if (mapInst._keys[nextIdx] === undefMarker) {
-							nextIdx++;
-						} else {
-							break;
-						}
-					}
-					if (!mapInst.size || nextIdx === mapInst._keys.length) {
-						return {value: void 0, done:true};
-					}
-					return {value: getter.call(mapInst, nextIdx++), done: false};
-				} else {
-					return {value: void 0, done:true};
-				}
-			}
-		};
-	}
 
 	function hasProtoMethod(instance, method){
 		return typeof instance[method] === 'function';
 	}
 
-	var supportsGetters;
+	var supportsGetters = (function () {
+		try {
+			var a = {};
+			Object.defineProperty(a, 't', {
+				configurable: true,
+				enumerable: false,
+				get: function () {
+					return true;
+				},
+				set: undefined
+			});
+			return !!a.t;
+		} catch (e) {
+			return false;
+		}
+	}());
 
+	var isCallable = function (fn) {
+		return typeof fn === 'function';
+	};
+
+	// 23.1.1.1 Map ( [ iterable ] )
 	var Map = function Map() {
+		// 1. If NewTarget is undefined, throw a TypeError exception.
 		if (!(this instanceof Map)) {
 			throw new TypeError('Constructor Map requires "new"');
 		}
+		// 2. Let map be ? OrdinaryCreateFromConstructor(NewTarget, "%MapPrototype%", « [[MapData]] »).
+		var map = ordinaryCreateFromConstructor(this, "%MapPrototype%", {
+			_keys: [],
+			_values: [],
+			_size: 0,
+			_es6Map: true
+		});
 
-		var data = arguments[0];
-		Object.defineProperty(this, '_keys', {
-			configurable: true,
-			enumerable: false,
-			writable: true,
-			value: []
-		});
-		Object.defineProperty(this, '_values', {
-			configurable: true,
-			enumerable: false,
-			writable: true,
-			value: []
-		});
-		Object.defineProperty(this, '_size', {
-			configurable: true,
-			enumerable: false,
-			writable: true,
-			value: 0
-		});
+		// 3. Set map.[[MapData]] to a new empty List.
+		// Polyfill.io - This step was done as part of step two.
 
 		// Some old engines do not support ES5 getters/setters.  Since Map only requires these for the size property, we can fall back to setting the size property statically each time the size of the map changes.
-		try {
-			Object.defineProperty(Map.prototype, 'size', {
-				configurable: true,
-				enumerable: false,
-				get: function() {
-					return this._size;
-				},
-				set: undefined
-			});
-			Object.defineProperty(this, 'size', {
-				configurable: true,
-				enumerable: false,
-				get: function() {
-					return this._size;
-				},
-				set: undefined
-			});
-			supportsGetters = true;
-		} catch (e) {
-			supportsGetters = false;
-			Object.defineProperty(this, 'size', {
+		if (!supportsGetters) {
+			Object.defineProperty(map, 'size', {
 				configurable: true,
 				enumerable: false,
 				writable: true,
 				value: 0
 			});
 		}
+
+		// 4. If iterable is not present, let iterable be undefined.
+		var data = arguments[0] || undefined;
+
+		// 5. If iterable is either undefined or null, return map.
+		if (data === null || data === undefined) {
+			return map;
+		}
+
+		// 6. Let adder be ? Get(map, "set").
+		var adder = map.set;
+
+		// 7. If IsCallable(adder) is false, throw a TypeError exception.
+		if (!isCallable(adder)) {
+			throw new TypeError("Map.prototype.set is not a function");
+		}
+
+		// 8. Let iteratorRecord be ? GetIterator(iterable).
+		// Polyfill.io - We currently only support iterable objects that have a forEach method.
+
 		// If `data` is iterable (indicated by presence of a forEach method), pre-populate the map
 		if (data && hasProtoMethod(data, 'forEach')){
 			// Fastpath: If `data` is a Map, shortcircuit all following the checks
 			if (data instanceof Map ||
 				// If `data` is not an instance of Map, it could be because you have a Map from an iframe or a worker or something.
-				// Check if  `data` has all the `Map` methods and if so, assume data is another Map
+				// Check if `data` has all the `Map` methods and if so, assume data is another Map
 				hasProtoMethod(data, 'clear') &&
 				hasProtoMethod(data, 'delete') &&
 				hasProtoMethod(data, 'entries') &&
@@ -116,16 +164,20 @@
 				hasProtoMethod(data, 'set') &&
 				hasProtoMethod(data, 'values')){
 				data.forEach(function (value, key) {
-					this.set.apply(this, [key, value]);
-				}, this);
+					map.set.apply(map, [key, value]);
+				}, map);
 			} else {
 				data.forEach(function (item) {
-					this.set.apply(this, item);
-				}, this);
+					map.set.apply(map, item);
+				}, map);
 			}
 		}
+		return map;
 	};
 
+	// 23.1.2.1. Map.prototype
+	// The initial value of Map.prototype is the intrinsic object %MapPrototype%.
+	// This property has the attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: false }.
 	Object.defineProperty(Map, 'prototype', {
 		configurable: false,
 		enumerable: false,
@@ -133,137 +185,18 @@
 		value: {}
 	});
 
-	Object.defineProperty(Map.prototype, 'get', {
-		configurable: true,
-		enumerable: false,
-		writable: true,
-		value: function get (key) {
-			var idx = this._keys.indexOf(encodeKey(key));
-			return (idx !== -1) ? this._values[idx] : undefined;
-		}
-	});
-	Object.defineProperty(Map.prototype, 'set', {
-		configurable: true,
-		enumerable: false,
-		writable: true,
-		value: function set (key, value) {
-			var idx = this._keys.indexOf(encodeKey(key));
-			if (idx !== -1) {
-				this._values[idx] = value;
-			} else {
-				this._keys.push(encodeKey(key));
-				this._values.push(value);
-				++this._size;
-				if (!supportsGetters) {
-					this.size = this._size;
-				}
-			}
-			return this;
-		}
-	});
-	Object.defineProperty(Map.prototype, 'has', {
-		configurable: true,
-		enumerable: false,
-		writable: true,
-		value: function has (key) {
-			return (this._keys.indexOf(encodeKey(key)) !== -1);
-		}
-	});
-	Object.defineProperty(Map.prototype, 'delete', {
-		configurable: true,
-		enumerable: false,
-		writable: true,
-		value: function (key) {
-			var idx = this._keys.indexOf(encodeKey(key));
-			if (idx === -1) return false;
-			this._keys[idx] = undefMarker;
-			this._values[idx] = undefMarker;
-			--this._size;
-			if (!supportsGetters) {
-				this.size = this._size;
-			}
-			return true;
-		}
-	});
-	Object.defineProperty(Map.prototype, 'clear', {
-		configurable: true,
-		enumerable: false,
-		writable: true,
-		value: function clear () {
-			this._keys = [];
-			this._values = [];
-			this._size = 0;
-			if (!supportsGetters) {
-				this.size = this._size;
-			}
-		}
-	});
-	Object.defineProperty(Map.prototype, 'values', {
-		configurable: true,
-		enumerable: false,
-		writable: true,
-		value: function values () {
-			var iterator = makeIterator(this, function(i) { return this._values[i]; });
-			iterator[Symbol.iterator] = this.values.bind(this);
-			return iterator;
-		}
-	});
-	Object.defineProperty(Map.prototype, 'keys', {
-		configurable: true,
-		enumerable: false,
-		writable: true,
-		value: function keys () {
-			var iterator = makeIterator(this, function(i) { return decodeKey(this._keys[i]); });
-			iterator[Symbol.iterator] = this.keys.bind(this);
-			return iterator;
-		}
-	});
-	var entries = function entries () {
-		var iterator = makeIterator(this, function(i) { return [decodeKey(this._keys[i]), this._values[i]]; });
-		iterator[Symbol.iterator] = this.entries.bind(this);
-		return iterator;
-	};
-	Object.defineProperty(Map.prototype, Symbol.iterator, {
-		configurable: true,
-		enumerable: false,
-		writable: true,
-		value: entries
-	});
-	Object.defineProperty(Map.prototype, 'entries', {
-		configurable: true,
-		enumerable: false,
-		writable: true,
-		value: entries
-	});
-	Object.defineProperty(Map.prototype, 'forEach', {
-		configurable: true,
-		enumerable: false,
-		writable: true,
-		value: function(callbackFn, thisArg) {
-			thisArg = thisArg || global;
-			var iterator = this.entries();
-			var result = iterator.next();
-			while (result.done === false) {
-				callbackFn.call(thisArg, result.value[1], result.value[0], this);
-				result = iterator.next();
-			}
-		}
-	});
-	Object.defineProperty(Map.prototype, 'constructor', {
-		configurable: true,
-		enumerable: false,
-		writable: true,
-		value: Map
-	});
-	try {
+	// 23.1.2.2 get Map [ @@species ]
+	if (supportsGetters) {
 		Object.defineProperty(Map, Symbol.species, {
 			configurable: true,
 			enumerable: false,
-			get: function get() {
-				return Map;
-			}
+			get: function () {
+				// 1. Return the this value.
+				return this;
+			},
+			set: undefined
 		});
-	} catch (e) {
+	} else {
 		Object.defineProperty(Map, Symbol.species, {
 			configurable: true,
 			enumerable: false,
@@ -271,6 +204,322 @@
 			value: Map
 		});
 	}
+
+	// 23.1.3.1 Map.prototype.clear ( )
+	Object.defineProperty(Map.prototype, 'clear', {
+		configurable: true,
+		enumerable: false,
+		writable: true,
+		value: function clear() {
+			// 1. Let M be the this value.
+			var M = this;
+			// 2. If Type(M) is not Object, throw a TypeError exception.
+			if (typeof M !== 'object') {
+				throw new TypeError('Method Map.prototype.clear called on incompatible receiver ' + Object.prototype.toString.call(M));
+			}
+			// 3. If M does not have a [[MapData]] internal slot, throw a TypeError exception.
+			if (M._es6Map !== true) {
+				throw new TypeError('Method Map.prototype.clear called on incompatible receiver ' + Object.prototype.toString.call(M));
+			}
+			// 4. Let entries be the List that is M.[[MapData]].
+			var entries = M._keys;
+			// 5. For each Record {[[Key]], [[Value]]} p that is an element of entries, do
+			for (var i = 0; i < entries.length; i++) {
+				// 5.a. Set p.[[Key]] to empty.
+				M._keys[i] = undefMarker;
+				// 5.b. Set p.[[Value]] to empty.
+				M._values[i] = undefMarker;
+			}
+			this._size = 0;
+			if (!supportsGetters) {
+				this.size = this._size;
+			}
+			// 6. Return undefined.
+			return undefined;
+		}
+	});
+
+	// 23.1.3.2. Map.prototype.constructor
+	Object.defineProperty(Map.prototype, 'constructor', {
+		configurable: true,
+		enumerable: false,
+		writable: true,
+		value: Map
+	});
+
+	// 23.1.3.3. Map.prototype.delete ( key )
+	Object.defineProperty(Map.prototype, 'delete', {
+		configurable: true,
+		enumerable: false,
+		writable: true,
+		value: function (key) {
+			// 1. Let M be the this value.
+			var M = this;
+			// 2. If Type(M) is not Object, throw a TypeError exception.
+			if (typeof M !== 'object') {
+				throw new TypeError('Method Map.prototype.clear called on incompatible receiver ' + Object.prototype.toString.call(M));
+			}
+			// 3. If M does not have a [[MapData]] internal slot, throw a TypeError exception.
+			if (M._es6Map !== true) {
+				throw new TypeError('Method Map.prototype.clear called on incompatible receiver ' + Object.prototype.toString.call(M));
+			}
+			// 4. Let entries be the List that is M.[[MapData]].
+			var entries = M._keys;
+			// 5. For each Record {[[Key]], [[Value]]} p that is an element of entries, do
+			for (var i = 0; i < entries.length; i++) {
+				// a. If p.[[Key]] is not empty and SameValueZero(p.[[Key]], key) is true, then
+				if (M._keys[i] !== undefMarker && sameValueZero(M._keys[i], key)) {
+					// i. Set p.[[Key]] to empty.
+					this._keys[i] = undefMarker;
+					// ii. Set p.[[Value]] to empty.
+					this._values[i] = undefMarker;
+					--this._size;
+					if (!supportsGetters) {
+						this.size = this._size;
+					}
+					// iii. Return true.
+					return true;
+				}
+			}
+			// 6. Return false.
+			return false;
+		}
+	});
+
+	// 23.1.3.4. Map.prototype.entries ( )
+	Object.defineProperty(Map.prototype, 'entries', {
+		configurable: true,
+		enumerable: false,
+		writable: true,
+		value: function entries () {
+			// 1. Let M be the this value.
+			var M = this;
+			// 2. Return ? CreateMapIterator(M, "key+value").
+			return createMapIterator(M, 'key+value');
+		}
+	});
+
+	// 23.1.3.5. Map.prototype.forEach ( callbackfn [ , thisArg ] )
+	Object.defineProperty(Map.prototype, 'forEach', {
+		configurable: true,
+		enumerable: false,
+		writable: true,
+		value: function (callbackFn) {
+			// 1. Let M be the this value.
+			var M = this;
+			// 2. If Type(M) is not Object, throw a TypeError exception.
+			if (typeof M !== 'object') {
+				throw new TypeError('Method Map.prototype.forEach called on incompatible receiver ' + Object.prototype.toString.call(M));
+			}
+			// 3. If M does not have a [[MapData]] internal slot, throw a TypeError exception.
+			if (M._es6Map !== true) {
+				throw new TypeError('Method Map.prototype.forEach called on incompatible receiver ' + Object.prototype.toString.call(M));
+			}
+			// 4. If IsCallable(callbackfn) is false, throw a TypeError exception.
+			if (!isCallable(callbackFn)) {
+				throw new TypeError(Object.prototype.toString.call(callbackFn) + ' is not a function.');
+			}
+			// 5. If thisArg is present, let T be thisArg; else let T be undefined.
+			if (arguments[1]) {
+				var T = arguments[1];
+			}
+			// 6. Let entries be the List that is M.[[MapData]].
+			var entries = M._keys;
+			// 7. For each Record {[[Key]], [[Value]]} e that is an element of entries, in original key insertion order, do
+			for (var i = 0; i < entries.length; i++) {
+				// a. If e.[[Key]] is not empty, then
+				if (M._keys[i] !== undefMarker && M._values[i] !== undefMarker ) {
+					// i. Perform ? Call(callbackfn, T, « e.[[Value]], e.[[Key]], M »).
+					callbackFn.call(T, M._values[i], M._keys[i], M);
+				}
+			}
+			// 8. Return undefined.
+			return undefined;
+		}
+	});
+
+	// 23.1.3.6. Map.prototype.get ( key )
+	Object.defineProperty(Map.prototype, 'get', {
+		configurable: true,
+		enumerable: false,
+		writable: true,
+		value: function get(key) {
+			// 1. Let M be the this value.
+			var M = this;
+			// 2. If Type(M) is not Object, throw a TypeError exception.
+			if (typeof M !== 'object') {
+				throw new TypeError('Method Map.prototype.get called on incompatible receiver ' + Object.prototype.toString.call(M));
+			}
+			// 3. If M does not have a [[MapData]] internal slot, throw a TypeError exception.
+			if (M._es6Map !== true) {
+				throw new TypeError('Method Map.prototype.get called on incompatible receiver ' + Object.prototype.toString.call(M));
+			}
+			// 4. Let entries be the List that is M.[[MapData]].
+			var entries = M._keys;
+			// 5. For each Record {[[Key]], [[Value]]} p that is an element of entries, do
+			for (var i = 0; i < entries.length; i++) {
+				// a. If p.[[Key]] is not empty and SameValueZero(p.[[Key]], key) is true, return p.[[Value]].
+				if (M._keys[i] !== undefMarker && sameValueZero(M._keys[i], key)) {
+					return M._values[i];
+				}
+			}
+			// 6. Return undefined.
+			return undefined;
+		}
+	});
+
+	// 23.1.3.7. Map.prototype.has ( key )
+	Object.defineProperty(Map.prototype, 'has', {
+		configurable: true,
+		enumerable: false,
+		writable: true,
+		value: function has (key) {
+			// 1. Let M be the this value.
+			var M = this;
+			// 2. If Type(M) is not Object, throw a TypeError exception.
+			if (typeof M !== 'object') {
+				throw new TypeError('Method Map.prototype.has called on incompatible receiver ' + Object.prototype.toString.call(M));
+			}
+			// 3. If M does not have a [[MapData]] internal slot, throw a TypeError exception.
+			if (M._es6Map !== true) {
+				throw new TypeError('Method Map.prototype.has called on incompatible receiver ' + Object.prototype.toString.call(M));
+			}
+			// 4. Let entries be the List that is M.[[MapData]].
+			var entries = M._keys;
+			// 5. For each Record {[[Key]], [[Value]]} p that is an element of entries, do
+			for (var i = 0; i < entries.length; i++) {
+				// a. If p.[[Key]] is not empty and SameValueZero(p.[[Key]], key) is true, return true.
+				if (M._keys[i] !== undefMarker && sameValueZero(M._keys[i], key)) {
+					return true;
+				}
+			}
+			// 6. Return false.
+			return false;
+		}
+	});
+
+	// 23.1.3.8. Map.prototype.keys ( )
+	Object.defineProperty(Map.prototype, 'keys', {
+		configurable: true,
+		enumerable: false,
+		writable: true,
+		value: function keys () {
+			// 1. Let M be the this value.
+			var M = this;
+			// 2. Return ? CreateMapIterator(M, "key").
+			return createMapIterator(M, "key");
+		}
+	});
+
+	// 23.1.3.9. Map.prototype.set ( key, value )
+	Object.defineProperty(Map.prototype, 'set', {
+		configurable: true,
+		enumerable: false,
+		writable: true,
+		value: function set(key, value) {
+			// 1. Let M be the this value.
+			var M = this;
+			// 2. If Type(M) is not Object, throw a TypeError exception.
+			if (typeof M !== 'object') {
+				throw new TypeError('Method Map.prototype.set called on incompatible receiver ' + Object.prototype.toString.call(M));
+			}
+			// 3. If M does not have a [[MapData]] internal slot, throw a TypeError exception.
+			if (M._es6Map !== true) {
+				throw new TypeError('Method Map.prototype.set called on incompatible receiver ' + Object.prototype.toString.call(M));
+			}
+			// 4. Let entries be the List that is M.[[MapData]].
+			var entries = M._keys;
+			// 5. For each Record {[[Key]], [[Value]]} p that is an element of entries, do
+			for (var i = 0; i < entries.length; i++) {
+				// a. If p.[[Key]] is not empty and SameValueZero(p.[[Key]], key) is true, then
+				if (M._keys[i] !== undefMarker && sameValueZero(M._keys[i], key)) {
+					// i. Set p.[[Value]] to value.
+					M._values[i] = value;
+					// Return M.
+					return M;
+				}
+			}
+			// 6. If key is -0, let key be +0.
+			if (key === -0) {
+				key = 0;
+			}
+			// 7. Let p be the Record {[[Key]]: key, [[Value]]: value}.
+			var p = {};
+			p['[[Key]]'] = key;
+			p['[[Value]]'] = value;
+			// 8. Append p as the last element of entries.
+			M._keys.push(p['[[Key]]']);
+			M._values.push(p['[[Value]]']);
+			++M._size;
+			if (!supportsGetters) {
+				M.size = M._size;
+			}
+			// 9. Return M.
+			return M;
+		}
+	});
+
+	// 23.1.3.10. get Map.prototype.size
+	if (supportsGetters) {
+		Object.defineProperty(Map.prototype, 'size', {
+			configurable: true,
+			enumerable: false,
+			get: function () {
+				// 1. Let M be the this value.
+				var M = this;
+				// 2. If Type(M) is not Object, throw a TypeError exception.
+				if (typeof M !== 'object') {
+					throw new TypeError('Method Map.prototype.size called on incompatible receiver ' + Object.prototype.toString.call(M));
+				}
+				// 3. If M does not have a [[MapData]] internal slot, throw a TypeError exception.
+				if (M._es6Map !== true) {
+					throw new TypeError('Method Map.prototype.size called on incompatible receiver ' + Object.prototype.toString.call(M));
+				}
+				// 4. Let entries be the List that is M.[[MapData]].
+				var entries = M._keys;
+				// 5. Let count be 0.
+				var count = 0;
+				// 6. For each Record {[[Key]], [[Value]]} p that is an element of entries, do
+				for (var i = 0; i < entries.length; i++) {
+					// a. If p.[[Key]] is not empty, set count to count+1.
+					if (M._keys[i] !== undefMarker) {
+						count = count + 1;
+					}
+				}
+				// 7. Return count.
+				return count;
+			},
+			set: undefined
+		});
+	}
+
+	// 23.1.3.11. Map.prototype.values ( )
+	Object.defineProperty(Map.prototype, 'values', {
+		configurable: true,
+		enumerable: false,
+		writable: true,
+		value: function values () {
+			// 1. Let M be the this value.
+			var M = this;
+			// 2. Return ? CreateMapIterator(M, "value").
+			return createMapIterator(M, 'value');
+		}
+	});
+
+	// 23.1.3.12. Map.prototype [ @@iterator ] ( )
+	// The initial value of the @@iterator property is the same function object as the initial value of the entries property.
+	Object.defineProperty(Map.prototype, Symbol.iterator, {
+		configurable: true,
+		enumerable: false,
+		writable: true,
+		value: Map.prototype.entries
+	});
+
+	// 23.1.3.13. Map.prototype [ @@toStringTag ]
+	// The initial value of the @@toStringTag property is the String value "Map".
+	// This property has the attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }.
+
+	// 19.2.4.2 name
 	Object.defineProperty(Map, 'name', {
 		configurable: true,
 		enumerable: false,
@@ -278,12 +527,141 @@
 		value: 'Map'
 	});
 
-	// Export the object
-	Object.defineProperty(global, 'Map', {
+	// 23.1.5.1. CreateMapIterator ( map, kind )
+	function createMapIterator(map, kind) {
+		// 1. If Type(map) is not Object, throw a TypeError exception.
+		if (typeof map !== 'object') {
+			throw new TypeError('createMapIterator called on incompatible receiver ' + Object.prototype.toString.call(map));
+		}
+		// 2. If map does not have a [[MapData]] internal slot, throw a TypeError exception.
+		if (map._es6Map !== true) {
+			throw new TypeError('createMapIterator called on incompatible receiver ' + Object.prototype.toString.call(map));
+		}
+		// 3. Let iterator be ObjectCreate(%MapIteratorPrototype%, « [[Map]], [[MapNextIndex]], [[MapIterationKind]] »).
+		var iterator = Object.create(MapIteratorPrototype);
+		// 4. Set iterator.[[Map]] to map.
+		Object.defineProperty(iterator, '[[Map]]', {
+			configurable: true,
+			enumerable: false,
+			writable: true,
+			value: map
+		});
+		// 5. Set iterator.[[MapNextIndex]] to 0.
+		Object.defineProperty(iterator, '[[MapNextIndex]]', {
+			configurable: true,
+			enumerable: false,
+			writable: true,
+			value: 0
+		});
+		// 6. Set iterator.[[MapIterationKind]] to kind.
+		Object.defineProperty(iterator, '[[MapIterationKind]]', {
+			configurable: true,
+			enumerable: false,
+			writable: true,
+			value: kind
+		});
+		// 7. Return iterator.
+		return iterator;
+	}
+
+	// 23.1.5.2. The %MapIteratorPrototype% Object
+	var MapIteratorPrototype = {
+		// Polyfill.io - We use this as a quick way to check if an object is a Map Iterator instance.
+		isMapIterator: true,
+		// 23.1.5.2.1. %MapIteratorPrototype%.next ( )
+		next: function next () {
+			// 1. Let O be the this value.
+			var O = this;
+			// 2. If Type(O) is not Object, throw a TypeError exception.
+			if (typeof O !== 'object') {
+				throw new TypeError('Method %MapIteratorPrototype%.next called on incompatible receiver ' + Object.prototype.toString.call(O));
+			}
+			// 3. If O does not have all of the internal slots of a Map Iterator Instance (23.1.5.3), throw a TypeError exception.
+			if (!O.isMapIterator) {
+				throw new TypeError('Method %MapIteratorPrototype%.next called on incompatible receiver ' + Object.prototype.toString.call(O));
+			}
+			// 4. Let m be O.[[Map]].
+			var m = O['[[Map]]'];
+			// 5. Let index be O.[[MapNextIndex]].
+			var index = O['[[MapNextIndex]]'];
+			// 6. Let itemKind be O.[[MapIterationKind]].
+			var itemKind = O['[[MapIterationKind]]'];
+			// 7. If m is undefined, return CreateIterResultObject(undefined, true).
+			if (m === undefined) {
+				return createIterResultObject(undefined, true);
+			}
+			// 8. Assert: m has a [[MapData]] internal slot.
+			if (!m._es6Map) {
+				throw new Error();
+			}
+			// 9. Let entries be the List that is m.[[MapData]].
+			var entries = m._keys;
+			// 10. Let numEntries be the number of elements of entries.
+			var numEntries = entries.length;
+			// 11. NOTE: numEntries must be redetermined each time this method is evaluated.
+			// 12. Repeat, while index is less than numEntries,
+			while (index < numEntries) {
+				// a. Let e be the Record {[[Key]], [[Value]]} that is the value of entries[index].
+				var e = Object.create(null);
+				e['[[Key]]'] = m._keys[index];
+				e['[[Value]]'] = m._values[index];
+				// b. Set index to index+1.
+				index = index + 1;
+				// c. Set O.[[MapNextIndex]] to index.
+				O['[[MapNextIndex]]'] = index;
+				// d. If e.[[Key]] is not empty, then
+				if (e['[[Key]]'] !== undefMarker) {
+					// i. If itemKind is "key", let result be e.[[Key]].
+					if (itemKind === 'key') {
+						var result = e['[[Key]]'];
+					// ii. Else if itemKind is "value", let result be e.[[Value]].
+					} else if (itemKind === 'value') {
+						var result = e['[[Value]]'];
+					// iii. Else,
+					} else {
+						// 1. Assert: itemKind is "key+value".
+						if (itemKind !== 'key+value') {
+							throw new Error();
+						}
+						// 2. Let result be CreateArrayFromList(« e.[[Key]], e.[[Value]] »).
+						var result = [
+							e['[[Key]]'],
+							e['[[Value]]']
+						];
+					}
+					// iv. Return CreateIterResultObject(result, false).
+					return createIterResultObject(result, false);
+				}
+			}
+			// 13. Set O.[[Map]] to undefined.
+			O['[[Map]]'] = undefined;
+			// 14. Return CreateIterResultObject(undefined, true).
+			return createIterResultObject(undefined, true);
+		}
+
+		// 23.1.5.2.2 %MapIteratorPrototype% [ @@toStringTag ]
+    // The initial value of the @@toStringTag property is the String value "Map Iterator".
+		// This property has the attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }.
+	};
+	Object.defineProperty(MapIteratorPrototype, Symbol.iterator, {
 		configurable: true,
 		enumerable: false,
 		writable: true,
-		value: Map
+		value: function iterator() {
+			return this;
+		}
 	});
 
+	// Export the object
+	try {
+		Object.defineProperty(global, 'Map', {
+			configurable: true,
+			enumerable: false,
+			writable: true,
+			value: Map
+		});
+	} catch (e) {
+		// IE 8 and lower do not like non-enumerable properties to be set on the global object for some reason.
+		global['Map'] = Map;
+	}
 }(this));

--- a/polyfills/Map/polyfill.js
+++ b/polyfills/Map/polyfill.js
@@ -317,7 +317,10 @@
 			}
 		} catch (e) {
 			// Polyfill.io - For user agents which do not have iteration methods on argument objects or arrays, we can special case those.
-			if (Array.isArray(iterable) || Object.prototype.toString.call(iterable) === '[object Arguments]') {
+			if (Array.isArray(iterable) ||
+				Object.prototype.toString.call(iterable) === '[object Arguments]' ||
+				// IE 7 & IE 8 return '[object Object]' for the arguments object, we can detect by checking for the existence of the callee property
+				(!!iterable.callee)) {
 				var index;
 				var length = iterable.length;
 				for (index = 0; index < length; index++) {

--- a/polyfills/Map/polyfill.js
+++ b/polyfills/Map/polyfill.js
@@ -519,13 +519,16 @@
 	// The initial value of the @@toStringTag property is the String value "Map".
 	// This property has the attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }.
 
-	// 19.2.4.2 name
-	Object.defineProperty(Map, 'name', {
-		configurable: true,
-		enumerable: false,
-		writable: false,
-		value: 'Map'
-	});
+	// Polyfill.io - Safari 8 implements Map.name but as a non-configurable property, which means it would throw an error if we try and configure it here.
+	if (!('name' in Map)) {
+		// 19.2.4.2 name
+		Object.defineProperty(Map, 'name', {
+			configurable: true,
+			enumerable: false,
+			writable: false,
+			value: 'Map'
+		});
+	}
 
 	// 23.1.5.1. CreateMapIterator ( map, kind )
 	function createMapIterator(map, kind) {

--- a/polyfills/Map/polyfill.js
+++ b/polyfills/Map/polyfill.js
@@ -71,7 +71,7 @@
 		// Some old engines do not support ES5 getters/setters.  Since Map only requires these for the size property, we can fall back to setting the size property statically each time the size of the map changes.
 		try {
 			Object.defineProperty(Map.prototype, 'size', {
-				configure: true,
+				configurable: true,
 				enumerable: false,
 				get: function() {
 					return this._size;
@@ -79,7 +79,7 @@
 				set: undefined
 			});
 			Object.defineProperty(this, 'size', {
-				configure: true,
+				configurable: true,
 				enumerable: false,
 				get: function() {
 					return this._size;

--- a/polyfills/Map/polyfill.js
+++ b/polyfills/Map/polyfill.js
@@ -48,6 +48,10 @@
 	var supportsGetters;
 
 	var Map = function Map() {
+		if (!(this instanceof Map)) {
+			throw new TypeError('Constructor Map requires "new"');
+		}
+
 		var data = arguments[0];
 		Object.defineProperty(this, '_keys', {
 			configurable: true,

--- a/polyfills/Map/tests.js
+++ b/polyfills/Map/tests.js
@@ -1,7 +1,208 @@
 /* eslint-env mocha, browser */
 /* global proclaim */
+var arePropertyDescriptorsSupported = function() {
+	var obj = {};
+	try {
+		Object.defineProperty(obj, 'x', {
+			enumerable: false,
+			value: obj
+		});
+		/* eslint-disable no-unused-vars, no-restricted-syntax */
+		for (var _ in obj) {
+			return false;
+		}
+		/* eslint-enable no-unused-vars, no-restricted-syntax */
+		return obj.x === obj;
+	} catch (e) { // this is IE 8.
+		return false;
+	}
+};
 
-describe('Map', function() {
+var supportsDescriptors = Object.defineProperty && arePropertyDescriptorsSupported();
+
+describe('Map', function () {
+
+	if (supportsDescriptors) {
+		it('has no enumerable properties on the prototype', function () {
+			for (var _ in Map.prototype) {
+				proclaim.isTrue(false, 'Expected no enumerable properties, found ' + _ + ' was enumerable');
+			}
+		});
+
+		it('has no enumerable properties on the instance', function () {
+			var o = new Map();
+			for (var _ in o) {
+				proclaim.isTrue(false, 'Expected no enumerable properties, found ' + _ + ' was enumerable');
+			}
+		});
+
+		var hasGetOwnPropertyDescriptor = 'getOwnPropertyDescriptor' in Object && typeof Object.getOwnPropertyDescriptor === 'function';
+		if (hasGetOwnPropertyDescriptor) {
+			it('has correct descriptors defined for Map', function () {
+				var descriptor = Object.getOwnPropertyDescriptor(window, 'Map');
+
+				proclaim.isTrue(descriptor.configurable);
+				proclaim.isFalse(descriptor.enumerable);
+				proclaim.isTrue(descriptor.writable);
+				proclaim.doesNotInclude(descriptor, 'get');
+				proclaim.doesNotInclude(descriptor, 'set');
+				proclaim.ok(descriptor.value);
+			});
+			it('has correct descriptors defined for Map.name', function () {
+				var descriptor = Object.getOwnPropertyDescriptor(Map, 'name');
+
+				proclaim.isTrue(descriptor.configurable);
+				proclaim.isFalse(descriptor.enumerable);
+				proclaim.isFalse(descriptor.writable);
+				proclaim.doesNotInclude(descriptor, 'get');
+				proclaim.doesNotInclude(descriptor, 'set');
+				proclaim.ok(descriptor.value);
+			});
+			it('has correct descriptors defined for Map.prototype', function () {
+				var descriptor = Object.getOwnPropertyDescriptor(Map, 'prototype');
+
+				proclaim.isFalse(descriptor.configurable);
+				proclaim.isFalse(descriptor.enumerable);
+				proclaim.isFalse(descriptor.writable);
+				proclaim.doesNotInclude(descriptor, 'get');
+				proclaim.doesNotInclude(descriptor, 'set');
+				proclaim.ok(descriptor.value);
+			});
+			it('has correct descriptors defined for Map.prototype.size', function () {
+				var descriptor = Object.getOwnPropertyDescriptor(Map.prototype, 'size');
+
+				proclaim.isTrue(descriptor.configurable, 'a' + descriptor.configurable);
+				proclaim.isFalse(descriptor.enumerable);
+				proclaim.doesNotInclude(descriptor.writable);
+				proclaim.ok(descriptor.get);
+				proclaim.isUndefined(descriptor.set);
+				proclaim.include(descriptor, 'set');
+				proclaim.doesNotInclude(descriptor, 'value');
+			});
+			it('has correct descriptors defined for Map.prototype.get', function () {
+				var descriptor = Object.getOwnPropertyDescriptor(Map.prototype, 'get');
+
+				proclaim.isTrue(descriptor.configurable);
+				proclaim.isFalse(descriptor.enumerable);
+				proclaim.isTrue(descriptor.writable);
+				proclaim.doesNotInclude(descriptor, 'get');
+				proclaim.doesNotInclude(descriptor, 'set');
+				proclaim.ok(descriptor.value);
+			});
+			it('has correct descriptors defined for Map.prototype.set', function () {
+				var descriptor = Object.getOwnPropertyDescriptor(Map.prototype, 'set');
+
+				proclaim.isTrue(descriptor.configurable);
+				proclaim.isFalse(descriptor.enumerable);
+				proclaim.isTrue(descriptor.writable);
+				proclaim.doesNotInclude(descriptor, 'get');
+				proclaim.doesNotInclude(descriptor, 'set');
+				proclaim.ok(descriptor.value);
+			});
+			it('has correct descriptors defined for Map.prototype.has', function () {
+				var descriptor = Object.getOwnPropertyDescriptor(Map.prototype, 'has');
+
+				proclaim.isTrue(descriptor.configurable);
+				proclaim.isFalse(descriptor.enumerable);
+				proclaim.isTrue(descriptor.writable);
+				proclaim.doesNotInclude(descriptor, 'get');
+				proclaim.doesNotInclude(descriptor, 'set');
+				proclaim.ok(descriptor.value);
+			});
+			it('has correct descriptors defined for Map.prototype.delete', function () {
+				var descriptor = Object.getOwnPropertyDescriptor(Map.prototype, 'delete');
+
+				proclaim.isTrue(descriptor.configurable);
+				proclaim.isFalse(descriptor.enumerable);
+				proclaim.isTrue(descriptor.writable);
+				proclaim.doesNotInclude(descriptor, 'get');
+				proclaim.doesNotInclude(descriptor, 'set');
+				proclaim.ok(descriptor.value);
+			});
+			it('has correct descriptors defined for Map.prototype.clear', function () {
+				var descriptor = Object.getOwnPropertyDescriptor(Map.prototype, 'clear');
+
+				proclaim.isTrue(descriptor.configurable);
+				proclaim.isFalse(descriptor.enumerable);
+				proclaim.isTrue(descriptor.writable);
+				proclaim.doesNotInclude(descriptor, 'get');
+				proclaim.doesNotInclude(descriptor, 'set');
+				proclaim.ok(descriptor.value);
+			});
+			it('has correct descriptors defined for Map.prototype.values', function () {
+				var descriptor = Object.getOwnPropertyDescriptor(Map.prototype, 'values');
+
+				proclaim.isTrue(descriptor.configurable);
+				proclaim.isFalse(descriptor.enumerable);
+				proclaim.isTrue(descriptor.writable);
+				proclaim.doesNotInclude(descriptor, 'get');
+				proclaim.doesNotInclude(descriptor, 'set');
+				proclaim.ok(descriptor.value);
+			});
+			it('has correct descriptors defined for Map.prototype.keys', function () {
+				var descriptor = Object.getOwnPropertyDescriptor(Map.prototype, 'keys');
+
+				proclaim.isTrue(descriptor.configurable);
+				proclaim.isFalse(descriptor.enumerable);
+				proclaim.isTrue(descriptor.writable);
+				proclaim.doesNotInclude(descriptor, 'get');
+				proclaim.doesNotInclude(descriptor, 'set');
+				proclaim.ok(descriptor.value);
+			});
+			it('has correct descriptors defined for Map.prototype[Symbol.iterator]', function () {
+				var descriptor = Object.getOwnPropertyDescriptor(Map.prototype, Symbol.iterator);
+
+				proclaim.isTrue(descriptor.configurable);
+				proclaim.isFalse(descriptor.enumerable);
+				proclaim.isTrue(descriptor.writable);
+				proclaim.doesNotInclude(descriptor, 'get');
+				proclaim.doesNotInclude(descriptor, 'set');
+				proclaim.ok(descriptor.value);
+			});
+			it('has correct descriptors defined for Map.prototype.entries', function () {
+				var descriptor = Object.getOwnPropertyDescriptor(Map.prototype, 'entries');
+
+				proclaim.isTrue(descriptor.configurable);
+				proclaim.isFalse(descriptor.enumerable);
+				proclaim.isTrue(descriptor.writable);
+				proclaim.doesNotInclude(descriptor, 'get');
+				proclaim.doesNotInclude(descriptor, 'set');
+				proclaim.ok(descriptor.value);
+			});
+			it('has correct descriptors defined for Map.prototype.forEach', function () {
+				var descriptor = Object.getOwnPropertyDescriptor(Map.prototype, 'forEach');
+
+				proclaim.isTrue(descriptor.configurable);
+				proclaim.isFalse(descriptor.enumerable);
+				proclaim.isTrue(descriptor.writable);
+				proclaim.doesNotInclude(descriptor, 'get');
+				proclaim.doesNotInclude(descriptor, 'set');
+				proclaim.ok(descriptor.value);
+			});
+			it('has correct descriptors defined for Map.prototype.constructor', function () {
+				var descriptor = Object.getOwnPropertyDescriptor(Map.prototype, 'constructor');
+
+				proclaim.isTrue(descriptor.configurable);
+				proclaim.isFalse(descriptor.enumerable);
+				proclaim.isTrue(descriptor.writable);
+				proclaim.doesNotInclude(descriptor, 'get');
+				proclaim.doesNotInclude(descriptor, 'set');
+				proclaim.ok(descriptor.value);
+			});
+			it('has correct descriptors defined for Map[Symbol.species]', function () {
+				var descriptor = Object.getOwnPropertyDescriptor(Map, Symbol.species);
+
+				proclaim.isTrue(descriptor.configurable);
+				proclaim.isFalse(descriptor.enumerable);
+				proclaim.doesNotInclude(descriptor, 'writable');
+				proclaim.include(descriptor, 'get');
+				proclaim.include(descriptor, 'set');
+				proclaim.isUndefined(descriptor.set);
+				proclaim.doesNotInclude(descriptor, 'value');
+			});
+		}
+	}
+
 	it("has valid constructor", function () {
 		proclaim.isInstanceOf(new Map, Map);
 		proclaim.isInstanceOf(new Map(), Map);
@@ -172,9 +373,7 @@ describe('Map', function() {
 
 		it("implements iterable for all iterators", function () {
 			var o = new Map([["1", 1], ["2", 2], ["3", 3]]);
-			var valuesIteratorFactory = o.values()[Symbol.iterator];
-			proclaim.isFunction(valuesIteratorFactory);
-			var valuesIterator = valuesIteratorFactory();
+			var valuesIterator = o.values()[Symbol.iterator]();
 			proclaim.isObject(valuesIterator);
 			var v = valuesIterator.next();
 			proclaim.equal(v.value, 1);
@@ -185,9 +384,7 @@ describe('Map', function() {
 			v = valuesIterator.next();
 			proclaim.equal(v.done, true);
 
-			var keysIteratorFactory = o.keys()[Symbol.iterator];
-			proclaim.isFunction(keysIteratorFactory);
-			var keysIterator = keysIteratorFactory();
+			var keysIterator = o.keys()[Symbol.iterator]();
 			proclaim.isObject(keysIterator);
 			var k = keysIterator.next();
 			proclaim.equal(k.value, "1");
@@ -198,9 +395,7 @@ describe('Map', function() {
 			k = keysIterator.next();
 			proclaim.equal(k.done, true);
 
-			var entriesIteratorFactory = o.entries()[Symbol.iterator];
-			proclaim.isFunction(entriesIteratorFactory);
-			var entriesIterator = entriesIteratorFactory();
+			var entriesIterator = o.entries()[Symbol.iterator]();
 			proclaim.isObject(entriesIterator);
 			var e = entriesIterator.next();
 			proclaim.deepEqual(e.value, [1,"1"]);

--- a/polyfills/Map/tests.js
+++ b/polyfills/Map/tests.js
@@ -230,7 +230,7 @@ describe('Map', function () {
 			}
 		});
 
-		it ("can be pre-populated", function() {
+		it("can be pre-populated with an array", function() {
 			var a = 1;
 			var b = {};
 			var c = new Map();
@@ -246,6 +246,52 @@ describe('Map', function () {
 			proclaim.equal(d.has(c), true);
 			proclaim.equal(d.size, 3);
 		});
+
+		it("can be pre-populated with the arguments object", function() {
+			var a = 1;
+			var b = {};
+			var c = new Map();
+			var m = (function () {
+				return new Map(arguments);
+			}([1, 1], [b, 2], [c, 3]));
+			proclaim.equal(m.has(a), true);
+			proclaim.equal(m.has(b), true);
+			proclaim.equal(m.has(c), true);
+			proclaim.equal(m.size, 3);
+
+			var d = new Map(m);
+			proclaim.equal(d.has(a), true);
+			proclaim.equal(d.has(b), true);
+			proclaim.equal(d.has(c), true);
+			proclaim.equal(d.size, 3);
+		});
+
+		if ('Symbol' in window && 'iterator' in Symbol) {
+			it("can be pre-populated with custom iterable", function () {
+				var count = 0;
+				var a = {};
+				a[Symbol.iterator] = function () {
+					return {
+						next: function () {
+							if (count === 5) {
+								return { done: true };
+							}
+							return {
+								done: false,
+								value: [count, count++]
+							};
+						}
+					};
+				};
+				var m = new Map(a);
+				proclaim.equal(m.has(0), true, 'a');
+				proclaim.equal(m.has(1), true, 'b');
+				proclaim.equal(m.has(2), true, 'c');
+				proclaim.equal(m.has(3), true, 'd');
+				proclaim.equal(m.has(4), true, 'e');
+				proclaim.equal(m.size, 5, 'f');
+			});
+		}
 	});
 
 	describe('Map.prototype.clear', function () {

--- a/polyfills/Map/tests.js
+++ b/polyfills/Map/tests.js
@@ -71,7 +71,7 @@ describe('Map', function () {
 			it('has correct descriptors defined for Map.prototype.size', function () {
 				var descriptor = Object.getOwnPropertyDescriptor(Map.prototype, 'size');
 
-				proclaim.isTrue(descriptor.configurable, 'a' + descriptor.configurable);
+				proclaim.isTrue(descriptor.configurable);
 				proclaim.isFalse(descriptor.enumerable);
 				proclaim.doesNotInclude(descriptor.writable);
 				proclaim.ok(descriptor.get);
@@ -203,16 +203,26 @@ describe('Map', function () {
 		}
 	}
 
-	it("has valid constructor", function () {
-		proclaim.equal(Map.length, 0);
-		proclaim.isInstanceOf(new Map, Map);
-		proclaim.isInstanceOf(new Map(), Map);
-		proclaim.equal((new Map()).constructor, Map);
-		proclaim.equal((new Map()).constructor.name, "Map");
-		if ("__proto__" in {}) {
-			proclaim.equal((new Map).__proto__.isPrototypeOf(new Map()), true);
-			proclaim.equal((new Map).__proto__ === Map.prototype, true);
-		}
+	describe('constructor', function () {
+		it('has 0 length', function () {
+			proclaim.equal(Map.length, 0);
+		});
+
+		it('throws error if called without NewTarget set. I.E. Called as a normal function and not a constructor', function () {
+			proclaim.throws(function () {
+				Map();
+			});
+		});
+		it("has valid constructor", function () {
+			proclaim.isInstanceOf(new Map, Map);
+			proclaim.isInstanceOf(new Map(), Map);
+			proclaim.equal((new Map()).constructor, Map);
+			proclaim.equal((new Map()).constructor.name, "Map");
+			if ("__proto__" in {}) {
+				proclaim.equal((new Map).__proto__.isPrototypeOf(new Map()), true);
+				proclaim.equal((new Map).__proto__ === Map.prototype, true);
+			}
+		});
 	});
 
 	it ("can be pre-populated", function() {

--- a/polyfills/Map/tests.js
+++ b/polyfills/Map/tests.js
@@ -204,6 +204,7 @@ describe('Map', function () {
 	}
 
 	it("has valid constructor", function () {
+		proclaim.equal(Map.length, 0);
 		proclaim.isInstanceOf(new Map, Map);
 		proclaim.isInstanceOf(new Map(), Map);
 		proclaim.equal((new Map()).constructor, Map);

--- a/polyfills/Map/tests.js
+++ b/polyfills/Map/tests.js
@@ -210,7 +210,7 @@ describe('Map', function () {
 
 		it('throws error if called without NewTarget set. I.E. Called as a normal function and not a constructor', function () {
 			proclaim.throws(function () {
-				Map();
+				Map(); // eslint-disable-line new-cap
 			});
 		});
 
@@ -240,6 +240,93 @@ describe('Map', function () {
 			proclaim.equal(d.has(b), true);
 			proclaim.equal(d.has(c), true);
 			proclaim.equal(d.size, 3);
+		});
+	});
+
+	describe('Map.prototype.clear', function () {
+		it('has 0 length', function () {
+			proclaim.equal(Map.prototype.clear.length, 0);
+		});
+
+		it('throws a TypeError if `this` is not an Object', function () {
+			proclaim.throws(function () {
+				Map.prototype.clear.call('');
+			}, TypeError);
+			proclaim.throws(function () {
+				Map.prototype.clear.call(1);
+			}, TypeError);
+			proclaim.throws(function () {
+				Map.prototype.clear.call(true);
+			}, TypeError);
+			proclaim.throws(function () {
+				Map.prototype.clear.call(/ /);
+			}, TypeError);
+			proclaim.throws(function () {
+				Map.prototype.clear.call(null);
+			}, TypeError);
+			proclaim.throws(function () {
+				Map.prototype.clear.call(undefined);
+			}, TypeError);
+		});
+
+		it('throws a TypeError if `this` is not an a Map Object', function () {
+			proclaim.throws(function () {
+				Map.prototype.clear.call([]);
+			}, TypeError);
+			proclaim.throws(function () {
+				Map.prototype.clear.call({});
+			}, TypeError);
+		});
+
+		// TODO: Need to test the fact that the existing [[MapData]] List is preserved because
+		// there may be existing Map Iterator objects that are suspended midway through iterating over that List.
+
+	});
+
+	describe('Map.prototype.delete', function () {
+		it('has 1 length', function () {
+			proclaim.equal(Map.prototype['delete'].length, 1);
+		});
+
+		it('throws a TypeError if `this` is not an Object', function () {
+			proclaim.throws(function () {
+				Map.prototype['delete'].call('');
+			}, TypeError);
+			proclaim.throws(function () {
+				Map.prototype['delete'].call(1);
+			}, TypeError);
+			proclaim.throws(function () {
+				Map.prototype['delete'].call(true);
+			}, TypeError);
+			proclaim.throws(function () {
+				Map.prototype['delete'].call(/ /);
+			}, TypeError);
+			proclaim.throws(function () {
+				Map.prototype['delete'].call(null);
+			}, TypeError);
+			proclaim.throws(function () {
+				Map.prototype['delete'].call(undefined);
+			}, TypeError);
+		});
+
+		it('throws a TypeError if `this` is not an a Map Object', function () {
+			proclaim.throws(function () {
+				Map.prototype['delete'].call([]);
+			}, TypeError);
+			proclaim.throws(function () {
+				Map.prototype['delete'].call({});
+			}, TypeError);
+		});
+
+		it('returns false if key was not in map', function () {
+			var map = new Map();
+			proclaim.isFalse(map['delete']('k'));
+		});
+
+		it('returns true if key was in map', function () {
+			var map = new Map();
+			map.set('k', 1);
+			proclaim.isTrue(map['delete']('k'));
 		});
 	});
 

--- a/polyfills/Map/tests.js
+++ b/polyfills/Map/tests.js
@@ -213,6 +213,7 @@ describe('Map', function () {
 				Map();
 			});
 		});
+
 		it("has valid constructor", function () {
 			proclaim.isInstanceOf(new Map, Map);
 			proclaim.isInstanceOf(new Map(), Map);
@@ -223,23 +224,23 @@ describe('Map', function () {
 				proclaim.equal((new Map).__proto__ === Map.prototype, true);
 			}
 		});
-	});
 
-	it ("can be pre-populated", function() {
-		var a = 1;
-		var b = {};
-		var c = new Map();
-		var m = new Map([[1,1], [b,2], [c, 3]]);
-		proclaim.equal(m.has(a), true);
-		proclaim.equal(m.has(b), true);
-		proclaim.equal(m.has(c), true);
-		proclaim.equal(m.size, 3);
+		it ("can be pre-populated", function() {
+			var a = 1;
+			var b = {};
+			var c = new Map();
+			var m = new Map([[1,1], [b,2], [c, 3]]);
+			proclaim.equal(m.has(a), true);
+			proclaim.equal(m.has(b), true);
+			proclaim.equal(m.has(c), true);
+			proclaim.equal(m.size, 3);
 
-		var d = new Map(m);
-		proclaim.equal(d.has(a), true);
-		proclaim.equal(d.has(b), true);
-		proclaim.equal(d.has(c), true);
-		proclaim.equal(d.size, 3);
+			var d = new Map(m);
+			proclaim.equal(d.has(a), true);
+			proclaim.equal(d.has(b), true);
+			proclaim.equal(d.has(c), true);
+			proclaim.equal(d.size, 3);
+		});
 	});
 
 	it("implements .size()", function () {

--- a/polyfills/Map/tests.js
+++ b/polyfills/Map/tests.js
@@ -51,7 +51,12 @@ describe('Map', function () {
 			it('has correct descriptors defined for Map.name', function () {
 				var descriptor = Object.getOwnPropertyDescriptor(Map, 'name');
 
-				proclaim.isTrue(descriptor.configurable);
+				try {
+					proclaim.isTrue(descriptor.configurable);
+				} catch (e) {
+					// Safari 8 implements Map.name as a non-configurable property.
+					proclaim.isFalse(descriptor.configurable);
+				}
 				proclaim.isFalse(descriptor.enumerable);
 				proclaim.isFalse(descriptor.writable);
 				proclaim.doesNotInclude(descriptor, 'get');


### PR DESCRIPTION
Inline with my other updates to polyfills, I have added the specification steps inline in the polyfill.

A nice benefit from this rewrite is on the Map.prototype.forEach method, we now only iterate the map once. We used to iterate it twice.

Another nice benefit is we don't need a `NaN` symbol marker anymore, that was only needed because we were using `Array.prototype.indexOf` to find keys instead of following the specification which states that we should iterate through the keys and use `sameValueZero` (which handles `NaN` correctly.

In a later PR we can look to optimise the size of this polyfill by creating some helpers functions around defining properties.

Update: This polyfill now supports custom iterators to be used to construct a Map object 🎉. I also made it work correctly with argument objects (for browsers which do not have iteration methods attached to those objects).