### PR TITLE
Alias GoogleBot 2.1 to Chrome 41

### DIFF
--- a/lib/UA.js
+++ b/lib/UA.js
@@ -139,6 +139,10 @@ const aliases = {
 		"45": ["chrome", 58],
 		"46": ["chrome", 59],
 		"47": ["chrome", 60]
+	},
+
+	"googlebot": {
+		"2.1": ["chrome", 41]
 	}
 };
 
@@ -174,7 +178,6 @@ function UA(uaString) {
 
 		// Electron ` Electron/X.Y.Z` (see #1129)
 		uaString = uaString.replace(/ Electron\/[\d\.]+\d+/i, '');
-
 
 		this.ua = useragent.parse(uaString);
 

--- a/test/unit/lib/UA.js
+++ b/test/unit/lib/UA.js
@@ -242,6 +242,9 @@ describe("lib/UA", function () {
 
 				const yandex = new UA("Mozilla/5.0 (Linux; Android 5.0.1; GT-I9505 Build/LRX22C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.111 YaBrowser/14.2.1.1239.00 Mobile Safari/537.36");
 				assert.equal(yandex.ua.family, 'chrome');
+
+				const googlebot = new UA("Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)");
+				assert.equal(googlebot.ua.family, 'chrome');
 			});
 		});
 	});
@@ -349,6 +352,21 @@ describe("lib/UA", function () {
 			test = UA.normalize("Mozilla/5.0 (iPhone; CPU iPhone OS 6_1_3 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Mobile/10B329 [FBAN/FBIOS;FBAV/6.0.2;FBBV/183159;FBDV/iPhone4,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/6.1.3;FBSS/2; FBCR/AT&T;FBID/phone;FBLC/en_US;FBOP/1]");
 			assert.equal(test, "ios_saf/6.1.0");
 		});
+
+		it("should resolve mobile googlebot 2.1 to chrome 41.0.0", function () {
+			const googlebot = UA.normalize("Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)");
+			assert.equal(googlebot, "chrome/41.0.0");
+		});
+
+		it("should resolve desktop googlebot 2.1 to chrome 41.0.0", function () {
+			const googlebot = UA.normalize("Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)");
+			assert.equal(googlebot, "chrome/41.0.0");
+		});
+
+		it("should resolve legacy desktop googlebot 2.1 to chrome 41.0.0", function () {
+			const googlebot = UA.normalize("Googlebot/2.1 (+http://www.google.com/bot.html)");
+			assert.equal(googlebot, "chrome/41.0.0");
+		});
 	});
 
 	describe(".isUnknown", function () {
@@ -441,5 +459,4 @@ describe("lib/UA", function () {
 			});
 		});
 	});
-
 });


### PR DESCRIPTION
GoogleBot is currently an unknown/unsupported browser in the eyes of the polyfill-service. This causes issues for sites crawled by GoogleBot as we would not serve the correct set of polyfills to make the site work for GoogleBot. Even setting the `unknown` property to `polyfill` does not work for all cases as our `Element` polyfill seems to throw an error in browsers which support `Element` natively (Which GoogleBot does).

It turns out that GoogleBot 2.1 is using Chrome 41, we can alias this specific version of GoogleBot to that specific version of Chrome, this will make the polyfill-service start serving the correct polyfills for GoogleBot.

In another PR I will look to make the `Element` polyfill not throw an error in browsers which support it natively.

This PR fixes https://github.com/Financial-Times/polyfill-service/issues/1405.

