### PR TITLE
Update IntersectionObserver{,Entry} compatibility table.

### DIFF
--- a/docs/assets/compat.json
+++ b/docs/assets/compat.json
@@ -7073,60 +7073,6 @@
       "9.1": "native"
     }
   },
-  "IntersectionObserverEntry": {
-    "chrome": {
-      "35": "polyfilled",
-      "40": "polyfilled",
-      "42": "polyfilled",
-      "46": "polyfilled",
-      "48": "polyfilled",
-      "58": "native"
-    },
-    "firefox": {
-      "30": "polyfilled",
-      "33": "polyfilled",
-      "41": "polyfilled",
-      "42": "polyfilled",
-      "44": "polyfilled",
-      "49": "polyfilled",
-      "53": "native"
-    },
-    "ie": {
-      "7": "missing",
-      "8": "missing",
-      "9": "polyfilled",
-      "10": "polyfilled",
-      "11": "polyfilled",
-      "13": "polyfilled",
-      "14": "polyfilled",
-      "15": "polyfilled"
-    },
-    "safari": {
-      "6": "polyfilled",
-      "7": "polyfilled",
-      "8": "polyfilled",
-      "9": "polyfilled",
-      "10": "native",
-      "5.1": "polyfilled"
-    },
-    "android": {
-      "5": "polyfilled",
-      "6": "native",
-      "7": "native",
-      "7.1": "polyfilled",
-      "5.1": "native",
-      "4.4": "polyfilled"
-    },
-    "ios_saf": {
-      "4": "native",
-      "5": "native",
-      "6": "native",
-      "7": "native",
-      "8": "native",
-      "10.3": "native",
-      "9.1": "polyfilled"
-    }
-  },
   "Map": {
     "chrome": {
       "35": "polyfilled",
@@ -7233,6 +7179,60 @@
       "8": "native",
       "10.3": "native",
       "9.1": "native"
+    }
+  },
+  "IntersectionObserverEntry": {
+    "chrome": {
+      "35": "polyfilled",
+      "40": "polyfilled",
+      "42": "polyfilled",
+      "46": "polyfilled",
+      "48": "polyfilled",
+      "58": "native"
+    },
+    "firefox": {
+      "30": "polyfilled",
+      "33": "polyfilled",
+      "41": "polyfilled",
+      "42": "polyfilled",
+      "44": "polyfilled",
+      "49": "polyfilled",
+      "53": "native"
+    },
+    "ie": {
+      "7": "missing",
+      "8": "missing",
+      "9": "polyfilled",
+      "10": "polyfilled",
+      "11": "polyfilled",
+      "13": "polyfilled",
+      "14": "polyfilled",
+      "15": "polyfilled"
+    },
+    "safari": {
+      "6": "polyfilled",
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "9": "polyfilled",
+      "10": "native",
+      "5.1": "polyfilled"
+    },
+    "android": {
+      "5": "polyfilled",
+      "6": "native",
+      "7": "native",
+      "7.1": "polyfilled",
+      "5.1": "native",
+      "4.4": "polyfilled"
+    },
+    "ios_saf": {
+      "4": "native",
+      "5": "native",
+      "6": "native",
+      "7": "native",
+      "8": "native",
+      "10.3": "native",
+      "9.1": "polyfilled"
     }
   },
   "IntersectionObserver": {

--- a/docs/assets/compat.json
+++ b/docs/assets/compat.json
@@ -7197,11 +7197,11 @@
       "42": "polyfilled",
       "44": "polyfilled",
       "49": "polyfilled",
-      "53": "native"
+      "53": "polyfilled"
     },
     "ie": {
-      "7": "missing",
-      "8": "missing",
+      "7": "polyfilled",
+      "8": "polyfilled",
       "9": "polyfilled",
       "10": "polyfilled",
       "11": "polyfilled",
@@ -7214,24 +7214,24 @@
       "7": "polyfilled",
       "8": "polyfilled",
       "9": "polyfilled",
-      "10": "native",
-      "5.1": "polyfilled"
+      "10": "polyfilled",
+      "5.1": "missing"
     },
     "android": {
       "5": "polyfilled",
-      "6": "native",
-      "7": "native",
+      "6": "polyfilled",
+      "7": "polyfilled",
       "7.1": "polyfilled",
-      "5.1": "native",
+      "5.1": "polyfilled",
       "4.4": "polyfilled"
     },
     "ios_saf": {
-      "4": "native",
-      "5": "native",
-      "6": "native",
-      "7": "native",
-      "8": "native",
-      "10.3": "native",
+      "4": "missing",
+      "5": "missing",
+      "6": "missing",
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "10.3": "polyfilled",
       "9.1": "polyfilled"
     }
   },
@@ -7251,12 +7251,12 @@
       "42": "polyfilled",
       "44": "polyfilled",
       "49": "polyfilled",
-      "53": "native"
+      "53": "polyfilled"
     },
     "ie": {
       "7": "polyfilled",
       "8": "polyfilled",
-      "9": "missing",
+      "9": "polyfilled",
       "10": "polyfilled",
       "11": "polyfilled",
       "13": "polyfilled",
@@ -7268,24 +7268,24 @@
       "7": "polyfilled",
       "8": "polyfilled",
       "9": "polyfilled",
-      "10": "native",
-      "5.1": "polyfilled"
+      "10": "polyfilled",
+      "5.1": "missing"
     },
     "android": {
       "5": "polyfilled",
-      "6": "native",
-      "7": "native",
+      "6": "polyfilled",
+      "7": "polyfilled",
       "7.1": "polyfilled",
-      "5.1": "native",
+      "5.1": "polyfilled",
       "4.4": "polyfilled"
     },
     "ios_saf": {
-      "4": "native",
-      "5": "native",
-      "6": "native",
-      "7": "native",
-      "8": "native",
-      "10.3": "native",
+      "4": "missing",
+      "5": "missing",
+      "6": "missing",
+      "7": "polyfilled",
+      "8": "polyfilled",
+      "10.3": "polyfilled",
       "9.1": "polyfilled"
     }
   },


### PR DESCRIPTION
Safari has no native support at all, that I can see; Firefox is polyfilled until version 55 (it was present in 53 but behind a flag); the polyfill says it works in IE7+ and Safari 6+.

Hope I've understood this right, apologies if not!