### PR TITLE
Make Object.entries tests use ES3 syntax to enable them to run in ES3 environments

### DIFF
--- a/polyfills/Object/entries/tests.js
+++ b/polyfills/Object/entries/tests.js
@@ -50,18 +50,26 @@ it('has length `1`', function() {
 	proclaim.equal(Object.entries.length, 1);
 });
 
-it('should terminate if getting a value throws an exception', function() {
-	proclaim.throws(function() {
-		Object.entries({
-			get a() {
-				throw new Error('This is the thrown error');
-			},
-			get b() {
-				throw new Error();
-			}
-		});
-	}, Error, 'This is the thrown error');
-});
+if (supportsDescriptors) {
+	it('should terminate if getting a value throws an exception', function () {
+		proclaim.throws(function () {
+			var obj = {};
+			Object.defineProperty(obj, 'a', {
+				enumerable: true,
+				get: function () {
+					throw new Error('This is the thrown error');
+				}
+			});
+			Object.defineProperty(obj, 'b', {
+				enumerable: true,
+				get: function () {
+					throw new Error();
+				}
+			});
+			Object.entries(obj);
+		}, Error, 'This is the thrown error');
+	});
+}
 
 it('should throw TypeError when called with `null`', function() {
 	proclaim.throws(function() {
@@ -75,42 +83,74 @@ it('should throw TypeError when called with `undefined`', function() {
 	}, TypeError);
 });
 
-it('does not see a new element added by a getter that is hit during iteration', function() {
-	var bAddsC = {
-		a: 'A',
-		get b() {
-			this.c = 'C';
-			return 'B';
-		}
-	};
+if (supportsDescriptors) {
+	it('does not see a new element added by a getter that is hit during iteration', function () {
+		var bAddsC = {
+			a: 'A'
+		};
+		Object.defineProperty(bAddsC, 'b', {
+			enumerable: true,
+			get: function () {
+				this.c = 'C';
+				return 'B';
+			}
+		});
 
-	var result = Object.entries(bAddsC);
+		var result = Object.entries(bAddsC);
 
-	proclaim.isArray(result, 'result is an array');
-	proclaim.equal(result.length, 2, 'result has 2 items');
+		proclaim.isArray(result, 'result is an array');
+		proclaim.equal(result.length, 2);
 
-	proclaim.isArray(result[0], 'first entry is an array');
-	proclaim.isArray(result[1], 'second entry is an array');
+		proclaim.isArray(result[0], 'first entry is an array');
+		proclaim.isArray(result[1], 'second entry is an array');
 
-	proclaim.deepEqual(result, [
-		['a', 'A'],
-		['b', 'B']
-	]);
-});
+		proclaim.deepEqual(result, [
+			['a', 'A'],
+			['b', 'B']
+		]);
+	});
 
-it('does not see an element made non-enumerable by a getter that is hit during iteration', function() {
-	if (supportsDescriptors) {
-
-		var bDeletesC = {
-			a: 'A',
-			get b() {
+	it('does not see an element made non-enumerable by a getter that is hit during iteration', function () {
+		var bHidesC = {
+			a: 'A'
+		};
+		Object.defineProperty(bHidesC, 'b', {
+			enumerable: true,
+			get: function () {
 				Object.defineProperty(this, 'c', {
 					enumerable: false
 				});
 				return 'B';
-			},
-			c: 'C'
+			}
+		});
+		bHidesC.c = 'C';
+
+		var result = Object.entries(bHidesC);
+
+		proclaim.isArray(result, 'result is an array');
+		proclaim.equal(result.length, 2, 'result has 2 items');
+
+		proclaim.isArray(result[0], 'first entry is an array');
+		proclaim.isArray(result[1], 'second entry is an array');
+
+		proclaim.deepEqual(result, [
+			['a', 'A'],
+			['b', 'B']
+		]);
+	});
+
+	it('does not see an element removed by a getter that is hit during iteration', function () {
+		var bDeletesC = {
+			a: 'A'
 		};
+		Object.defineProperty(bDeletesC, 'b', {
+			enumerable: true,
+			get: function () {
+				delete this.c;
+				return 'B';
+			}
+		});
+		bDeletesC.c = 'C';
 
 		var result = Object.entries(bDeletesC);
 
@@ -124,35 +164,8 @@ it('does not see an element made non-enumerable by a getter that is hit during i
 			['a', 'A'],
 			['b', 'B']
 		]);
-	} else {
-		this.skip();
-	}
-});
-
-it('does not see an element removed by a getter that is hit during iteration', function() {
-
-	var bDeletesC = {
-		a: 'A',
-		get b() {
-			delete this.c;
-			return 'B';
-		},
-		c: 'C'
-	};
-
-	var result = Object.entries(bDeletesC);
-
-	proclaim.isArray(result, 'result is an array');
-	proclaim.equal(result.length, 2, 'result has 2 items');
-
-	proclaim.isArray(result[0], 'first entry is an array');
-	proclaim.isArray(result[1], 'second entry is an array');
-
-	proclaim.deepEqual(result, [
-		['a', 'A'],
-		['b', 'B']
-	]);
-});
+	});
+}
 
 it('does not see inherited properties', function() {
 	var F = function G() {};


### PR DESCRIPTION
Currently these tests will never run in IE7 or IE8 due to the use of the `get` syntax being used. This causes issues for our script which generates the compatibility data.

https://github.com/Financial-Times/polyfill-service/blob/5619eb89b5fad1c79135c6c9ff08ccfdaf47080e/docs/assets/compat.json#L9204-L9209