### PR TITLE
Remove incorrect test for userland defined iterator on Array.from

### DIFF
--- a/polyfills/Array/from/tests.js
+++ b/polyfills/Array/from/tests.js
@@ -92,27 +92,6 @@ describe('returns an array with', function () {
 			}
 		}
 
-		it('can convert from a user-defined iterator', function () {
-			function iterator(cnt) {
-				return {
-					next: function () {
-						return cnt === 0
-							? {
-								done: true
-							}
-							: {
-								value: cnt--,
-								done: false
-							};
-					}
-				};
-			}
-			proclaim.deepEqual(Array.from(iterator(0)), []);
-			proclaim.deepEqual(Array.from(iterator(1)), [1]);
-			proclaim.deepEqual(Array.from(iterator(2)), [2, 1]);
-			proclaim.deepEqual(Array.from(iterator(3)), [3, 2, 1]);
-		});
-
 		if ('Symbol' in window && 'iterator' in Symbol) {
 			it('can understand objects which have a property named Symbol.iterator', function () {
 				var o = {};


### PR DESCRIPTION
This test did not use a valid userland defined iterator. Userland defined iterators are meant to be defined using `Symbol.iterator`