### PR TITLE
Add option to skip mounting tests

### DIFF
--- a/service/index.js
+++ b/service/index.js
@@ -65,7 +65,10 @@ app.use((req, res, next) => {
 
 app.use(require('./routes/api.js'));
 app.use(require('./routes/meta.js'));
-app.use('/test', require('./routes/test.js'));
+
+if (!process.env.SKIP_TESTS) {
+	app.use('/test', require('./routes/test.js'));
+}
 
 if (process.env.RUM_MYSQL_DSN) {
 	app.use(require('./routes/rum.js'));


### PR DESCRIPTION
What do you think about giving the option not to mount the tests?

This came up because I have security scanners that are flagging the tests for XSS issues.  I haven't dug in to assess the specifics of those vectors, but in any case, I don't really want people running the tests on my production instance anyway.

Would this option be acceptable to you?