### PR TITLE
Update Yaku version to support Promise polyfilling in Web Worker

### DIFF
--- a/packages/polyfill-library/package-lock.json
+++ b/packages/polyfill-library/package-lock.json
@@ -4835,9 +4835,9 @@
       }
     },
     "yaku": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/yaku/-/yaku-0.17.11.tgz",
-      "integrity": "sha1-IHmotN1F5pN/+H3SlXNYc+cB9NA=",
+      "version": "0.18.6",
+      "resolved": "https://registry.npmjs.org/yaku/-/yaku-0.18.6.tgz",
+      "integrity": "sha512-pZ7KsMhnb8+46v6w17H96r16iA3O0qalqE7FMfiSYYEgyh7yBBVT7/bzTeYCAW3FnD1U4BElijQm4g13dETKqw==",
       "dev": true
     },
     "yallist": {

--- a/packages/polyfill-library/package.json
+++ b/packages/polyfill-library/package.json
@@ -84,6 +84,6 @@
     "usertiming": "^0.1.8",
     "web-animations-js": "^2.2.5",
     "whatwg-fetch": "^2.0.3",
-    "yaku": "0.17.11"
+    "yaku": "0.18.6"
   }
 }


### PR DESCRIPTION
Hi! First of all, thank you very much for a great service!
I've encountered a problem while trying to load the `polyfill.js` inside of Web Worker of IE11 (`importScripts`). While running the Promise polyfill, it crashed, because the Web Worker was not identified as a browser and it ran the code containing `process.nextTick`. It was fixed in https://github.com/ysmood/yaku/pull/57 and released in `yaku@0.18.6` =)