### PR TITLE
Serve Number.isInteger polyfill to Chrome 19-33

### DIFF
--- a/packages/polyfill-library/polyfills/Number/isInteger/config.json
+++ b/packages/polyfill-library/polyfills/Number/isInteger/config.json
@@ -6,7 +6,7 @@
 	"browsers": {
 		"ie": "<13",
 		"ie_mob": "*",
-		"chrome": "<19",
+		"chrome": "<34",
 		"ios_chr": "*",
 		"safari": "<9",
 		"ios_saf": "<9",


### PR DESCRIPTION
Chrome 19 to 33 doesn't support Number.isInteger: https://caniuse.com/#feat=es6-number

Here's the result from their tests:

![image](https://user-images.githubusercontent.com/1151641/38976531-3907529e-43ba-11e8-8a9a-c86b4a6e0f5e.png)

And the current polyfill works OK with Chrome Mobile 26:

![image](https://user-images.githubusercontent.com/1151641/38976576-5277b084-43ba-11e8-9912-9fee1b649d70.png)
