### PR TITLE
Serve HTMLCanvasElement.prototype.toBlob to Edge and don't serve to Safari 11

### DIFF
--- a/packages/polyfill-library/polyfills/HTMLCanvasElement/prototype/toBlob/config.json
+++ b/packages/polyfill-library/polyfills/HTMLCanvasElement/prototype/toBlob/config.json
@@ -6,7 +6,7 @@
 		"chrome": "<50",
 		"firefox": "<19",
 		"safari": "<11",
-		"ie": "*",
+		"ie": ">=10",
 		"opera": "*"
 	},
 	"dependencies": [

--- a/packages/polyfill-library/polyfills/HTMLCanvasElement/prototype/toBlob/config.json
+++ b/packages/polyfill-library/polyfills/HTMLCanvasElement/prototype/toBlob/config.json
@@ -5,8 +5,8 @@
 	"browsers": {
 		"chrome": "<50",
 		"firefox": "<19",
-		"safari": "*",
-		"ie": "10 - 11",
+		"safari": "<11",
+		"ie": "*",
 		"opera": "*"
 	},
 	"dependencies": [


### PR DESCRIPTION
Addresses #1437 and discussions in #1258 