### PR TITLE
Enable custom polyfill collection to be used with the polyfill-library module

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,9 @@
 		"browser": false,
 		"node": true
 	},
+	"parserOptions": {
+		"ecmaVersion": 2017
+	},
 	"rules": {
 		"no-unused-vars": 2,
 		"no-undef": 2,

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "license": "CC0-1.0",
   "engines": {
-    "node": "6.11.1 - 9"
+    "node": ">=8"
   },
   "devDependencies": {
     "whitesource": "^18.3.1"

--- a/packages/polyfill-library/lib/aliases.js
+++ b/packages/polyfill-library/lib/aliases.js
@@ -41,13 +41,13 @@ module.exports = function (...polyfillNameResolverFunctions) {
  *
  * @return {array} An expanded list of polyfill identifiers
  */
-function applyResolverToIdentifiers(featureSet, nameResolverFunction) {
+async function applyResolverToIdentifiers(featureSet, nameResolverFunction) {
 	const processQueue = Object.keys(featureSet);
 
 	while (processQueue.length > 0) {
 		const featureName = processQueue.shift();
 		const feature = featureSet[featureName];
-		const resultItems = nameResolverFunction(featureName);
+		const resultItems = await nameResolverFunction(featureName);
 
 		// No aliases for this feature - do not modify feature set
 		if (!Array.isArray(resultItems)) continue;

--- a/packages/polyfill-library/lib/index.js
+++ b/packages/polyfill-library/lib/index.js
@@ -289,7 +289,7 @@ const PolyfillLibrary = class PolyfillLibrary {
 							);
 							output.add(streamFromPromise(detect.then(wrap => {
 								if (wrap) {
-									return (lf + "}" + lf + lf)
+									return (lf + "}" + lf + lf);
 								}
 							})));
 						} else {

--- a/packages/polyfill-library/lib/index.js
+++ b/packages/polyfill-library/lib/index.js
@@ -179,9 +179,7 @@ const PolyfillLibrary = class PolyfillLibrary {
 
 			// Build a polyfill bundle of polyfill sources sorted in dependency order
 			.then(targetedFeatures => {
-				const warnings = {
-					unknown: []
-				};
+				const warnings = { unknown: [] };
 				const graph = tsort();
 
 				Object.keys(targetedFeatures).forEach(featureName => {
@@ -324,20 +322,8 @@ const PolyfillLibrary = class PolyfillLibrary {
 				}
 			});
 
-		if (
-			options.callback &&
-			typeof options.callback === "string" &&
-			options.callback.match(/^[\w\.]+$/)
-		) {
-			output.add(
-				streamFromString(
-					"\ntypeof " +
-						options.callback +
-						"==='function' && " +
-						options.callback +
-						"();"
-				)
-			);
+		if (options.callback && typeof options.callback === 'string' && options.callback.match(/^[\w\.]+$/)) {
+			output.add(streamFromString("\ntypeof "+options.callback+"==='function' && "+options.callback+"();"));
 		}
 
 		return options.stream ? output : Promise.resolve(streamToString(output));

--- a/packages/polyfill-library/lib/index.js
+++ b/packages/polyfill-library/lib/index.js
@@ -1,278 +1,360 @@
-'use strict';
+"use strict";
 
-const fs = require('graceful-fs');
-const path = require('path');
-const tsort = require('tsort');
-const createAliasResolver = require('./aliases');
-const UA = require('./UA');
-const sourceslib = require('./sources');
-const appVersion = require('../package.json').version;
-const Handlebars = require('handlebars');
-const cloneDeep = require('lodash').cloneDeep;
-const streamFromPromise = require('stream-from-promise');
-const lazystream = require('lazystream');
-const streamFromString = require('from2-string');
-const mergeStream = require('merge2');
-const streamToString = require('stream-to-string');
-const shuffle = require('shuffle-array');
+const fs = require("graceful-fs");
+const path = require("path");
+const tsort = require("tsort");
+const createAliasResolver = require("./aliases");
+const UA = require("./UA");
+const Sources = require("./sources");
+const appVersion = require("../package.json").version;
+const Handlebars = require("handlebars");
+const cloneDeep = require("lodash").cloneDeep;
+const streamFromPromise = require("stream-from-promise");
+const lazystream = require("lazystream");
+const streamFromString = require("from2-string");
+const mergeStream = require("merge2");
+const streamToString = require("stream-to-string");
+const shuffle = require("shuffle-array");
 
+const rumTemplate = Handlebars.compile(
+	fs.readFileSync(path.join(__dirname, "rumTemplate.js.handlebars"), "utf-8")
+);
 
-const rumTemplate = Handlebars.compile(fs.readFileSync(path.join(__dirname, 'rumTemplate.js.handlebars'), 'utf-8'));
-
-function listAllPolyfills() {
-	return sourceslib.listPolyfills();
-}
-
-function describePolyfill(featureName) {
-	return Promise.resolve(sourceslib.getPolyfillMetaSync(featureName));
-}
-
-function getOptions(opts) {
-	opts = Object.assign({
-		uaString: '',
-		minify: true,
-		unknown: 'ignore',
-		features: {},
-		excludes: [],
-		rum: false
-	}, opts);
-
-	if (opts.unknown !== 'polyfill') {
-		opts.unknown = 'ignore';
+const PolyfillLibrary = class PolyfillLibrary {
+	constructor(polyfillsPath) {
+		this.sourceslib = new Sources(polyfillsPath);
 	}
 
-	// Normalise flags
-	Object.keys(opts.features).forEach(k => {
-		if (!opts.features[k].flags) {
-			opts.features[k].flags = new Set();
-		} else if (opts.features[k].flags.constructor !== Set) {
-			opts.features[k].flags = new Set(opts.features[k].flags);
+	listAllPolyfills() {
+		return this.sourceslib.listPolyfills();
+	}
+
+	describePolyfill(featureName) {
+		return Promise.resolve(this.sourceslib.getPolyfillMetaSync(featureName));
+	}
+
+	getOptions(opts) {
+		opts = Object.assign(
+			{
+				uaString: "",
+				minify: true,
+				unknown: "ignore",
+				features: {},
+				excludes: [],
+				rum: false
+			},
+			opts
+		);
+
+		if (opts.unknown !== "polyfill") {
+			opts.unknown = "ignore";
 		}
-	});
-	return opts;
-}
 
-/**
- * Given a set of features that should be polyfilled in 'options.features' (with flags i.e. `{<featurename>: {flags:Set[<flaglist>]}, ...}`), determine which have a configuration valid for the given options.uaString, and return a promise of set of canonical (unaliased) features (with flags) and polyfills.
- *
- * @param {object} options - Valid keys are uaString, minify, unknown, excludes, rum and features
- * @return {promise} - Canonicalised feature definitions filtered for UA
- */
-function getPolyfills(options) {
+		// Normalise flags
+		Object.keys(opts.features).forEach(k => {
+			if (!opts.features[k].flags) {
+				opts.features[k].flags = new Set();
+			} else if (opts.features[k].flags.constructor !== Set) {
+				opts.features[k].flags = new Set(opts.features[k].flags);
+			}
+		});
+		return opts;
+	}
 
-	options = getOptions(options);
-	const ua = new UA(options.uaString);
-
-	const resolveAliases = createAliasResolver(
-		function aliasFromConfig(featureName) {
-			return sourceslib.getConfigAliasesSync(featureName);
-		},
-		function aliasAll(featureName) {
-			return (featureName === 'all') ? sourceslib.listPolyfillsSync() : undefined;
-		}
-	);
-
-	const resolveDependencies = createAliasResolver(
-		function aliasDependencies(featureName) {
-			const meta = sourceslib.getPolyfillMetaSync(featureName);
-			return (meta && meta.dependencies || [])
+	/**
+	 * Given a set of features that should be polyfilled in 'options.features' (with flags i.e. `{<featurename>: {flags:Set[<flaglist>]}, ...}`), determine which have a configuration valid for the given options.uaString, and return a promise of set of canonical (unaliased) features (with flags) and polyfills.
+	 *
+	 * @param {object} options - Valid keys are uaString, minify, unknown, excludes, rum and features
+	 * @return {promise} - Canonicalised feature definitions filtered for UA
+	 */
+	getPolyfills(options) {
+		options = this.getOptions(options);
+		const ua = new UA(options.uaString);
+		const aliasFromConfig = featureName => {
+			return this.sourceslib.getConfigAliasesSync(featureName);
+		};
+		const aliasAll = featureName => {
+			return featureName === "all"
+				? this.sourceslib.listPolyfillsSync()
+				: undefined;
+		};
+		const resolveAliases = createAliasResolver(aliasFromConfig, aliasAll);
+		const aliasDependencies = featureName => {
+			const meta = this.sourceslib.getPolyfillMetaSync(featureName);
+			return ((meta && meta.dependencies) || [])
 				.filter(depName => options.excludes.indexOf(depName) === -1)
-				.concat(featureName)
-			;
-		}
-	);
+				.concat(featureName);
+		};
+		const resolveDependencies = createAliasResolver(aliasDependencies);
 
-	// Filter the features object to remove features not suitable for the current UA
-	const filterForUATargeting = function(features) {
-		const featuresList = Object.keys(features);
-		return featuresList.map(featureName => {
-			const meta = sourceslib.getPolyfillMetaSync(featureName);
-			if (!meta) return false;
+		// Filter the features object to remove features not suitable for the current UA
+		const filterForUATargeting = (features) => {
+			const featuresList = Object.keys(features);
+			return featuresList
+				.map(featureName => {
+					const meta = this.sourceslib.getPolyfillMetaSync(featureName);
+					if (!meta) return false;
 
-			const isBrowserMatch = (meta.browsers && meta.browsers[ua.getFamily()] && ua.satisfies(meta.browsers[ua.getFamily()]));
-			const hasAlwaysFlagOverride = (features[featureName].flags.has('always'));
-			const unknownOverride = (options.unknown === 'polyfill' && ua.isUnknown());
+					const isBrowserMatch =
+						meta.browsers &&
+						meta.browsers[ua.getFamily()] &&
+						ua.satisfies(meta.browsers[ua.getFamily()]);
+					const hasAlwaysFlagOverride = features[featureName].flags.has(
+						"always"
+					);
+					const unknownOverride =
+						options.unknown === "polyfill" && ua.isUnknown();
 
-			return (isBrowserMatch || hasAlwaysFlagOverride || unknownOverride) ? featureName : false;
-		}).reduce(function(out, key) {
-			if (key) out[key] = features[key];
-			return out;
-		}, {});
-	};
+					return isBrowserMatch || hasAlwaysFlagOverride || unknownOverride
+						? featureName
+						: false;
+				})
+				.reduce(function(out, key) {
+					if (key) out[key] = features[key];
+					return out;
+				}, {});
+		};
 
-	const filterForExcludes = function(features) {
-		Object.keys(features).forEach(featureName => {
-			if (options.excludes.indexOf(featureName) !== -1) {
-				delete features[featureName];
-			}
-		});
-		return features;
-	};
-
-	const filterForUnusedAbstractMethods = function (features) {
-		const featuresMeta = Object.keys(features).map(featureName => sourceslib.getPolyfillMetaSync(featureName));
-		let dependencyWasRemoved = false;
-		Object.keys(features).forEach(featureName => {
-			if (featureName.startsWith('_')) {
-				if (!featuresMeta.some(meta => (meta.dependencies || []).some(dep => dep === featureName))) {
+		const filterForExcludes = function(features) {
+			Object.keys(features).forEach(featureName => {
+				if (options.excludes.indexOf(featureName) !== -1) {
 					delete features[featureName];
-					dependencyWasRemoved = true;
 				}
-			}
-		});
-		if (dependencyWasRemoved) {
-			return filterForUnusedAbstractMethods(features);
-		}
-		return features;
-	};
+			});
+			return features;
+		};
 
-	return Promise.resolve(options.features)
-		.then(resolveAliases)
-		.then(filterForUATargeting)
-		.then(resolveDependencies)
-		.then(filterForUATargeting)
-		.then(filterForExcludes)
-		.then(filterForUnusedAbstractMethods)
-	;
-}
-
-function getPolyfillString(options) {
-
-	options = getOptions(options);
-	const ua = new UA(options.uaString);
-	const uaDebugName = ua.getFamily() + '/' + ua.getVersion() + ((ua.isUnknown() || !ua.meetsBaseline()) ? ' (unknown/unsupported; using policy `unknown='+options.unknown+'`)' : '');
-	const lf = options.minify ? '' : '\n';
-	const allWarnText = 'Using the `all` alias with polyfill.io is a very bad idea. In a future version of the service, `all` will deliver the same behaviour as `default`, so we recommend using `default` instead.';
-	const output = mergeStream();
-	const explainerComment = [];
-	// Check UA and turn requested features into a list of polyfills
-	const unsupportedUA = ((!ua.meetsBaseline() || ua.isUnknown()) && options.unknown !== 'polyfill');
-
-	Promise.resolve(unsupportedUA ? {} : getPolyfills(options))
-
-	// Build a polyfill bundle of polyfill sources sorted in dependency order
-	.then(targetedFeatures => {
-		const warnings = {unknown:[]};
-		const graph = tsort();
-
-		Object.keys(targetedFeatures).forEach(featureName => {
-			const feature = targetedFeatures[featureName];
-			const polyfill = sourceslib.getPolyfillMetaSync(featureName);
-			if (!polyfill) {
-				warnings.unknown.push(featureName);
-			} else {
-
-				graph.add(featureName);
-
-				if (polyfill.dependencies) {
-					polyfill.dependencies.forEach(depName => {
-						if (depName in targetedFeatures) {
-							graph.add(depName, featureName);
-						}
-					});
+		const filterForUnusedAbstractMethods = (features)=> {
+			const featuresMeta = Object.keys(features).map(featureName =>
+				this.sourceslib.getPolyfillMetaSync(featureName)
+			);
+			let dependencyWasRemoved = false;
+			Object.keys(features).forEach(featureName => {
+				if (featureName.startsWith("_")) {
+					if (
+						!featuresMeta.some(meta =>
+							(meta.dependencies || []).some(dep => dep === featureName)
+						)
+					) {
+						delete features[featureName];
+						dependencyWasRemoved = true;
+					}
 				}
-
-				feature.comment = featureName + ', License: ' + (polyfill.license || 'CC0') + ((feature.aliasOf && feature.aliasOf.size) ? ' (required by "' + Array.from(feature.aliasOf).join('", "') + '")' : '');
+			});
+			if (dependencyWasRemoved) {
+				return filterForUnusedAbstractMethods(features);
 			}
-		});
+			return features;
+		};
 
-		const sortedFeatures = graph.sort();
+		return Promise.resolve(options.features)
+			.then(resolveAliases)
+			.then(filterForUATargeting)
+			.then(resolveDependencies)
+			.then(filterForUATargeting)
+			.then(filterForExcludes)
+			.then(filterForUnusedAbstractMethods);
+	}
 
-		if (!options.minify) {
-			explainerComment.push(
-				'Polyfill service ' + ((process.env.NODE_ENV === 'production') ? 'v'+appVersion : 'DEVELOPMENT MODE - for live use set NODE_ENV to \'production\''),
-				'For detailed credits and licence information see https://github.com/financial-times/polyfill-service.',
-				'',
-				'UA detected: ' + uaDebugName,
-				'Features requested: ' + Object.keys(options.features),
-				''
-			);
-			if (!ua.meetsBaseline() && ua.getBaseline()) {
-				explainerComment.push(
-					'Version range for polyfill support in ' + ua.getFamily() + ' is: ' + ua.getBaseline(),
-					''
-				);
-			}
-			explainerComment.push(...sortedFeatures
-				.filter(featureName => (targetedFeatures[featureName] && targetedFeatures[featureName].comment))
-				.map(featureName => '- ' + targetedFeatures[featureName].comment)
-			);
-			if (warnings.unknown.length) {
-				explainerComment.push(
-					'',
-					'These features were not recognised:',
-					warnings.unknown.map(s => '- '+s)
-				);
-			}
-			if ('all' in options.features) {
-				explainerComment.push('', allWarnText);
-			}
-		} else {
-			explainerComment.push('Disable minification (remove `.min` from URL path) for more info');
-		}
-		output.add(streamFromString('/* ' + explainerComment.join('\n * ') + ' */\n\n'));
+	getPolyfillString(options) {
+		options = this.getOptions(options);
+		const ua = new UA(options.uaString);
+		const uaDebugName =
+			ua.getFamily() +
+			"/" +
+			ua.getVersion() +
+			(ua.isUnknown() || !ua.meetsBaseline()
+				? " (unknown/unsupported; using policy `unknown=" +
+				  options.unknown +
+				  "`)"
+				: "");
+		const lf = options.minify ? "" : "\n";
+		const allWarnText =
+			"Using the `all` alias with polyfill.io is a very bad idea. In a future version of the service, `all` will deliver the same behaviour as `default`, so we recommend using `default` instead.";
+		const output = mergeStream();
+		const explainerComment = [];
+		// Check UA and turn requested features into a list of polyfills
+		const unsupportedUA =
+			(!ua.meetsBaseline() || ua.isUnknown()) && options.unknown !== "polyfill";
 
-		if (options.rum && process.env.RUM_BEACON_HOST) {
-			output.add(new lazystream.Readable(() => {
-				const optionsForRUM = cloneDeep(options);
-				Object.keys(options.features).forEach(f => optionsForRUM.features[f].flags.add('always'));
-				const MAX_RUM_TESTS = 10;
-				return streamFromPromise(getPolyfills(optionsForRUM)
-					.then(rumFeatures => {
-						return rumTemplate({
-							host: process.env.RUM_BEACON_HOST,
-							features: shuffle(Object.keys(rumFeatures)).slice(0, MAX_RUM_TESTS).reduce((op, featureName) => {
-								const polyfill = sourceslib.getPolyfillMetaSync(featureName);
-								if (polyfill.detectSource) {
-									op.push({name: featureName, detect: polyfill.detectSource});
+		Promise.resolve(unsupportedUA ? {} : this.getPolyfills(options))
+
+			// Build a polyfill bundle of polyfill sources sorted in dependency order
+			.then(targetedFeatures => {
+				const warnings = { unknown: [] };
+				const graph = tsort();
+
+				Object.keys(targetedFeatures).forEach(featureName => {
+					const feature = targetedFeatures[featureName];
+					const polyfill = this.sourceslib.getPolyfillMetaSync(featureName);
+					if (!polyfill) {
+						warnings.unknown.push(featureName);
+					} else {
+						graph.add(featureName);
+
+						if (polyfill.dependencies) {
+							polyfill.dependencies.forEach(depName => {
+								if (depName in targetedFeatures) {
+									graph.add(depName, featureName);
 								}
-								return op;
-							}, [])
-						});
-					}));
-			}));
-		}
+							});
+						}
 
-		if (sortedFeatures.length) {
-			// Outer closure hides private features from global scope
-			output.add(streamFromString("(function(undefined) {" + lf));
+						feature.comment =
+							featureName +
+							", License: " +
+							(polyfill.license || "CC0") +
+							(feature.aliasOf && feature.aliasOf.size
+								? ' (required by "' +
+								  Array.from(feature.aliasOf).join('", "') +
+								  '")'
+								: "");
+					}
+				});
 
-			// Using the graph, stream all the polyfill sources in dependency order
-			for (const featureName of sortedFeatures) {
-				const polyfill = sourceslib.getPolyfillMetaSync(featureName);
-				const wrapInDetect = (targetedFeatures[featureName].flags.has('gated') && polyfill.detectSource);
-				if (wrapInDetect) {
-					output.add(streamFromString("if (!(" + polyfill.detectSource + ")) {" + lf));
+				const sortedFeatures = graph.sort();
+
+				if (!options.minify) {
+					explainerComment.push(
+						"Polyfill service " +
+							(process.env.NODE_ENV === "production"
+								? "v" + appVersion
+								: "DEVELOPMENT MODE - for live use set NODE_ENV to 'production'"),
+						"For detailed credits and licence information see https://github.com/financial-times/polyfill-service.",
+						"",
+						"UA detected: " + uaDebugName,
+						"Features requested: " + Object.keys(options.features),
+						""
+					);
+					if (!ua.meetsBaseline() && ua.getBaseline()) {
+						explainerComment.push(
+							"Version range for polyfill support in " +
+								ua.getFamily() +
+								" is: " +
+								ua.getBaseline(),
+							""
+						);
+					}
+					explainerComment.push(
+						...sortedFeatures
+							.filter(
+								featureName =>
+									targetedFeatures[featureName] &&
+									targetedFeatures[featureName].comment
+							)
+							.map(featureName => "- " + targetedFeatures[featureName].comment)
+					);
+					if (warnings.unknown.length) {
+						explainerComment.push(
+							"",
+							"These features were not recognised:",
+							warnings.unknown.map(s => "- " + s)
+						);
+					}
+					if ("all" in options.features) {
+						explainerComment.push("", allWarnText);
+					}
+				} else {
+					explainerComment.push(
+						"Disable minification (remove `.min` from URL path) for more info"
+					);
+				}
+				output.add(
+					streamFromString("/* " + explainerComment.join("\n * ") + " */\n\n")
+				);
+
+				// Outer closure hides private features from global scope
+				output.add(streamFromString("(function(undefined) {" + lf));
+
+				if (options.rum && process.env.RUM_BEACON_HOST) {
+					output.add(
+						new lazystream.Readable(() => {
+							const optionsForRUM = cloneDeep(options);
+							Object.keys(options.features).forEach(f =>
+								optionsForRUM.features[f].flags.add("always")
+							);
+							const MAX_RUM_TESTS = 10;
+							return streamFromPromise(
+								this.getPolyfills(optionsForRUM).then(rumFeatures => {
+									return rumTemplate({
+										host: process.env.RUM_BEACON_HOST,
+										features: shuffle(Object.keys(rumFeatures))
+											.slice(0, MAX_RUM_TESTS)
+											.reduce((op, featureName) => {
+												const polyfill = this.sourceslib.getPolyfillMetaSync(
+													featureName
+												);
+												if (polyfill.detectSource) {
+													op.push({
+														name: featureName,
+														detect: polyfill.detectSource
+													});
+												}
+												return op;
+											}, [])
+									});
+								})
+							);
+						})
+					);
 				}
 
-				output.add(sourceslib.streamPolyfillSource(featureName, (options.minify ? 'min' : 'raw')));
+				if (sortedFeatures.length) {
+					// Using the graph, stream all the polyfill sources in dependency order
+					for (const featureName of sortedFeatures) {
+						const polyfill = this.sourceslib.getPolyfillMetaSync(featureName);
+						const wrapInDetect =
+							targetedFeatures[featureName].flags.has("gated") &&
+							polyfill.detectSource;
+						if (wrapInDetect) {
+							output.add(
+								streamFromString("if (!(" + polyfill.detectSource + ")) {" + lf)
+							);
+						}
 
-				if (wrapInDetect) {
-					output.add(streamFromString(lf + "}" + lf + lf));
+						output.add(
+							this.sourceslib.streamPolyfillSource(
+								featureName,
+								options.minify ? "min" : "raw"
+							)
+						);
+
+						if (wrapInDetect) {
+							output.add(streamFromString(lf + "}" + lf + lf));
+						}
+					}
+				} else {
+					if (!options.minify) {
+						output.add(
+							streamFromString(
+								"\n/* No polyfills found for current settings */\n\n"
+							)
+						);
+					}
 				}
-			}
-			
-			// Invoke the closure, binding `this` to window (in a browser),
-			// self (in a web worker), or global (in Node/IOjs)
-			output.add(streamFromString("})" + lf + ".call('object' === typeof window && window || 'object' === typeof self && self || 'object' === typeof global && global || {});" + lf));
-		} else {
-			if (!options.minify) {
-				output.add(streamFromString('\n/* No polyfills found for current settings */\n\n'));
-			}
-		}
 
-		if ('all' in options.features) {
-			output.add(streamFromString("\nconsole.log('"+allWarnText+"');\n"));
-		}
-	});
+				// Invoke the closure, binding `this` to window (in a browser),
+				// self (in a web worker), or global (in Node/IOjs)
+				output.add(
+					streamFromString(
+						"})" +
+							lf +
+							".call('object' === typeof window && window || 'object' === typeof self && self || 'object' === typeof global && global || {});" +
+							lf
+					)
+				);
 
-	return options.stream ? output : Promise.resolve(streamToString(output));
-}
+				if ("all" in options.features) {
+					output.add(
+						streamFromString("\nconsole.log('" + allWarnText + "');\n")
+					);
+				}
+			});
 
-module.exports = {
-	describePolyfill: describePolyfill,
-	listAllPolyfills: listAllPolyfills,
-	getPolyfills: getPolyfills,
-	getPolyfillString: getPolyfillString,
-	normalizeUserAgent: UA.normalize,
+		return options.stream ? output : Promise.resolve(streamToString(output));
+	}
 };
+
+PolyfillLibrary.prototype.normalizeUserAgent = UA.normalize;
+
+module.exports = PolyfillLibrary;

--- a/packages/polyfill-library/lib/index.js
+++ b/packages/polyfill-library/lib/index.js
@@ -25,12 +25,24 @@ const PolyfillLibrary = class PolyfillLibrary {
 		this.sourceslib = new Sources(polyfillsPath);
 	}
 
+	static listAllPolyfills() {
+		return new PolyfillLibrary().listAllPolyfills();
+	}
+
 	listAllPolyfills() {
 		return this.sourceslib.listPolyfills();
 	}
 
+	static describePolyfill(featureName) {
+		return new PolyfillLibrary().describePolyfill(featureName);
+	}
+
 	describePolyfill(featureName) {
 		return Promise.resolve(this.sourceslib.getPolyfillMetaSync(featureName));
+	}
+
+	static getOptions(opts) {
+		return new PolyfillLibrary().getOptions(opts);
 	}
 
 	getOptions(opts) {
@@ -59,6 +71,10 @@ const PolyfillLibrary = class PolyfillLibrary {
 			}
 		});
 		return opts;
+	}
+
+	static getPolyfills(options) {
+		return new PolyfillLibrary().getPolyfills(options);
 	}
 
 	/**
@@ -154,6 +170,10 @@ const PolyfillLibrary = class PolyfillLibrary {
 			.then(filterForUATargeting)
 			.then(filterForExcludes)
 			.then(filterForUnusedAbstractMethods);
+	}
+
+	static getPolyfillString(options) {
+		return new PolyfillLibrary().getPolyfillString(options);
 	}
 
 	getPolyfillString(options) {
@@ -360,5 +380,6 @@ const PolyfillLibrary = class PolyfillLibrary {
 };
 
 PolyfillLibrary.prototype.normalizeUserAgent = UA.normalize;
+PolyfillLibrary.normalizeUserAgent = UA.normalize;
 
 module.exports = PolyfillLibrary;

--- a/packages/polyfill-library/lib/index.js
+++ b/packages/polyfill-library/lib/index.js
@@ -281,17 +281,24 @@ const PolyfillLibrary = class PolyfillLibrary {
 						);
 						if (wrapInDetect) {
 							output.add(streamFromPromise(detect));
-						}
-
-						output.add(
-							this.sourceslib.streamPolyfillSource(
-								featureName,
-								options.minify ? "min" : "raw"
-							)
-						);
-
-						if (wrapInDetect) {
-							output.add(streamFromString(lf + "}" + lf + lf));
+							output.add(
+								this.sourceslib.streamPolyfillSource(
+									featureName,
+									options.minify ? "min" : "raw"
+								)
+							);
+							output.add(streamFromPromise(detect.then(wrap => {
+								if (wrap) {
+									return (lf + "}" + lf + lf)
+								}
+							})));
+						} else {
+							output.add(
+								this.sourceslib.streamPolyfillSource(
+									featureName,
+									options.minify ? "min" : "raw"
+								)
+							);
 						}
 					}
 				} else {

--- a/packages/polyfill-library/lib/index.js
+++ b/packages/polyfill-library/lib/index.js
@@ -10,19 +10,48 @@ const streamFromString = require("from2-string");
 const mergeStream = require("merge2");
 const streamToString = require("stream-to-string");
 
+/**
+ * Class representing a polyfill bundling library.
+ */
 const PolyfillLibrary = class PolyfillLibrary {
+	/**
+	 * Create an PolyfillLibrary instance.
+	 * @param {String} [polyfillsPath] - The folder location on the file system where the polyfill sources exist.
+	 * Defaults to the location of the polyfill sources which come bundled with the polyfill-library module.
+	 * @returns {PolyfillLibrary} A new PolyfillLibrary instance.
+	 */
 	constructor(polyfillsPath) {
 		this.sourceslib = new Sources(polyfillsPath);
 	}
 
+	/**
+	 * Get a list of all the polyfills which exist within the collection of polyfill sources.
+	 * @returns {Promise<Array>} A promise which resolves with an array of all the polyfills within the collection.
+	 */
 	listAllPolyfills() {
 		return this.sourceslib.listPolyfills();
 	}
 
+	/**
+	 * Get the metadata for a specific polyfill within the collection of polyfill sources.
+	 * @param {String} featureName - The name of a polyfill whose metadata should be returned.
+	 * @returns {Promise<Object|undefined>} A promise which resolves with the metadata or with `undefined` if no metadata exists for the polyfill.
+	 */
 	describePolyfill(featureName) {
 		return this.sourceslib.getPolyfillMeta(featureName);
 	}
 
+	/**
+	 * Create an options object for use with `getPolyfills` or `getPolyfillString`.
+	 * @param {object} opts - Valid keys are uaString, minify, unknown, excludes, rum and features.
+	 * @param {Boolean} [opts.minify=true] - Whether to return the minified or raw implementation of the polyfills.
+	 * @param {'ignore'|'polyfill'} [opts.unknown='ignore'] - Whether to return all polyfills or no polyfills if the user-agent is unknown or unsupported.
+	 * @param {Object} [opts.features={}] - Which features should be returned if the user-agent does not support them natively.
+	 * @param {Array<String>} [opts.excludes=[]] - Which features should be excluded from the returned object.
+	 * @param {String} [opts.uaString=''] - The user-agent string to check each feature against.
+	 * @param {Boolean} [opts.rum=false] - Whether to add a script to the polyfill bundle which reports anonymous usage data
+	 * @return {Object} - opts merged with the defaults opts values.
+	 */
 	getOptions(opts) {
 		opts = Object.assign(
 			{
@@ -52,10 +81,19 @@ const PolyfillLibrary = class PolyfillLibrary {
 	}
 
 	/**
-	 * Given a set of features that should be polyfilled in 'options.features' (with flags i.e. `{<featurename>: {flags:Set[<flaglist>]}, ...}`), determine which have a configuration valid for the given options.uaString, and return a promise of set of canonical (unaliased) features (with flags) and polyfills.
+	 * Given a set of features that should be polyfilled in 'options.features'
+	 * (with flags i.e. `{<featurename>: {flags:Set[<flaglist>]}, ...}`),
+	 * determine which have a configuration valid for the given options.uaString,
+	 * and return a promise of set of canonical (unaliased) features (with flags) and polyfills.
 	 *
-	 * @param {object} options - Valid keys are uaString, minify, unknown, excludes, rum and features
-	 * @return {promise} - Canonicalised feature definitions filtered for UA
+	 * @param {object} options - Valid keys are uaString, minify, unknown, excludes, rum and features.
+	 * @param {Boolean} [options.minify=true] - Whether to return the minified or raw implementation of the polyfills.
+	 * @param {'ignore'|'polyfill'} [options.unknown='ignore'] - Whether to return all polyfills or no polyfills if the user-agent is unknown or unsupported.
+	 * @param {Object} [options.features={}] - Which features should be returned if the user-agent does not support them natively.
+	 * @param {Array<String>} [options.excludes=[]] - Which features should be excluded from the returned object.
+	 * @param {String} [options.uaString=''] - The user-agent string to check each feature against.
+	 * @param {Boolean} [options.rum=false] - Whether to add a script to the polyfill bundle which reports anonymous usage data.
+	 * @return {Promise<Object>} - Canonicalised feature definitions filtered for UA
 	 */
 	getPolyfills(options) {
 		options = this.getOptions(options);
@@ -154,6 +192,18 @@ const PolyfillLibrary = class PolyfillLibrary {
 			.then(filterForUnusedAbstractMethods);
 	}
 
+	/**
+	 * Create a polyfill bundle.
+	 * @param {object} options - Valid keys are uaString, minify, unknown, excludes, rum and features.
+	 * @param {Boolean} [options.minify=true] - Whether to return the minified or raw implementation of the polyfills.
+	 * @param {'ignore'|'polyfill'} [options.unknown='ignore'] - Whether to return all polyfills or no polyfills if the user-agent is unknown or unsupported.
+	 * @param {Object} [options.features={}] - Which features should be returned if the user-agent does not support them natively.
+	 * @param {Array<String>} [options.excludes=[]] - Which features should be excluded from the returned object.
+	 * @param {String} [options.uaString=''] - The user-agent string to check each feature against.
+	 * @param {Boolean} [options.rum=false] - Whether to add a script to the polyfill bundle which reports anonymous usage data.
+	 * @param {Boolean} [options.stream=false] - Whether to return a stream or a string of the polyfill bundle.
+	 * @return {Promise<String> | ReadStream} - Polyfill bundle as either a utf-8 stream or a promise of a utf-8 string.
+	 */
 	getPolyfillString(options) {
 		options = this.getOptions(options);
 		const ua = new UA(options.uaString);
@@ -337,7 +387,7 @@ const PolyfillLibrary = class PolyfillLibrary {
 		return options.stream ? output : Promise.resolve(streamToString(output));
 	};
 };
+
 PolyfillLibrary.prototype.normalizeUserAgent = UA.normalize;
-PolyfillLibrary.normalizeUserAgent = UA.normalize;
 
 module.exports = PolyfillLibrary;

--- a/packages/polyfill-library/lib/index.js
+++ b/packages/polyfill-library/lib/index.js
@@ -351,6 +351,10 @@ const PolyfillLibrary = class PolyfillLibrary {
 				}
 			});
 
+			if (options.callback && typeof options.callback === 'string' && options.callback.match(/^[\w\.]+$/)) {
+				output.add(streamFromString("\ntypeof "+options.callback+"==='function' && "+options.callback+"();"));
+			}
+
 		return options.stream ? output : Promise.resolve(streamToString(output));
 	}
 };

--- a/packages/polyfill-library/lib/sources.js
+++ b/packages/polyfill-library/lib/sources.js
@@ -1,73 +1,63 @@
-'use strict';
+"use strict";
 
-const path = require('path');
-const fs = require('graceful-fs');
-const denodeify = require('denodeify');
+const path = require("path");
+const fs = require("graceful-fs");
+const denodeify = require("denodeify");
 const readFile = denodeify(fs.readFile);
-const process = require('process');
-const console = require('console');
+module.exports = class Sources {
+	constructor(polyfillsPath = path.join(__dirname, "../polyfills/__dist")) {
+		this.polyfillsPath = polyfillsPath;
+		// Discover and index all the available polyfills (synchronously so that the index is available for the first request)
+		try {
+			this.metadata = {};
+			this.configuredAliases = require(path.join(polyfillsPath, "aliases.json"));
+			this.features = fs.readdirSync(polyfillsPath).filter(f => f.indexOf(".json") === -1);
+			this.features.forEach(featureName => {
+				this.metadata[featureName] = JSON.parse(fs.readFileSync(path.join(polyfillsPath, featureName, "meta.json"), "UTF-8"));
+			});
+		} catch (e) {
+			throw new Error(`No polyfill sources found in ${polyfillsPath}.  Run "npm run build" to build them`);
+		}
+	}
 
-const polyfillsPath = path.join(__dirname, '../polyfills/__dist');
+	polyfillExistsSync(featureName) {
+		return this.features.indexOf(featureName) !== -1;
+	}
 
-let features;
-let configuredAliases;
-const metadata = {};
+	getPolyfillMetaSync(featureName) {
+		return this.metadata[featureName];
+	}
 
-// Discover and index all the available polyfills (synchronously so that the index is available for the first request)
-try {
-	configuredAliases = require('../polyfills/__dist/aliases.json');
-	features = fs.readdirSync(polyfillsPath).filter(f => f.indexOf('.json') === -1);
-	features.forEach(featureName => {
-		metadata[featureName] = JSON.parse(fs.readFileSync(path.join(polyfillsPath, featureName, 'meta.json'), 'UTF-8'));
-	});
-} catch(e) {
-	console.log("No polyfill sources found.  Run `npm run build` to build them");
-	process.exit(1);
-}
+	listPolyfillsSync() {
+		return this.features;
+	}
 
-exports.polyfillExistsSync = function(featureName) {
-	return (features.indexOf(featureName) !== -1);
-};
+	listPolyfills() {
+		return Promise.resolve(this.features);
+	}
 
-exports.getPolyfillMetaSync = function(featureName) {
-	return metadata[featureName];
-};
+	getConfigAliasesSync(featureName) {
+		return this.configuredAliases[featureName];
+	}
 
-exports.listPolyfillsSync = function() {
-	return features;
-};
+	streamPolyfillSource(featureName, type) {
+		return fs.createReadStream(path.join(this.polyfillsPath, featureName, type + ".js"), { encoding: "UTF-8" });
+	}
 
-
-exports.listPolyfills = function() {
-	return Promise.resolve(features);
-};
-
-exports.getConfigAliasesSync = function(featureName) {
-	return configuredAliases[featureName];
-};
-
-exports.streamPolyfillSource = function (featureName, type) {
-	return fs.createReadStream(path.join(polyfillsPath, featureName, type + '.js'), { encoding: 'UTF-8' });
-};
-
-// TODO: deprecate this
-exports.getPolyfill = function (featureName) {
-	if (features.indexOf(featureName) !== -1) {
-		const getSources = [
-			readFile(path.join(polyfillsPath, featureName, 'raw.js'), 'utf-8'),
-			readFile(path.join(polyfillsPath, featureName, 'min.js'), 'utf-8')
-		];
-		return Promise.all(getSources)
-			.then(sources => {
-				const op = Object.assign({}, metadata[featureName], {
+	// TODO: deprecate this
+	getPolyfill(featureName) {
+		if (this.features.indexOf(featureName) !== -1) {
+			const getSources = [readFile(path.join(this.polyfillsPath, featureName, "raw.js"), "utf-8"), readFile(path.join(this.polyfillsPath, featureName, "min.js"), "utf-8")];
+			return Promise.all(getSources).then(sources => {
+				const op = Object.assign({}, this.metadata[featureName], {
 					rawSource: sources[0],
 					minSource: sources[1],
 					name: featureName
 				});
 				return op;
-			})
-		;
-	} else {
-		return Promise.resolve(null);
+			});
+		} else {
+			return Promise.resolve(null);
+		}
 	}
 };

--- a/packages/polyfill-library/lib/sources.js
+++ b/packages/polyfill-library/lib/sources.js
@@ -4,60 +4,56 @@ const path = require("path");
 const fs = require("graceful-fs");
 const denodeify = require("denodeify");
 const readFile = denodeify(fs.readFile);
-module.exports = class Sources {
+const readdir = denodeify(fs.readdir);
+const Sources = class Sources {
 	constructor(polyfillsPath = path.join(__dirname, "../polyfills/__dist")) {
 		this.polyfillsPath = polyfillsPath;
-		// Discover and index all the available polyfills (synchronously so that the index is available for the first request)
-		try {
-			this.metadata = {};
-			this.configuredAliases = require(path.join(polyfillsPath, "aliases.json"));
-			this.features = fs.readdirSync(polyfillsPath).filter(f => f.indexOf(".json") === -1);
-			this.features.forEach(featureName => {
-				this.metadata[featureName] = JSON.parse(fs.readFileSync(path.join(polyfillsPath, featureName, "meta.json"), "UTF-8"));
-			});
-		} catch (e) {
-			throw new Error(`No polyfill sources found in ${polyfillsPath}.  Run "npm run build" to build them`);
-		}
 	}
 
-	polyfillExistsSync(featureName) {
-		return this.features.indexOf(featureName) !== -1;
+	polyfillExists(featureName) {
+		return new Promise((resolve, reject) => {
+			fs.stat(
+				path.join(this.polyfillsPath, featureName, "raw.js"),
+				(err, stats) => {
+					if (err) {
+						return err.code === "ENOENT" ? resolve(false) : reject(err);
+					}
+					resolve(stats.isFile());
+				}
+			);
+		});
 	}
 
-	getPolyfillMetaSync(featureName) {
-		return this.metadata[featureName];
-	}
-
-	listPolyfillsSync() {
-		return this.features;
+	getPolyfillMeta(featureName) {
+		return readFile(
+			path.join(this.polyfillsPath, featureName, "meta.json"),
+			"UTF-8"
+		)
+			.then(JSON.parse)
+			.catch(() => undefined);
 	}
 
 	listPolyfills() {
-		return Promise.resolve(this.features);
+		return readdir(this.polyfillsPath).then(features =>
+			features.filter(f => f.indexOf(".json") === -1)
+		);
 	}
 
-	getConfigAliasesSync(featureName) {
-		return this.configuredAliases[featureName];
+	getConfigAliases(featureName) {
+		return readFile(path.join(this.polyfillsPath, "aliases.json")).then(
+			aliasesJson => {
+				const aliases = JSON.parse(aliasesJson);
+				return aliases[featureName] ? aliases[featureName] : undefined;
+			}
+		);
 	}
 
 	streamPolyfillSource(featureName, type) {
-		return fs.createReadStream(path.join(this.polyfillsPath, featureName, type + ".js"), { encoding: "UTF-8" });
-	}
-
-	// TODO: deprecate this
-	getPolyfill(featureName) {
-		if (this.features.indexOf(featureName) !== -1) {
-			const getSources = [readFile(path.join(this.polyfillsPath, featureName, "raw.js"), "utf-8"), readFile(path.join(this.polyfillsPath, featureName, "min.js"), "utf-8")];
-			return Promise.all(getSources).then(sources => {
-				const op = Object.assign({}, this.metadata[featureName], {
-					rawSource: sources[0],
-					minSource: sources[1],
-					name: featureName
-				});
-				return op;
-			});
-		} else {
-			return Promise.resolve(null);
-		}
+		return fs.createReadStream(
+			path.join(this.polyfillsPath, featureName, type + ".js"),
+			{ encoding: "UTF-8" }
+		);
 	}
 };
+
+module.exports = Sources;

--- a/packages/polyfill-library/lib/sources.js
+++ b/packages/polyfill-library/lib/sources.js
@@ -5,11 +5,27 @@ const fs = require("graceful-fs");
 const denodeify = require("denodeify");
 const readFile = denodeify(fs.readFile);
 const readdir = denodeify(fs.readdir);
+
+/**
+ * Class representing a collection of polyfill sources.
+ */
 const Sources = class Sources {
+	/**
+	 * Create an instance of Sources.
+	 * @param {String} [polyfillsPath] - The folder location on the file system where the polyfill sources exist.
+	 * Defaults to the location of the polyfill sources which come bundled with the polyfill-library module.
+	 * @returns {Sources} A new Sources instance.
+	 */
 	constructor(polyfillsPath = path.join(__dirname, "../polyfills/__dist")) {
 		this.polyfillsPath = polyfillsPath;
 	}
 
+	/**
+	 * Find out if a specific polyfill exists within the collection of polyfill sources.
+	 * @param {String} featureName - The name of a polyfill which may exist.
+	 * @returns {Promise<Boolean>} A promise which resolves with `true` if the polyfill exists or `false` if the polyfill does not exist.
+	 * @throws {Error} Will throw if an error occurs when checking the file system for the polyfill.
+	 */
 	polyfillExists(featureName) {
 		return new Promise((resolve, reject) => {
 			fs.stat(
@@ -24,6 +40,11 @@ const Sources = class Sources {
 		});
 	}
 
+	/**
+	 * Get the metadata for a specific polyfill within the collection of polyfill sources.
+	 * @param {String} featureName - The name of a polyfill whose metadata should be returned.
+	 * @returns {Promise<Object|undefined>} A promise which resolves with the metadata or with `undefined` if no metadata exists for the polyfill.
+	 */
 	getPolyfillMeta(featureName) {
 		return readFile(
 			path.join(this.polyfillsPath, featureName, "meta.json"),
@@ -33,12 +54,21 @@ const Sources = class Sources {
 			.catch(() => undefined);
 	}
 
+	/**
+	 * Get a list of all the polyfills which exist within the collection of polyfill sources.
+	 * @returns {Promise<Array>} A promise which resolves with an array of all the polyfills within the collection.
+	 */
 	listPolyfills() {
 		return readdir(this.polyfillsPath).then(features =>
 			features.filter(f => f.indexOf(".json") === -1)
 		);
 	}
 
+	/**
+	 * Get the aliases for a specific polyfill.
+	 * @param {String} featureName - The name of a polyfill whose metadata should be returned.
+	 * @returns {Promise<Object|undefined>} A promise which resolves with the metadata or with `undefined` if no metadata exists for the polyfill.
+	 */
 	getConfigAliases(featureName) {
 		return readFile(path.join(this.polyfillsPath, "aliases.json")).then(
 			aliasesJson => {
@@ -48,6 +78,12 @@ const Sources = class Sources {
 		);
 	}
 
+	/**
+	 * Get the aliases for a specific polyfill.
+	 * @param {String} featureName - The name of a polyfill whose implementation should be returned.
+	 * @param {'min'|'raw'} type - Which implementation should be returned: minified or raw implementation.
+	 * @returns {ReadStream} A ReadStream instance of the polyfill implementation as a utf-8 string.
+	 */
 	streamPolyfillSource(featureName, type) {
 		return fs.createReadStream(
 			path.join(this.polyfillsPath, featureName, type + ".js"),

--- a/packages/polyfill-library/package-lock.json
+++ b/packages/polyfill-library/package-lock.json
@@ -84,12 +84,14 @@
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
     },
     "ansi-styles": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
     },
     "append-transform": {
       "version": "0.4.0",
@@ -207,6 +209,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
       "requires": {
         "chalk": "1.1.3",
         "esutils": "2.0.2",
@@ -217,6 +220,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
       "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+      "dev": true,
       "requires": {
         "babel-code-frame": "6.26.0",
         "babel-generator": "6.26.0",
@@ -243,6 +247,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
       "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
+      "dev": true,
       "requires": {
         "babel-messages": "6.23.0",
         "babel-runtime": "6.26.0",
@@ -258,6 +263,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+      "dev": true,
       "requires": {
         "babel-helper-hoist-variables": "6.24.1",
         "babel-runtime": "6.26.0",
@@ -269,6 +275,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
       "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
+      "dev": true,
       "requires": {
         "babel-helper-function-name": "6.24.1",
         "babel-runtime": "6.26.0",
@@ -280,6 +287,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+      "dev": true,
       "requires": {
         "babel-helper-get-function-arity": "6.24.1",
         "babel-runtime": "6.26.0",
@@ -292,6 +300,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0"
@@ -301,6 +310,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0"
@@ -310,6 +320,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0"
@@ -319,6 +330,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
       "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0",
@@ -329,6 +341,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
       "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
+      "dev": true,
       "requires": {
         "babel-helper-optimise-call-expression": "6.24.1",
         "babel-messages": "6.23.0",
@@ -342,6 +355,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-template": "6.26.0"
@@ -351,6 +365,7 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
       }
@@ -359,6 +374,7 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
       }
@@ -367,6 +383,7 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
       }
@@ -375,6 +392,7 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
       }
@@ -383,6 +401,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
       "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-template": "6.26.0",
@@ -395,6 +414,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
       "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
+      "dev": true,
       "requires": {
         "babel-helper-define-map": "6.26.0",
         "babel-helper-function-name": "6.24.1",
@@ -411,6 +431,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-template": "6.26.0"
@@ -420,6 +441,7 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
       }
@@ -428,6 +450,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
       "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0"
@@ -437,6 +460,7 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
       }
@@ -445,6 +469,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
+      "dev": true,
       "requires": {
         "babel-helper-function-name": "6.24.1",
         "babel-runtime": "6.26.0",
@@ -455,6 +480,7 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
       }
@@ -463,6 +489,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
       "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
+      "dev": true,
       "requires": {
         "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
         "babel-runtime": "6.26.0",
@@ -473,6 +500,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
       "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
+      "dev": true,
       "requires": {
         "babel-plugin-transform-strict-mode": "6.24.1",
         "babel-runtime": "6.26.0",
@@ -484,6 +512,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
       "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
+      "dev": true,
       "requires": {
         "babel-helper-hoist-variables": "6.24.1",
         "babel-runtime": "6.26.0",
@@ -494,6 +523,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
       "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
+      "dev": true,
       "requires": {
         "babel-plugin-transform-es2015-modules-amd": "6.24.1",
         "babel-runtime": "6.26.0",
@@ -504,6 +534,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
       "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
+      "dev": true,
       "requires": {
         "babel-helper-replace-supers": "6.24.1",
         "babel-runtime": "6.26.0"
@@ -513,6 +544,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+      "dev": true,
       "requires": {
         "babel-helper-call-delegate": "6.24.1",
         "babel-helper-get-function-arity": "6.24.1",
@@ -526,6 +558,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0"
@@ -535,6 +568,7 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
       }
@@ -543,6 +577,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
+      "dev": true,
       "requires": {
         "babel-helper-regex": "6.26.0",
         "babel-runtime": "6.26.0",
@@ -553,6 +588,7 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
       }
@@ -561,6 +597,7 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
       }
@@ -569,6 +606,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
+      "dev": true,
       "requires": {
         "babel-helper-regex": "6.26.0",
         "babel-runtime": "6.26.0",
@@ -579,6 +617,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
       "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
+      "dev": true,
       "requires": {
         "regenerator-transform": "0.10.1"
       }
@@ -587,6 +626,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0"
@@ -596,6 +636,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
       "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
+      "dev": true,
       "requires": {
         "babel-plugin-check-es2015-constants": "6.22.0",
         "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
@@ -627,6 +668,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+      "dev": true,
       "requires": {
         "babel-core": "6.26.0",
         "babel-runtime": "6.26.0",
@@ -641,6 +683,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true,
       "requires": {
         "core-js": "2.5.3",
         "regenerator-runtime": "0.11.1"
@@ -650,6 +693,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-traverse": "6.26.0",
@@ -662,6 +706,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+      "dev": true,
       "requires": {
         "babel-code-frame": "6.26.0",
         "babel-messages": "6.23.0",
@@ -678,6 +723,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "esutils": "2.0.2",
@@ -688,12 +734,14 @@
     "babylon": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+      "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "base": {
       "version": "0.11.2",
@@ -731,6 +779,7 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "dev": true,
       "requires": {
         "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
@@ -827,6 +876,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
       "requires": {
         "ansi-styles": "2.2.1",
         "escape-string-regexp": "1.0.5",
@@ -971,6 +1021,12 @@
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
+    },
     "collection-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -1020,7 +1076,8 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "concat-stream": {
       "version": "1.6.0",
@@ -1036,7 +1093,8 @@
     "convert-source-map": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-      "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
+      "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
+      "dev": true
     },
     "copy-descriptor": {
       "version": "0.1.1",
@@ -1047,7 +1105,8 @@
     "core-js": {
       "version": "2.5.3",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-      "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
+      "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -1069,6 +1128,7 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -1145,6 +1205,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+      "dev": true,
       "requires": {
         "repeating": "2.0.1"
       }
@@ -1176,7 +1237,8 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "eslint": {
       "version": "4.13.1",
@@ -1338,7 +1400,8 @@
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
     },
     "event-source-polyfill": {
       "version": "0.0.9",
@@ -1574,6 +1637,12 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
+    "get-caller-file": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+      "dev": true
+    },
     "get-value": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
@@ -1633,7 +1702,8 @@
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "dev": true
     },
     "globby": {
       "version": "5.0.0",
@@ -1691,6 +1761,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
       "requires": {
         "ansi-regex": "2.1.1"
       }
@@ -1771,6 +1842,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+      "dev": true,
       "requires": {
         "os-homedir": "1.0.2",
         "os-tmpdir": "1.0.2"
@@ -1911,6 +1983,7 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
       "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+      "dev": true,
       "requires": {
         "loose-envify": "1.3.1"
       }
@@ -2019,6 +2092,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "dev": true,
       "requires": {
         "number-is-nan": "1.0.1"
       }
@@ -2155,7 +2229,8 @@
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
     },
     "js-yaml": {
       "version": "3.10.0",
@@ -2170,7 +2245,8 @@
     "jsesc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+      "dev": true
     },
     "json-schema-traverse": {
       "version": "0.3.1",
@@ -2193,7 +2269,8 @@
     "json5": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+      "dev": true
     },
     "just-extend": {
       "version": "1.1.27",
@@ -2348,6 +2425,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "dev": true,
       "requires": {
         "js-tokens": "3.0.2"
       }
@@ -2413,6 +2491,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
         "brace-expansion": "1.1.8"
       }
@@ -2447,6 +2526,7 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }
@@ -2526,7 +2606,8 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "mutationobserver-shim": {
       "version": "0.3.2",
@@ -2665,7 +2746,8 @@
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
     },
     "nyc": {
       "version": "10.3.2",
@@ -2722,18 +2804,6 @@
             "string-width": "1.0.2",
             "strip-ansi": "3.0.1",
             "wrap-ansi": "2.1.0"
-          },
-          "dependencies": {
-            "wrap-ansi": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-              "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-              "dev": true,
-              "requires": {
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1"
-              }
-            }
           }
         },
         "convert-source-map": {
@@ -2990,14 +3060,6 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
-          },
-          "dependencies": {
-            "code-point-at": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-              "dev": true
-            }
           }
         },
         "supports-color": {
@@ -3234,63 +3296,6 @@
             "which-module": "1.0.0",
             "y18n": "3.2.1",
             "yargs-parser": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz"
-          },
-          "dependencies": {
-            "get-caller-file": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-              "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
-              "dev": true
-            },
-            "os-locale": {
-              "version": "1.4.0",
-              "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-              "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-              "dev": true,
-              "requires": {
-                "lcid": "1.0.0"
-              }
-            },
-            "read-pkg-up": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-              "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-              "dev": true,
-              "requires": {
-                "find-up": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-                "read-pkg": "1.1.0"
-              }
-            },
-            "require-directory": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-              "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-              "dev": true
-            },
-            "require-main-filename": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-              "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-              "dev": true
-            },
-            "set-blocking": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-              "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-              "dev": true
-            },
-            "which-module": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-              "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
-              "dev": true
-            },
-            "y18n": {
-              "version": "3.2.1",
-              "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-              "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-              "dev": true
-            }
           }
         },
         "yargs-parser": {
@@ -3470,7 +3475,17 @@
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
+    },
+    "os-locale": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "dev": true,
+      "requires": {
+        "lcid": "1.0.0"
+      }
     },
     "os-tmpdir": {
       "version": "1.0.2",
@@ -3533,7 +3548,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -3621,7 +3637,8 @@
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+      "dev": true
     },
     "process-nextick-args": {
       "version": "1.0.7",
@@ -3705,6 +3722,16 @@
         "path-type": "1.1.0"
       }
     },
+    "read-pkg-up": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "dev": true,
+      "requires": {
+        "find-up": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+        "read-pkg": "1.1.0"
+      }
+    },
     "readable-stream": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
@@ -3722,17 +3749,20 @@
     "regenerate": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
-      "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg=="
+      "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
+      "dev": true
     },
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+      "dev": true
     },
     "regenerator-transform": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
       "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0",
@@ -3783,6 +3813,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+      "dev": true,
       "requires": {
         "regenerate": "1.3.3",
         "regjsgen": "0.2.0",
@@ -3792,12 +3823,14 @@
     "regjsgen": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
+      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+      "dev": true
     },
     "regjsparser": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+      "dev": true,
       "requires": {
         "jsesc": "0.5.0"
       },
@@ -3805,7 +3838,8 @@
         "jsesc": {
           "version": "0.5.0",
           "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+          "dev": true
         }
       }
     },
@@ -3830,9 +3864,22 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "dev": true,
       "requires": {
         "is-finite": "1.0.2"
       }
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-main-filename": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+      "dev": true
     },
     "require-uncached": {
       "version": "1.0.3",
@@ -3938,6 +3985,12 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
       "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
     },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
     "set-value": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
@@ -4017,7 +4070,8 @@
     "slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+      "dev": true
     },
     "slice-ansi": {
       "version": "1.0.0",
@@ -4177,6 +4231,7 @@
       "version": "0.4.18",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+      "dev": true,
       "requires": {
         "source-map": "0.5.7"
       }
@@ -4406,6 +4461,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
       "requires": {
         "ansi-regex": "2.1.1"
       }
@@ -4428,7 +4484,8 @@
     "supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
     },
     "table": {
       "version": "4.0.2",
@@ -4504,7 +4561,8 @@
     "to-fast-properties": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+      "dev": true
     },
     "to-object-path": {
       "version": "0.3.0",
@@ -4572,7 +4630,8 @@
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+      "dev": true
     },
     "tsort": {
       "version": "0.0.1",
@@ -4798,6 +4857,12 @@
         "isexe": "2.0.0"
       }
     },
+    "which-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+      "dev": true
+    },
     "window-size": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
@@ -4807,6 +4872,38 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
       "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+    },
+    "wrap-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "dev": true,
+      "requires": {
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        }
+      }
     },
     "wrappy": {
       "version": "1.0.2",
@@ -4833,6 +4930,12 @@
         "imurmurhash": "0.1.4",
         "slide": "1.1.6"
       }
+    },
+    "y18n": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+      "dev": true
     },
     "yaku": {
       "version": "0.17.11",

--- a/packages/polyfill-library/package.json
+++ b/packages/polyfill-library/package.json
@@ -37,7 +37,7 @@
   },
   "license": "CC0-1.0",
   "engines": {
-    "node": "6.11.1 - 9"
+    "node": ">=8"
   },
   "dependencies": {
     "denodeify": "^1.2.1",

--- a/packages/polyfill-library/package.json
+++ b/packages/polyfill-library/package.json
@@ -40,8 +40,6 @@
     "node": "6.11.1 - 9"
   },
   "dependencies": {
-    "babel-core": "^6.23.1",
-    "babel-preset-es2015": "^6.1.18",
     "denodeify": "^1.2.1",
     "from2-string": "^1.1.0",
     "graceful-fs": "^4.1.10",
@@ -58,6 +56,8 @@
     "useragent": "^2.1.12"
   },
   "devDependencies": {
+    "babel-core": "^6.23.1",
+    "babel-preset-es2015": "^6.1.18",
     "Base64": "^1.0.0",
     "array.of": "^0.1.1",
     "audio-context-polyfill": "^1.0.0",

--- a/packages/polyfill-library/test/unit/lib/index.js
+++ b/packages/polyfill-library/test/unit/lib/index.js
@@ -70,13 +70,16 @@ describe("polyfillio", () => {
 
 	});
 
-	describe('exports', () => {
-		beforeEach(() => {
-			polyfillio = require('../../../lib/index');
+	describe('exported property/properties', () => {
+		it('an object', () => {
+			assert.isFunction(require('../../../lib/index'));
 		});
+	});
 
-		it('exports an object', () => {
-			assert.isObject(polyfillio);
+	describe('constructed instance', () => {
+		beforeEach(() => {
+			const Polyfillio = require('../../../lib/index');
+			polyfillio = new Polyfillio;
 		});
 
 		it('describePolyfill is an exported function', () => {
@@ -101,41 +104,38 @@ describe("polyfillio", () => {
 	});
 
 	describe('.listAllPolyfills()', () => {
-		beforeEach(() => {
-			polyfillio = require('../../../lib/index');
-		});
-
-		it('calls and returns sourceslib.listPolyfills() without passing argument', () => {
-			sourceslib.listPolyfills.returns('return value for sourceslib.listPolyfills');
-			assert.equal(polyfillio.listAllPolyfills('test'), 'return value for sourceslib.listPolyfills');
-			assert.calledOnce(sourceslib.listPolyfills);
-			assert.neverCalledWith(sourceslib.listPolyfills, 'test');
+		it('calls and returns sourceslib.instance.listPolyfills() without passing argument', () => {
+			const Polyfillio = require('../../../lib/index');
+			polyfillio = new Polyfillio;
+			sourceslib.instance.listPolyfills.resolves('return value for sourceslib.instance.listPolyfills');
+			return polyfillio.listAllPolyfills('test').then(result => {
+				assert.equal(result, 'return value for sourceslib.instance.listPolyfills')
+				assert.calledOnce(sourceslib.instance.listPolyfills);
+				assert.neverCalledWith(sourceslib.instance.listPolyfills, 'test');
+			});
 		});
 	});
 
 	describe('.describePolyfill()', () => {
-		beforeEach(() => {
-			polyfillio = require('../../../lib/index');
-		});
+		it('calls and returns sourceslib.instance.getPolyfillMeta() with passed argument', () => {
+			const Polyfillio = require('../../../lib/index');
+			const polyfillio = new Polyfillio;
 
-		it('calls and returns sourceslib.getPolyfillMetaSync() with passed argument', () => {
-			sourceslib.getPolyfillMetaSync.returns('return value for sourceslib.getPolyfillMetaSync');
+			sourceslib.instance.getPolyfillMeta.resolves('return value for sourceslib.instance.getPolyfillMeta');
 			return polyfillio.describePolyfill('test')
 				.then(result => {
-					assert.equal(result, 'return value for sourceslib.getPolyfillMetaSync');
-					assert.calledOnce(sourceslib.getPolyfillMetaSync);
-					assert.calledWithExactly(sourceslib.getPolyfillMetaSync, 'test');
+					assert.equal(result, 'return value for sourceslib.instance.getPolyfillMeta');
+					assert.calledOnce(sourceslib.instance.getPolyfillMeta);
+					assert.calledWithExactly(sourceslib.instance.getPolyfillMeta, 'test');
 				})
 			;
 		});
 	});
 
 	describe('.normalizeUserAgent()', () => {
-		beforeEach(() => {
-			polyfillio = require('../../../lib/index');
-		});
-
 		it('calls and returns UA.normalize() with passed argument and UA', () => {
+			const Polyfillio = require('../../../lib/index');
+			polyfillio = new Polyfillio;
 			UA.normalize.returns('return value for UA.normalize');
 			assert.equal(polyfillio.normalizeUserAgent('test'), 'return value for UA.normalize');
 			assert.calledOnce(UA.normalize);
@@ -146,49 +146,43 @@ describe("polyfillio", () => {
 	describe('.getPolyfills()', () => {
 
 		describe('when options.features contains the `all` feature', () => {
-			beforeEach(() => {
-				polyfillio = require('../../../lib/index');
-			});
-
 			it('resolves to all polyfills', () => {
+				const Polyfillio = require('../../../lib/index');
+				polyfillio = new Polyfillio;
 
-				assert.notCalled(sourceslib.listPolyfillsSync);
+				assert.notCalled(sourceslib.instance.listPolyfills);
 
 				return polyfillio.getPolyfills({}).then(() => {
 					// Second argument to createAliasResolver contains the aliasAll function we are testing
 					const aliasAll = createAliasResolver.firstCall.args[1];
 
 					aliasAll('all');
-					assert.calledOnce(sourceslib.listPolyfillsSync);
+					assert.calledOnce(sourceslib.instance.listPolyfills);
 				});
 			});
 		});
 
 		describe('when options.features does not contains the `all` feature', () => {
-			beforeEach(() => {
-				polyfillio = require('../../../lib/index');
-			});
-
 			it('does not return all polyfills', () => {
+				const Polyfillio = require('../../../lib/index');
+				polyfillio = new Polyfillio;
 
-				assert.notCalled(sourceslib.listPolyfillsSync);
+				assert.notCalled(sourceslib.instance.listPolyfills);
 
 				return polyfillio.getPolyfills({}).then(() => {
 					// Second argument to createAliasResolver contains the aliasAll function we are testing
 					const aliasAll = createAliasResolver.firstCall.args[1];
 
 					aliasAll('es6');
-					assert.notCalled(sourceslib.listPolyfillsSync);
+					assert.notCalled(sourceslib.instance.listPolyfills);
 				});
 			});
 		});
 
 		describe('when options.uaString is not set', () => {
-			beforeEach(() => {
-				polyfillio = require('../../../lib/index');
-			});
-
 			it('calls UA with options.uAString set to an empty string', () => {
+				const Polyfillio = require('../../../lib/index');
+				polyfillio = new Polyfillio;
 				const options = {};
 				return polyfillio.getPolyfills(options).then(() => {
 					assert.calledWithExactly(UA, '');
@@ -197,11 +191,9 @@ describe("polyfillio", () => {
 		});
 
 		describe('when options.uaString is set', () => {
-			beforeEach(() => {
-				polyfillio = require('../../../lib/index');
-			});
-
 			it('calls UA with options.uAString', () => {
+				const Polyfillio = require('../../../lib/index');
+				polyfillio = new Polyfillio;
 				const options = {
 					uaString: 'chrome/38'
 				};
@@ -212,13 +204,13 @@ describe("polyfillio", () => {
 		});
 
 		describe('when options.features has no flags set', () => {
-
 			it('calls `resolveAliases` function with features object, giving each feature an empty Set of flags', () => {
 				const resolveAliasesStub = sinon.stub().returnsArg(0);
 				const resolveDependenciesStub = sinon.stub().returnsArg(0);
 				createAliasResolver.onCall(0).returns(resolveAliasesStub);
 				createAliasResolver.onCall(1).returns(resolveDependenciesStub);
-				polyfillio = require('../../../lib/index');
+				const Polyfillio = require('../../../lib/index');
+				polyfillio = new Polyfillio;
 
 				const options = {
 					features: {
@@ -243,7 +235,8 @@ describe("polyfillio", () => {
 				const resolveDependenciesStub = sinon.stub().returnsArg(0);
 				createAliasResolver.onCall(0).returns(resolveAliasesStub);
 				createAliasResolver.onCall(1).returns(resolveDependenciesStub);
-				polyfillio = require('../../../lib/index');
+				const Polyfillio = require('../../../lib/index');
+				polyfillio = new Polyfillio;
 
 				const options = {
 					features: {
@@ -274,7 +267,8 @@ describe("polyfillio", () => {
 				const resolveDependenciesStub = sinon.stub().returnsArg(0);
 				createAliasResolver.onCall(0).returns(resolveAliasesStub);
 				createAliasResolver.onCall(1).returns(resolveDependenciesStub);
-				polyfillio = require('../../../lib/index');
+				const Polyfillio = require('../../../lib/index');
+				polyfillio = new Polyfillio;;
 
 				const options = {
 					features: {
@@ -313,7 +307,7 @@ describe("polyfillio", () => {
 			createAliasResolver.onCall(0).returns(resolveAliasesStub);
 			createAliasResolver.onCall(1).returns(resolveDependenciesStub);
 
-			sourceslib.getPolyfillMetaSync.returns({
+			sourceslib.instance.getPolyfillMeta.resolves({
 				"browsers": {
 					"ie": "6 - 8"
 				}
@@ -321,7 +315,8 @@ describe("polyfillio", () => {
 			UA.mockUAInstance.getFamily.returns('ie');
 			UA.mockUAInstance.satisfies.returns(false);
 
-			polyfillio = require('../../../lib/index');
+			const Polyfillio = require('../../../lib/index');
+			polyfillio = new Polyfillio;;
 
 			const options = {
 				features: {
@@ -349,7 +344,7 @@ describe("polyfillio", () => {
 			createAliasResolver.onCall(0).returns(resolveAliasesStub);
 			createAliasResolver.onCall(1).returns(resolveDependenciesStub);
 
-			sourceslib.getPolyfillMetaSync.returns({
+			sourceslib.instance.getPolyfillMeta.resolves({
 				"browsers": {
 					"ie": "6 - 8"
 				}
@@ -357,7 +352,8 @@ describe("polyfillio", () => {
 			UA.mockUAInstance.getFamily.returns('ie');
 			UA.mockUAInstance.satisfies.returns(false);
 
-			polyfillio = require('../../../lib/index');
+			const Polyfillio = require('../../../lib/index');
+			polyfillio = new Polyfillio;;
 
 			const input = {
 				features: {
@@ -387,11 +383,12 @@ describe("polyfillio", () => {
 			createAliasResolver.onCall(0).returns(resolveAliasesStub);
 			createAliasResolver.onCall(1).returnsArg(0);
 
-			sourceslib.getPolyfillMetaSync.withArgs('Element.prototype.placeholder').returns({
+			sourceslib.instance.getPolyfillMeta.withArgs('Element.prototype.placeholder').resolves({
 				"dependencies": ["setImmediate", "Array.isArray", "Event"]
 			});
 
-			polyfillio = require('../../../lib/index');
+			const Polyfillio = require('../../../lib/index');
+			polyfillio = new Polyfillio;
 
 			const input = {
 				features: {
@@ -404,12 +401,12 @@ describe("polyfillio", () => {
 
 			return polyfillio.getPolyfills(input).then(() => {
 				const resolveDependencies = createAliasResolver.secondCall.args[0];
-				assert.deepEqual(resolveDependencies('Element.prototype.placeholder'), [
+				return resolveDependencies('Element.prototype.placeholder').then(dependencies=> assert.deepEqual(dependencies, [
 					"setImmediate",
 					"Array.isArray",
 					"Event",
 					"Element.prototype.placeholder"
-				]);
+				]));
 			});
 		});
 	});

--- a/packages/polyfill-library/test/unit/lib/index.js
+++ b/packages/polyfill-library/test/unit/lib/index.js
@@ -109,7 +109,7 @@ describe("polyfillio", () => {
 			polyfillio = new Polyfillio;
 			sourceslib.instance.listPolyfills.resolves('return value for sourceslib.instance.listPolyfills');
 			return polyfillio.listAllPolyfills('test').then(result => {
-				assert.equal(result, 'return value for sourceslib.instance.listPolyfills')
+				assert.equal(result, 'return value for sourceslib.instance.listPolyfills');
 				assert.calledOnce(sourceslib.instance.listPolyfills);
 				assert.neverCalledWith(sourceslib.instance.listPolyfills, 'test');
 			});

--- a/packages/polyfill-library/test/unit/mock/graceful-fs.mock.js
+++ b/packages/polyfill-library/test/unit/mock/graceful-fs.mock.js
@@ -5,6 +5,6 @@ const sinon = require('sinon');
 const fs = module.exports = sinon.stub();
 
 fs.readFile = sinon.stub();
-fs.readdirSync = sinon.stub();
-fs.readFileSync = sinon.stub();
+fs.readdir = sinon.stub();
 fs.createReadStream = sinon.stub();
+fs.stat = sinon.stub();

--- a/packages/polyfill-library/test/unit/mock/sources.mock.js
+++ b/packages/polyfill-library/test/unit/mock/sources.mock.js
@@ -2,12 +2,13 @@
 
 const sinon = require('sinon');
 
-module.exports = {
-	polyfillExistsSync: sinon.stub(),
-	getPolyfillMetaSync: sinon.stub(),
-	listPolyfillsSync: sinon.stub(),
-	listPolyfills: sinon.stub(),
-	getConfigAliasesSync: sinon.stub(),
+const instance = {
+	polyfillExists: sinon.stub().resolves(),
+	getPolyfillMeta: sinon.stub().resolves(),
+	listPolyfills: sinon.stub().resolves(),
+	getConfigAliases: sinon.stub().resolves(),
 	streamPolyfillSource: sinon.stub(),
-	getPolyfill: sinon.stub()
 };
+
+module.exports = sinon.stub().returns(instance);
+module.exports.instance = instance;

--- a/packages/polyfill-service/package-lock.json
+++ b/packages/polyfill-service/package-lock.json
@@ -4920,8 +4920,6 @@
     "polyfill-library": {
       "version": "file:../polyfill-library",
       "requires": {
-        "babel-core": "6.26.0",
-        "babel-preset-es2015": "6.24.1",
         "denodeify": "1.2.1",
         "from2-string": "1.1.0",
         "graceful-fs": "4.1.11",
@@ -5097,6 +5095,7 @@
         "babel-core": {
           "version": "6.26.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "babel-code-frame": "6.26.0",
             "babel-generator": "6.26.0",
@@ -5212,6 +5211,7 @@
         "babel-helpers": {
           "version": "6.24.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "babel-runtime": "6.26.0",
             "babel-template": "6.26.0"
@@ -5469,6 +5469,7 @@
         "babel-register": {
           "version": "6.26.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "babel-core": "6.26.0",
             "babel-runtime": "6.26.0",
@@ -5768,6 +5769,10 @@
           "version": "4.6.0",
           "bundled": true
         },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true
+        },
         "collection-visit": {
           "version": "1.0.0",
           "bundled": true,
@@ -5817,7 +5822,8 @@
         },
         "convert-source-map": {
           "version": "1.5.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "copy-descriptor": {
           "version": "0.1.1",
@@ -6274,6 +6280,10 @@
           "version": "1.0.1",
           "bundled": true
         },
+        "get-caller-file": {
+          "version": "1.0.2",
+          "bundled": true
+        },
         "get-value": {
           "version": "2.0.6",
           "bundled": true
@@ -6447,6 +6457,7 @@
         "home-or-tmp": {
           "version": "2.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "os-homedir": "1.0.2",
             "os-tmpdir": "1.0.2"
@@ -6765,7 +6776,8 @@
         },
         "json5": {
           "version": "0.5.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "just-extend": {
           "version": "1.1.27",
@@ -7195,16 +7207,6 @@
                 "string-width": "1.0.2",
                 "strip-ansi": "3.0.1",
                 "wrap-ansi": "2.1.0"
-              },
-              "dependencies": {
-                "wrap-ansi": {
-                  "version": "2.1.0",
-                  "bundled": true,
-                  "requires": {
-                    "string-width": "1.0.2",
-                    "strip-ansi": "3.0.1"
-                  }
-                }
               }
             },
             "convert-source-map": {
@@ -7413,12 +7415,6 @@
                 "code-point-at": "1.1.0",
                 "is-fullwidth-code-point": "1.0.0",
                 "strip-ansi": "3.0.1"
-              },
-              "dependencies": {
-                "code-point-at": {
-                  "version": "1.1.0",
-                  "bundled": true
-                }
               }
             },
             "supports-color": {
@@ -7614,47 +7610,6 @@
                 "which-module": "1.0.0",
                 "y18n": "3.2.1",
                 "yargs-parser": "5.0.0"
-              },
-              "dependencies": {
-                "get-caller-file": {
-                  "version": "1.0.2",
-                  "bundled": true
-                },
-                "os-locale": {
-                  "version": "1.4.0",
-                  "bundled": true,
-                  "requires": {
-                    "lcid": "1.0.0"
-                  }
-                },
-                "read-pkg-up": {
-                  "version": "1.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "find-up": "1.1.2",
-                    "read-pkg": "1.1.0"
-                  }
-                },
-                "require-directory": {
-                  "version": "2.1.1",
-                  "bundled": true
-                },
-                "require-main-filename": {
-                  "version": "1.0.1",
-                  "bundled": true
-                },
-                "set-blocking": {
-                  "version": "2.0.0",
-                  "bundled": true
-                },
-                "which-module": {
-                  "version": "1.0.0",
-                  "bundled": true
-                },
-                "y18n": {
-                  "version": "3.2.1",
-                  "bundled": true
-                }
               }
             },
             "yargs-parser": {
@@ -7798,6 +7753,13 @@
         "os-homedir": {
           "version": "1.0.2",
           "bundled": true
+        },
+        "os-locale": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "lcid": "1.0.0"
+          }
         },
         "os-tmpdir": {
           "version": "1.0.2",
@@ -7980,6 +7942,14 @@
             "path-type": "1.1.0"
           }
         },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
+          }
+        },
         "readable-stream": {
           "version": "2.3.3",
           "bundled": true,
@@ -8091,6 +8061,14 @@
           "version": "",
           "bundled": true
         },
+        "require-directory": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "bundled": true
+        },
         "require-uncached": {
           "version": "1.0.3",
           "bundled": true,
@@ -8175,6 +8153,10 @@
           "version": "5.4.1",
           "bundled": true
         },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true
+        },
         "set-value": {
           "version": "2.0.0",
           "bundled": true,
@@ -8236,7 +8218,8 @@
         },
         "slash": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "slice-ansi": {
           "version": "1.0.0",
@@ -8364,6 +8347,7 @@
         "source-map-support": {
           "version": "0.4.18",
           "bundled": true,
+          "dev": true,
           "requires": {
             "source-map": "0.5.7"
           }
@@ -8877,6 +8861,10 @@
             "isexe": "2.0.0"
           }
         },
+        "which-module": {
+          "version": "1.0.0",
+          "bundled": true
+        },
         "window-size": {
           "version": "0.1.0",
           "bundled": true,
@@ -8889,6 +8877,32 @@
         "wordwrap": {
           "version": "0.0.3",
           "bundled": true
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1"
+          },
+          "dependencies": {
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "number-is-nan": "1.0.1"
+              }
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              }
+            }
+          }
         },
         "wrap-fn": {
           "version": "",
@@ -8913,6 +8927,10 @@
             "imurmurhash": "0.1.4",
             "slide": "1.1.6"
           }
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "bundled": true
         },
         "yaku": {
           "version": "0.17.11",

--- a/packages/polyfill-service/package.json
+++ b/packages/polyfill-service/package.json
@@ -47,7 +47,7 @@
   },
   "license": "CC0-1.0",
   "engines": {
-    "node": "6.11.1 - 9"
+    "node": ">=8"
   },
   "dependencies": {
     "accepts": "^1.3.4",

--- a/packages/polyfill-service/package.json
+++ b/packages/polyfill-service/package.json
@@ -20,9 +20,9 @@
   },
   "bugs": {
     "url": "https://github.com/financial-times/polyfill-service/issues"
-	},
-	"main": "node_modules/polyfill-library/lib/index.js",
-	"bin": "bin/polyfill-service",
+  },
+  "main": "node_modules/polyfill-library/lib/index.js",
+  "bin": "bin/polyfill-service",
   "scripts": {
     "start": "bin/polyfill-service",
     "dev": "node tasks/node/spawn service-with-watch",

--- a/packages/polyfill-service/service/routes/api.js
+++ b/packages/polyfill-service/service/routes/api.js
@@ -2,7 +2,8 @@
 
 'use strict';
 
-const polyfillio = require('polyfill-library');
+const Polyfillio = require('polyfill-library');
+const polyfillio = new Polyfillio;
 const PolyfillSet = require('../PolyfillSet');
 const metrics = require('../metrics');
 const express = require('express');

--- a/packages/polyfill-service/service/routes/docs.js
+++ b/packages/polyfill-service/service/routes/docs.js
@@ -209,10 +209,10 @@ function refreshData() {
 				'missing': 'Not supported'
 			};
 			return Promise.all(Object.keys(compatdata)
-				.filter(feature => sources.polyfillExistsSync(feature) && feature.indexOf('_') !== 0)
+				.filter(feature => sources.polyfillExists(feature) && feature.indexOf('_') !== 0)
 				.sort()
 				.map(feat => {
-					const polyfill = sources.getPolyfillMetaSync(feat);
+					const polyfill = sources.getPolyfillMeta(feat);
 					const fdata = {
 						feature: feat,
 						slug: feat.replace(/[^\w]/g, '_'),

--- a/packages/polyfill-service/service/routes/test.js
+++ b/packages/polyfill-service/service/routes/test.js
@@ -2,7 +2,8 @@
 
 'use strict';
 
-const polyfillio = require('polyfill-library');
+const Polyfillio = require('polyfill-library');
+const polyfillio = new Polyfillio;
 const express = require('express');
 const fs = require('graceful-fs');
 const path = require('path');


### PR DESCRIPTION
Currently there is no way to include a custom set of polyfills to use with the polyfill-library instead of the included set.

This pull-request adds the ability to use a custom set of polyfills, so long as they fit the expected api:
File-system structure --
```
├── <feature name>
│   ├── meta.json
│   ├── min.js
│   └── raw.js
└── aliases.json
```

meta.json --
```
{
	"aliases": ["es6", "default"],
	"browsers": {
		"chrome": "<45",
		"firefox": "4 - 31",
		"ie": "6 - 11",
		"ie_mob": "10 - *",
		"opera": "<32",
		"op_mini": "*",
		"safari": "<9",
		"firefox_mob": "<32",
		"android": "*",
		"ios_saf": "<9",
		"samsung_mob": "<5",
		"bb": "10 - *"
	},
	"dependencies": ["features the polyfill depends on"],
	"detectSource": "'from' in Array",
}
```

min.js --
```
minified version of the polyfill
```

raw.js --
```
original version of the polyfill
```

aliases.json --
```
{
	"alias-name": ["features", "included", "in",  "the", "alias"]
}
```
