### PR TITLE
fix: npm script targets to start server / watcher crashing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ npm-debug.log
 .nyc_output/
 ws-*.json
 ws-log-npm-report
+/**/yarn*
+.idea

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "A polyfill combinator",
   "scripts": {
     "build": "cd packages/polyfill-library && npm run build && cd ../..",
-    "dev": "cd packages/polyfill-library && npm run dev && cd ../..",
+    "dev": "cd packages/polyfill-service && npm run dev && cd ../..",
     "postinstall": "npm run build",
     "install": "npm run install:library && npm run install:service",
     "install:library": "cd packages/polyfill-library && npm install && cd ../..",

--- a/packages/polyfill-service/package-lock.json
+++ b/packages/polyfill-service/package-lock.json
@@ -1463,8 +1463,8 @@
       "dependencies": {
         "debug": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "resolved": "https://npm.groupondev.com:443/api/npm/npm-release/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -5558,10 +5558,6 @@
             }
           }
         },
-        "bl": {
-          "version": "",
-          "bundled": true
-        },
         "brace-expansion": {
           "version": "1.1.8",
           "bundled": true,
@@ -5633,10 +5629,6 @@
           "bundled": true,
           "optional": true
         },
-        "caw": {
-          "version": "",
-          "bundled": true
-        },
         "center-align": {
           "version": "0.1.3",
           "bundled": true,
@@ -5659,10 +5651,6 @@
         },
         "chardet": {
           "version": "0.4.2",
-          "bundled": true
-        },
-        "checksum": {
-          "version": "",
           "bundled": true
         },
         "circular-json": {
@@ -5846,10 +5834,6 @@
             "which": "1.3.0"
           }
         },
-        "cryptiles": {
-          "version": "",
-          "bundled": true
-        },
         "debug": {
           "version": "2.6.9",
           "bundled": true,
@@ -5867,22 +5851,6 @@
         },
         "decode-uri-component": {
           "version": "0.2.0",
-          "bundled": true
-        },
-        "decompress-tar": {
-          "version": "",
-          "bundled": true
-        },
-        "decompress-tarbz2": {
-          "version": "",
-          "bundled": true
-        },
-        "decompress-targz": {
-          "version": "",
-          "bundled": true
-        },
-        "decompress-unzip": {
-          "version": "",
           "bundled": true
         },
         "deep-is": {
@@ -5944,10 +5912,6 @@
           "requires": {
             "esutils": "2.0.2"
           }
-        },
-        "each-async": {
-          "version": "",
-          "bundled": true
         },
         "error-ex": {
           "version": "1.3.1",
@@ -6203,10 +6167,6 @@
             "pinkie-promise": "2.0.1"
           }
         },
-        "findup-sync": {
-          "version": "",
-          "bundled": true
-        },
         "flat-cache": {
           "version": "1.3.0",
           "bundled": true,
@@ -6328,14 +6288,6 @@
             }
           }
         },
-        "glob-stream": {
-          "version": "",
-          "bundled": true
-        },
-        "global-tunnel": {
-          "version": "",
-          "bundled": true
-        },
         "globals": {
           "version": "9.18.0",
           "bundled": true
@@ -6362,14 +6314,6 @@
         },
         "growl": {
           "version": "1.9.2",
-          "bundled": true
-        },
-        "gulp-sourcemaps": {
-          "version": "",
-          "bundled": true
-        },
-        "gulp-util": {
-          "version": "",
           "bundled": true
         },
         "handlebars": {
@@ -6942,10 +6886,6 @@
           "version": "1.2.0",
           "bundled": true
         },
-        "micromatch": {
-          "version": "",
-          "bundled": true
-        },
         "mimic-fn": {
           "version": "1.1.0",
           "bundled": true
@@ -7045,10 +6985,6 @@
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true
-        },
-        "multipipe": {
-          "version": "",
           "bundled": true
         },
         "mutationobserver-shim": {
@@ -7929,10 +7865,6 @@
             }
           }
         },
-        "rc": {
-          "version": "",
-          "bundled": true
-        },
         "read-pkg": {
           "version": "1.1.0",
           "bundled": true,
@@ -8057,10 +7989,6 @@
             "is-finite": "1.0.2"
           }
         },
-        "request": {
-          "version": "",
-          "bundled": true
-        },
         "require-directory": {
           "version": "2.1.1",
           "bundled": true
@@ -8143,10 +8071,6 @@
         },
         "samsam": {
           "version": "1.3.0",
-          "bundled": true
-        },
-        "seek-bzip": {
-          "version": "",
           "bundled": true
         },
         "semver": {
@@ -8541,10 +8465,6 @@
             "is-utf8": "0.2.1"
           }
         },
-        "strip-dirs": {
-          "version": "",
-          "bundled": true
-        },
         "strip-json-comments": {
           "version": "2.0.1",
           "bundled": true
@@ -8600,14 +8520,6 @@
         },
         "through": {
           "version": "2.3.8",
-          "bundled": true
-        },
-        "through2": {
-          "version": "",
-          "bundled": true
-        },
-        "through2-filter": {
-          "version": "",
           "bundled": true
         },
         "tmp": {
@@ -8830,10 +8742,6 @@
             }
           }
         },
-        "utile": {
-          "version": "",
-          "bundled": true
-        },
         "validate-npm-package-license": {
           "version": "3.0.3",
           "bundled": true,
@@ -8841,10 +8749,6 @@
             "spdx-correct": "3.0.0",
             "spdx-expression-parse": "3.0.0"
           }
-        },
-        "vinyl-fs": {
-          "version": "",
-          "bundled": true
         },
         "web-animations-js": {
           "version": "2.3.1",
@@ -8869,10 +8773,6 @@
           "version": "0.1.0",
           "bundled": true,
           "optional": true
-        },
-        "winston": {
-          "version": "",
-          "bundled": true
         },
         "wordwrap": {
           "version": "0.0.3",
@@ -8904,10 +8804,6 @@
             }
           }
         },
-        "wrap-fn": {
-          "version": "",
-          "bundled": true
-        },
         "wrappy": {
           "version": "1.0.2",
           "bundled": true
@@ -8933,7 +8829,7 @@
           "bundled": true
         },
         "yaku": {
-          "version": "0.17.11",
+          "version": "0.18.6",
           "bundled": true
         },
         "yallist": {

--- a/packages/polyfill-service/package.json
+++ b/packages/polyfill-service/package.json
@@ -25,6 +25,7 @@
   "bin": "bin/polyfill-service",
   "scripts": {
     "start": "bin/polyfill-service",
+	"build": "cd ../polyfill-library && npm run build && cd ../polyfill-service",
     "dev": "node tasks/node/spawn service-with-watch",
     "lint": "eslint bin service tasks",
     "test-browser-quick": "node tasks/node/spawn service remote-test:quick",
@@ -73,7 +74,7 @@
     "mysql2": "^1.2.0",
     "node-zopfli": "^2.0.2",
     "on-headers": "^1.0.1",
-    "polyfill-library": "file:../polyfill-library",
+    "polyfill-library": "file:///Users/arichter/repositories/3rd/polyfill-service/packages/polyfill-library",
     "proclaim": "^3.5.0",
     "pump": "^1.0.2",
     "raven": "^0.12.1",


### PR DESCRIPTION
issues: 
- https://github.com/Financial-Times/polyfill-service/issues/1711
- https://github.com/Financial-Times/polyfill-service/issues/1712

---

- [x] fixes `npm run dev` from root directory
- [x] fixes watcher crashing upon change, when watcher is started from `/packages/polyfill-service` with `npm run dev`