### PR TITLE
Update Promise.prototype.finally browser versions

### DIFF
--- a/packages/polyfill-library/polyfills/Promise/prototype/finally/config.json
+++ b/packages/polyfill-library/polyfills/Promise/prototype/finally/config.json
@@ -2,17 +2,17 @@
 	"aliases": [
 	],
 	"browsers": {
-		"android": ">4.4",
+		"android": ">4.4 <63",
 		"bb": ">10",
 		"chrome": ">31 <63",
-		"firefox": ">28",
-		"ios_saf": ">7.1",
+		"firefox": ">28 <58",
+		"ios_saf": ">7.1 <11.3",
 		"ie": ">12",
 		"ie_mob": "*",
-		"opera": ">19",
+		"opera": ">19 <50",
 		"op_mini": "*",
-		"safari": ">7",
-		"firefox_mob": ">28"
+		"safari": ">7 <11.1",
+		"firefox_mob": ">28 <58"
 	},
 	"dependencies": [
 		"_ESAbstract.CreateMethodProperty",


### PR DESCRIPTION
Currently many of the latest browsers support `finally` natively, but the polyfill is still setup to be used.

As of this writing, [MDN[(https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/finally_ is outdated on Safari, but [Kangax](http://kangax.github.io/compat-table/es2016plus/#test-Promise.prototype.finally) is up to date on ` Promise.prototype.finally ` browser support.