### PR TITLE
Update license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "bugs": {
     "url": "https://github.com/financial-times/polyfill-service/issues"
   },
-  "license": "CC0-1.0",
+  "license": "MIT",
   "engines": {
     "node": ">=8"
   },


### PR DESCRIPTION
Make package.json match what's in LICENSE.md (MIT).

This will help people using automated tools properly identifying package's license (correct one will also be displayed on npm).