### PR TITLE
Add cache for file/dir reader

### DIFF
--- a/packages/polyfill-library/lib/reader.js
+++ b/packages/polyfill-library/lib/reader.js
@@ -1,5 +1,6 @@
+'use strict';
 const fs = require("graceful-fs");
-const denodeify = require('denodeify');
+const denodeify = require("denodeify");
 const readFile = denodeify(fs.readFile);
 const readdir = denodeify(fs.readdir);
 
@@ -18,7 +19,6 @@ function check(key) {
 	}
 	return null;
 }
-
 
 // reader instance
 function cachedReader(...args) {

--- a/packages/polyfill-library/lib/reader.js
+++ b/packages/polyfill-library/lib/reader.js
@@ -1,0 +1,50 @@
+const fs = require("graceful-fs");
+const denodeify = require('denodeify');
+const readFile = denodeify(fs.readFile);
+const readdir = denodeify(fs.readdir);
+
+const cache = require("lru-cache")({
+	max: 500, // 500 files is enough
+});
+
+// generate key for cache
+const gk = JSON.stringify;
+
+// check cache store
+function check(key) {
+	const cached = cache.get(key);
+	if (cached) {
+		return cached;
+	}
+	return null;
+}
+
+
+// reader instance
+function cachedReader(...args) {
+	const key = gk(["f", args]);
+	const checked = check(key);
+	if (checked !== null) {
+		return checked;
+	}
+	const data = readFile.apply(null, args);
+	cache.set(key, data);
+	return data;
+}
+
+// dirReader instance
+function cachedDirReader(...args) {
+	const key = gk(["d", args]);
+	const checked = check(key);
+	if (checked !== null) {
+		return checked;
+	}
+	const data = readdir.apply(null, args);
+	cache.set(key, data);
+	return data;
+}
+
+module.exports = {
+	readFile: cachedReader,
+	readdir: cachedDirReader,
+};

--- a/packages/polyfill-library/lib/sources.js
+++ b/packages/polyfill-library/lib/sources.js
@@ -2,9 +2,8 @@
 
 const path = require("path");
 const fs = require("graceful-fs");
-const denodeify = require("denodeify");
-const readFile = denodeify(fs.readFile);
-const readdir = denodeify(fs.readdir);
+const readFile = require('./reader').readFile;
+const readdir = require('./reader').readdir;
 
 /**
  * Class representing a collection of polyfill sources.

--- a/packages/polyfill-library/test/unit/lib/reader.js
+++ b/packages/polyfill-library/test/unit/lib/reader.js
@@ -1,0 +1,36 @@
+/* eslint-env mocha */
+"use strict";
+
+const assert = require("proclaim");
+const readFileC = require("../../../lib/reader").readFile;
+const readdirC = require("../../../lib/reader").readdir;
+const fs = require("graceful-fs");
+const denodeify = require("denodeify");
+const readFile = denodeify(fs.readFile);
+const readdir = denodeify(fs.readdir);
+const path = require("path");
+
+const fp = path.join(__dirname, "../../../lib/reader.js");
+const dp = path.join(__dirname, "../../../lib");
+
+describe("lib/reader", () => {
+	it("read file without cache", () => {
+		return Promise.all([readFile(fp), readFileC(fp)]).then(rs => {
+      assert.deepEqual(rs[0],rs[1]);
+		});
+  });
+
+  it("read file from cache", () => {
+    assert(readFileC(fp) === readFileC(fp), "should get data from cache");
+  });
+  
+  it("read dir without cache", () => {
+		return Promise.all([readdir(dp), readdirC(dp)]).then(rs => {
+      assert.deepEqual(rs[0],rs[1]);
+		});
+  });
+
+  it("read dir from cache", () => {
+    assert(readdirC(dp) === readdirC(dp), "should get data from cache");
+	});
+});


### PR DESCRIPTION
High io may occur under high concurrency, a basic lru-cache may be useful. 