### PR TITLE
Add DOMRect polyfill

### DIFF
--- a/packages/polyfill-library/polyfills/DOMRect/config.json
+++ b/packages/polyfill-library/polyfills/DOMRect/config.json
@@ -1,0 +1,18 @@
+{
+	"aliases": [],
+	"browsers": {
+		"ie": "*",
+		"ie_mob": "*",
+		"chrome": "<60",
+		"ios_chr": "<10.1",
+		"safari": "<10.1",
+		"ios_saf": "<10.1",
+		"firefox": "<=30",
+		"android": "<6"
+	},
+	"dependencies": [
+		"Object.defineProperties"
+	],
+	"spec": "https://www.w3.org/TR/geometry-1/#DOMRect",
+	"docs": "https://developer.mozilla.org/en-US/docs/Web/API/DOMRect"
+}

--- a/packages/polyfill-library/polyfills/DOMRect/detect.js
+++ b/packages/polyfill-library/polyfills/DOMRect/detect.js
@@ -1,0 +1,4 @@
+'DOMRect' in this && (function (DOMRect) {
+	try { return new DOMRect(); }
+	catch (e) { return false; }
+}(this.DOMRect))

--- a/packages/polyfill-library/polyfills/DOMRect/polyfill.js
+++ b/packages/polyfill-library/polyfills/DOMRect/polyfill.js
@@ -1,0 +1,99 @@
+(function (global) {
+	function number(v) {
+		return v === undefined ? 0 : Number(v);
+	}
+
+	function different(u, v) {
+		return u !== v && !(isNaN(u) && isNaN(v));
+	}
+
+	function DOMRect(xArg, yArg, wArg, hArg) {
+		var x, y, width, height, left, right, top, bottom;
+
+		x = number(xArg);
+		y = number(yArg);
+		width = number(wArg);
+		height = number(hArg);
+
+		Object.defineProperties(this, {
+			x: {
+				get: function () { return x; },
+				set: function (newX) {
+					if (different(x, newX)) {
+						x = newX;
+						left = right = undefined;
+					}
+				},
+				enumerable: true
+			},
+			y: {
+				get: function () { return y; },
+				set: function (newY) {
+					if (different(y, newY)) {
+						y = newY;
+						top = bottom = undefined;
+					}
+				},
+				enumerable: true
+			},
+			width: {
+				get: function () { return width; },
+				set: function (newWidth) {
+					if (different(width, newWidth)) {
+						width = newWidth;
+						left = right = undefined;
+					}
+				},
+				enumerable: true
+			},
+			height: {
+				get: function () { return height; },
+				set: function (newHeight) {
+					if (different(height, newHeight)) {
+						height = newHeight;
+						top = bottom = undefined;
+					}
+				},
+				enumerable: true
+			},
+			left: {
+				get: function () {
+					if (left === undefined) {
+						left = x + Math.min(0, width);
+					}
+					return left;
+				},
+				enumerable: true
+			},
+			right: {
+				get: function () {
+					if (right === undefined) {
+						right = x + Math.max(0, width);
+					}
+					return right;
+				},
+				enumerable: true
+			},
+			top: {
+				get: function () {
+					if (top === undefined) {
+						top = y + Math.min(0, height);
+					}
+					return top;
+				},
+				enumerable: true
+			},
+			bottom: {
+				get: function () {
+					if (bottom === undefined) {
+						bottom = y + Math.max(0, height);
+					}
+					return bottom;
+				},
+				enumerable: true
+			}
+		});
+	}
+
+	global.DOMRect = DOMRect;
+}(this));

--- a/packages/polyfill-library/polyfills/DOMRect/tests.js
+++ b/packages/polyfill-library/polyfills/DOMRect/tests.js
@@ -1,0 +1,145 @@
+/* eslint-env mocha, browser */
+/* global proclaim */
+
+describe('constructor', function () {
+	it('should create DOMRect with specified x, y, width, and height properties', function () {
+		var domRect = new DOMRect(12, 34, 56, 78);
+		proclaim.strictEqual(domRect.x, 12);
+		proclaim.strictEqual(domRect.y, 34);
+		proclaim.strictEqual(domRect.width, 56);
+		proclaim.strictEqual(domRect.height, 78);
+	});
+	it('should default undefined arguments to zero', function () {
+		var domRect = new DOMRect();
+		proclaim.strictEqual(domRect.x, 0);
+		proclaim.strictEqual(domRect.y, 0);
+		proclaim.strictEqual(domRect.width, 0);
+		proclaim.strictEqual(domRect.height, 0);
+	});
+	it('should interpret non-numeric arguments as NaN', function () {
+		var domRect = new DOMRect('text', 34, 56, 78);
+		proclaim.isTrue(isNaN(domRect.x));
+		proclaim.strictEqual(domRect.y, 34);
+		proclaim.strictEqual(domRect.width, 56);
+		proclaim.strictEqual(domRect.height, 78);
+		domRect = new DOMRect(12, 'text', 56, 78);
+		proclaim.strictEqual(domRect.x, 12);
+		proclaim.isTrue(isNaN(domRect.y));
+		proclaim.strictEqual(domRect.width, 56);
+		proclaim.strictEqual(domRect.height, 78);
+		domRect = new DOMRect(12, 34, 'text', 78);
+		proclaim.strictEqual(domRect.x, 12);
+		proclaim.strictEqual(domRect.y, 34);
+		proclaim.isTrue(isNaN(domRect.width));
+		proclaim.strictEqual(domRect.height, 78);
+		domRect = new DOMRect(12, 34, 56, 'text');
+		proclaim.strictEqual(domRect.x, 12);
+		proclaim.strictEqual(domRect.y, 34);
+		proclaim.strictEqual(domRect.width, 56);
+		proclaim.isTrue(isNaN(domRect.height));
+	});
+});
+
+describe('writable properties', function () {
+	it('should define `x` as writable', function () {
+		var domRect = new DOMRect();
+		domRect.x = 321;
+		proclaim.strictEqual(domRect.x, 321);
+	});
+
+	it('should define `y` as writable', function () {
+		var domRect = new DOMRect();
+		domRect.y = 321;
+		proclaim.strictEqual(domRect.y, 321);
+	});
+
+	it('should define `width` as writable', function () {
+		var domRect = new DOMRect();
+		domRect.width = 321;
+		proclaim.strictEqual(domRect.width, 321);
+	});
+
+	it('should define `height` as writable', function () {
+		var domRect = new DOMRect();
+		domRect.height = 321;
+		proclaim.strictEqual(domRect.height, 321);
+	});
+});
+
+describe('readonly properties', function () {
+	it('should define `left` as readonly', function () {
+		var domRect = new DOMRect(10, 20, 30, 40);
+		domRect.left = 321;
+		proclaim.strictEqual(domRect.left, /* x */ 10);
+	});
+
+	it('should define `right` as readonly', function () {
+		var domRect = new DOMRect(10, 20, 30, 40);
+		domRect.right = 321;
+		proclaim.strictEqual(domRect.right, /* x + width */ 40);
+	});
+
+	it('should define `top` as readonly', function () {
+		var domRect = new DOMRect(10, 20, 30, 40);
+		domRect.top = 321;
+		proclaim.strictEqual(domRect.top, /* y */ 20);
+	});
+
+	it('should define `bottom` as readonly', function () {
+		var domRect = new DOMRect(10, 20, 30, 40);
+		domRect.bottom = 321;
+		proclaim.strictEqual(domRect.bottom, /* y + height */ 60);
+	});
+
+	it('should have correct `left` and `right` when `width` is positive', function () {
+		var domRect = new DOMRect(100, 0, 200, 0);
+		proclaim.strictEqual(domRect.left, /* x */ 100);
+		proclaim.strictEqual(domRect.right, /* x + width */ 300);
+	});
+
+	it('should have correct `left` and `right` when `width` is negative', function () {
+		var domRect = new DOMRect(100, 0, -200, 0);
+		proclaim.strictEqual(domRect.left, /* x + width */ -100);
+		proclaim.strictEqual(domRect.right, /* x */ 100);
+	});
+
+	it('should have correct `top` and `bottom` when `height` is positive', function () {
+		var domRect = new DOMRect(0, 100, 0, 200);
+		proclaim.strictEqual(domRect.top, /* y */ 100);
+		proclaim.strictEqual(domRect.bottom, /* y + height */ 300);
+	});
+
+	it('should have correct `top` and `bottom` when `height` is negative', function () {
+		var domRect = new DOMRect(0, 100, 0, -200);
+		proclaim.strictEqual(domRect.top, /* y + height */ -100);
+		proclaim.strictEqual(domRect.bottom, /* y */ 100);
+	});
+
+	it('should have correct `left` and `right` when `x` is changed', function () {
+		var domRect = new DOMRect(100, 0, 200, 0);
+		domRect.x = 50;
+		proclaim.strictEqual(domRect.left, /* x */ 50);
+		proclaim.strictEqual(domRect.right, /* x + width */ 250);
+	});
+
+	it('should have correct `left` and `right` when `width` is changed', function () {
+		var domRect = new DOMRect(100, 0, 200, 0);
+		domRect.width = 300;
+		proclaim.strictEqual(domRect.left, /* x */ 100);
+		proclaim.strictEqual(domRect.right, /* x + width */ 400);
+	});
+
+	it('should have correct `top` and `bottom` when `y` is changed', function () {
+		var domRect = new DOMRect(0, 100, 0, 200);
+		domRect.y = 50;
+		proclaim.strictEqual(domRect.top, /* y */ 50);
+		proclaim.strictEqual(domRect.bottom, /* y + height */ 250);
+	});
+
+	it('should have correct `top` and `bottom` when `height` is changed', function () {
+		var domRect = new DOMRect(0, 100, 0, 200);
+		domRect.height = 300;
+		proclaim.strictEqual(domRect.top, /* y */ 100);
+		proclaim.strictEqual(domRect.bottom, /* y + height */ 400);
+	});
+});


### PR DESCRIPTION
This is a PR to add a simple DOMRect polyfill.

Spec: https://www.w3.org/TR/geometry-1/#DOMRect
MDN: https://developer.mozilla.org/en-US/docs/Web/API/DOMRect

We currently need a DOMRect polyfill for IE/Edge support in WordPress' new [block-based approach to editing](https://github.com/WordPress/gutenberg/), and it seems better to submit it to a polyfill library we appreciate than to maintain it privately.