### PR TITLE
Add undefined check to Symbol setDescriptor

### DIFF
--- a/packages/polyfill-library/polyfills/Symbol/polyfill.js
+++ b/packages/polyfill-library/polyfills/Symbol/polyfill.js
@@ -223,7 +223,7 @@
 		var protoDescriptor = gOPD(ObjectProto, key);
 		delete ObjectProto[key];
 		defineProperty(o, key, descriptor);
-		if (o !== ObjectProto) {
+		if (o !== ObjectProto && protoDescriptor) {
 			defineProperty(ObjectProto, key, protoDescriptor);
 		}
 	};


### PR DESCRIPTION
In an IE 11 environment, the `polyfill.js` file was throwing the error `Invalid descriptor for property '0'`, in the Symbol polyfill: https://github.com/Financial-Times/polyfill-service/blob/8717a9e04ac7aff99b4980fbedead98036b0929a/packages/polyfill-library/polyfills/Symbol/polyfill.js#L227

This line is being called with these arguments:
```javascript
defineProperty(ObjectProto, '0', undefined); // should not be called with undefined
```

In this pull request I have added an `undefined` check before calling `defineProperty`.