### PR TITLE
Fixed console specs link

### DIFF
--- a/packages/polyfill-library/polyfills/console/assert/config.json
+++ b/packages/polyfill-library/polyfills/console/assert/config.json
@@ -10,6 +10,6 @@
 		"Window",
 		"console"
 	],
-	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"spec": "https://console.spec.whatwg.org",
 	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
 }

--- a/packages/polyfill-library/polyfills/console/clear/config.json
+++ b/packages/polyfill-library/polyfills/console/clear/config.json
@@ -10,6 +10,6 @@
 		"Window",
 		"console"
 	],
-	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"spec": "https://console.spec.whatwg.org",
 	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
 }

--- a/packages/polyfill-library/polyfills/console/config.json
+++ b/packages/polyfill-library/polyfills/console/config.json
@@ -9,6 +9,6 @@
 	"dependencies": [
 		"Window"
 	],
-	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"spec": "https://console.spec.whatwg.org",
 	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
 }

--- a/packages/polyfill-library/polyfills/console/count/config.json
+++ b/packages/polyfill-library/polyfills/console/count/config.json
@@ -10,6 +10,6 @@
 		"Window",
 		"console"
 	],
-	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"spec": "https://console.spec.whatwg.org",
 	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
 }

--- a/packages/polyfill-library/polyfills/console/debug/config.json
+++ b/packages/polyfill-library/polyfills/console/debug/config.json
@@ -11,6 +11,6 @@
 		"console",
 		"console.log"
 	],
-	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"spec": "https://console.spec.whatwg.org",
 	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
 }

--- a/packages/polyfill-library/polyfills/console/dir/config.json
+++ b/packages/polyfill-library/polyfills/console/dir/config.json
@@ -10,6 +10,6 @@
 		"Window",
 		"console"
 	],
-	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"spec": "https://console.spec.whatwg.org",
 	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
 }

--- a/packages/polyfill-library/polyfills/console/dirxml/config.json
+++ b/packages/polyfill-library/polyfills/console/dirxml/config.json
@@ -10,6 +10,6 @@
 		"Window",
 		"console"
 	],
-	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"spec": "https://console.spec.whatwg.org",
 	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
 }

--- a/packages/polyfill-library/polyfills/console/error/config.json
+++ b/packages/polyfill-library/polyfills/console/error/config.json
@@ -12,6 +12,6 @@
 		"console",
 		"console.log"
 	],
-	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"spec": "https://console.spec.whatwg.org",
 	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
 }

--- a/packages/polyfill-library/polyfills/console/exception/config.json
+++ b/packages/polyfill-library/polyfills/console/exception/config.json
@@ -11,6 +11,6 @@
 		"Window",
 		"console"
 	],
-	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"spec": "https://console.spec.whatwg.org",
 	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
 }

--- a/packages/polyfill-library/polyfills/console/group/config.json
+++ b/packages/polyfill-library/polyfills/console/group/config.json
@@ -10,6 +10,6 @@
 		"Window",
 		"console"
 	],
-	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"spec": "https://console.spec.whatwg.org",
 	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
 }

--- a/packages/polyfill-library/polyfills/console/groupCollapsed/config.json
+++ b/packages/polyfill-library/polyfills/console/groupCollapsed/config.json
@@ -10,6 +10,6 @@
 		"Window",
 		"console"
 	],
-	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"spec": "https://console.spec.whatwg.org",
 	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
 }

--- a/packages/polyfill-library/polyfills/console/groupEnd/config.json
+++ b/packages/polyfill-library/polyfills/console/groupEnd/config.json
@@ -10,6 +10,6 @@
 		"Window",
 		"console"
 	],
-	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"spec": "https://console.spec.whatwg.org",
 	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
 }

--- a/packages/polyfill-library/polyfills/console/info/config.json
+++ b/packages/polyfill-library/polyfills/console/info/config.json
@@ -12,6 +12,6 @@
 		"console",
 		"console.log"
 	],
-	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"spec": "https://console.spec.whatwg.org",
 	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
 }

--- a/packages/polyfill-library/polyfills/console/log/config.json
+++ b/packages/polyfill-library/polyfills/console/log/config.json
@@ -10,6 +10,6 @@
 		"Window",
 		"console"
 	],
-	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"spec": "https://console.spec.whatwg.org",
 	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
 }

--- a/packages/polyfill-library/polyfills/console/markTimeline/config.json
+++ b/packages/polyfill-library/polyfills/console/markTimeline/config.json
@@ -7,7 +7,7 @@
 		"Window",
 		"console"
 	],
-	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"spec": "https://console.spec.whatwg.org",
 	"docs": "https://developer.mozilla.org/en/docs/Web/API/console",
 	"notes": [
 		"Formerly supported by chrome and safari, but [deprecated after discussion with Firebug](https://bugs.webkit.org/show_bug.cgi?id=63317).  Use `timeStamp()` instead."

--- a/packages/polyfill-library/polyfills/console/profile/config.json
+++ b/packages/polyfill-library/polyfills/console/profile/config.json
@@ -13,6 +13,6 @@
 	"test": {
 		"ci": false
 	},
-	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"spec": "https://console.spec.whatwg.org",
 	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
 }

--- a/packages/polyfill-library/polyfills/console/profileEnd/config.json
+++ b/packages/polyfill-library/polyfills/console/profileEnd/config.json
@@ -13,6 +13,6 @@
 	"test": {
 		"ci": false
 	},
-	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"spec": "https://console.spec.whatwg.org",
 	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
 }

--- a/packages/polyfill-library/polyfills/console/profiles/config.json
+++ b/packages/polyfill-library/polyfills/console/profiles/config.json
@@ -10,7 +10,7 @@
 	"test": {
 		"ci": false
 	},
-	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"spec": "https://console.spec.whatwg.org",
 	"docs": "https://developer.mozilla.org/en/docs/Web/API/console",
 	"notes": [
 		"`console.profiles` used to be an array storing profile data. It was removed in Chrome and Safari"

--- a/packages/polyfill-library/polyfills/console/table/config.json
+++ b/packages/polyfill-library/polyfills/console/table/config.json
@@ -10,6 +10,6 @@
 		"Window",
 		"console"
 	],
-	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"spec": "https://console.spec.whatwg.org",
 	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
 }

--- a/packages/polyfill-library/polyfills/console/time/config.json
+++ b/packages/polyfill-library/polyfills/console/time/config.json
@@ -10,6 +10,6 @@
 		"Window",
 		"console"
 	],
-	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"spec": "https://console.spec.whatwg.org",
 	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
 }

--- a/packages/polyfill-library/polyfills/console/timeEnd/config.json
+++ b/packages/polyfill-library/polyfills/console/timeEnd/config.json
@@ -11,6 +11,6 @@
 		"console",
 		"console.time"
 	],
-	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"spec": "https://console.spec.whatwg.org",
 	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
 }

--- a/packages/polyfill-library/polyfills/console/timeStamp/config.json
+++ b/packages/polyfill-library/polyfills/console/timeStamp/config.json
@@ -10,6 +10,6 @@
 		"Window",
 		"console"
 	],
-	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"spec": "https://console.spec.whatwg.org",
 	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
 }

--- a/packages/polyfill-library/polyfills/console/timeline/config.json
+++ b/packages/polyfill-library/polyfills/console/timeline/config.json
@@ -10,6 +10,6 @@
 		"Window",
 		"console"
 	],
-	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"spec": "https://console.spec.whatwg.org",
 	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
 }

--- a/packages/polyfill-library/polyfills/console/timelineEnd/config.json
+++ b/packages/polyfill-library/polyfills/console/timelineEnd/config.json
@@ -10,6 +10,6 @@
 		"Window",
 		"console"
 	],
-	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"spec": "https://console.spec.whatwg.org",
 	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
 }

--- a/packages/polyfill-library/polyfills/console/trace/config.json
+++ b/packages/polyfill-library/polyfills/console/trace/config.json
@@ -10,6 +10,6 @@
 		"Window",
 		"console"
 	],
-	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"spec": "https://console.spec.whatwg.org",
 	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
 }

--- a/packages/polyfill-library/polyfills/console/warn/config.json
+++ b/packages/polyfill-library/polyfills/console/warn/config.json
@@ -11,6 +11,6 @@
 		"console",
 		"console.log"
 	],
-	"spec": "https://github.com/DeveloperToolsWG/console-object/blob/master/api.md",
+	"spec": "https://console.spec.whatwg.org",
 	"docs": "https://developer.mozilla.org/en/docs/Web/API/console"
 }


### PR DESCRIPTION
Old link is deprecated: ~~https://github.com/DeveloperToolsWG/console-object/blob/master/api.md~~
New link is now: ~~https://github.com/DeveloperToolsWG/console-object~~ ➡ ~~https://github.com/whatwg/console~~ ➡ https://console.spec.whatwg.org