### PR TITLE
feat: do not overwrite the flags of features(&alias)

### DIFF
--- a/packages/polyfill-library/lib/aliases.js
+++ b/packages/polyfill-library/lib/aliases.js
@@ -69,7 +69,11 @@ async function applyResolverToIdentifiers(featureSet, nameResolverFunction) {
 					// Merge properties of source into properties of target
 					// Eg. 'es6|always' becomes 'Set|always', 'Map|always' etc.
 					// Note: optimisation here is important, a previous slower merge technique used to block the event loop for long periods
-					['flags', 'aliasOf'].forEach(prop => {
+					// Note: do not overwrite flags of feature
+					if (!featureSet[newName].flags || !featureSet[newName].flags.size) {
+						featureSet[newName].flags = props.flags;
+					}
+					['aliasOf'].forEach(prop => {
 						for (const v of props[prop]) {
 							if (!(prop in featureSet[newName])) {
 								featureSet[newName][prop] = new Set();

--- a/packages/polyfill-library/test/unit/lib/aliases.js
+++ b/packages/polyfill-library/test/unit/lib/aliases.js
@@ -181,7 +181,7 @@ describe('lib/aliases', () => {
 									aliasOf: ["alias_name_a"]
 								},
 								resolved_name_b: {
-									flags: ["always", "gated"],
+									flags: ["always"],
 									aliasOf: ["alias_name_a", "alias_name_b"]
 								},
 								resolved_name_c: {
@@ -290,7 +290,7 @@ describe('lib/aliases', () => {
 									aliasOf: ["alias_name_a", "first_alias_name_a"]
 								},
 								resolved_name_b: {
-									flags: ["always", "gated"],
+									flags: ["gated"],
 									aliasOf: ["alias_name_a", "alias_name_b", "first_alias_name_a"]
 								},
 								resolved_name_c: {
@@ -318,7 +318,7 @@ describe('lib/aliases', () => {
 						}).then(function(resolved) {
 							assert.deepEqual(setsToArrays(resolved), {
 								name_b: {
-									flags: ["always", "gated"],
+									flags: ["gated"],
 									aliasOf: ['alias_name_a']
 								}
 							});


### PR DESCRIPTION
the polyfill-liabrary will always merge the flags from feature and alias:

a query like this: ```default|gated,Promise|always``` , it is same as ```default|gated,Promise|always|gated```. Actually, i do not want the gated flag, i want to overwrite Promise anyway. There is no way to do things like this. I think we should not merge the flags if there is already flags assigned to feature (like, Promise).