### PR TITLE
A collection of little improvements to V3 docs.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ commands:
       - run: |
           cd << parameters.location >>
           if [ -d node_modules ]; then
-            npm run build
+            npm run postinstall && npm run prepublish
           else
             npm ci || npm install -g npm && npm ci
           fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,11 +18,7 @@ commands:
     steps:
       - run: |
           cd << parameters.location >>
-          if [ -d node_modules ]; then
-            npm run postinstall && npm run prepublish
-          else
-            npm ci || npm install -g npm && npm ci
-          fi
+          npm ci || npm install -g npm && npm ci
   integration_tests_service:
     description: "Intergation tests"
     parameters:

--- a/packages/polyfill-service/bower.json
+++ b/packages/polyfill-service/bower.json
@@ -14,7 +14,6 @@
   "dependencies": {
     "o-header-services": "^2.2.4",
     "o-footer-services": "^1.0.2",
-    "o-techdocs": "^7.0.8",
     "o-syntax-highlight": "^1.1.1",
     "o-normalise": "^1.6.2",
     "o-fonts": "^3.0.4",

--- a/packages/polyfill-service/website/src/pages/api.hbs
+++ b/packages/polyfill-service/website/src/pages/api.hbs
@@ -17,118 +17,119 @@
       <h2 id="get-v3-polyfill-(minify)">Requesting a minified polyfill bundle</h2>
       <p>Get a bundle of polyfills which have been minified ready for production website use. This endpoint responds with a JavaScript
         file containing the polyfills which should be served to the requesting browser.</p>
+
       <h3 id="request">Request</h3>
-      <div classname="o-techdocs-table-wrapper">
-        <table>
-          <tbody>
-            <tr>
-              <th scope="row">Method</th>
-              <td>
-                <code>GET</code>
-              </td>
-            </tr>
-            <tr>
-              <th scope="row">
-                Path
-              </th>
-              <td>
-                <code>/v3/polyfill.min.js</code>
-              </td>
-            </tr>
-            <tr>
-              <th scope="row">Querystring</th>
-              <td>
-                <dl>
-                  <dt>
-                    <code>
-                      <var>callback</var>
-                    </code>
-                  </dt>
-                  <dd>
-                    Name of the JavaScript function to call after the polyfill bundle is loaded.
-                  </dd>
-                  <dt>
-                    <code>
-                      <var>unknown</var>
-                    </code>
-                  </dt>
-                  <dd>
-                    What to do for browsers which are not supported. Possible values are `ignore` and `polyfill`. Setting to `ignore` will return
-                    no polyfills to unsuported browsers. Setting to `polyfill` will return all requested polyfills to unsupported browsers.
-                  </dd>
-                  <dt>
-                    <code>
-                      <var>flags</var>
-                    </code>
-                  </dt>
-                  <dd>
-                    Configuration settings for every polyfill being requested. Possible values are `always` and `gated`. Setting `always` will
-                    return all requested polyfills to every browser. Setting `gated` will wrap every polyfill within a feature detection,
-                    only adding the polyfill if the feature was not detected. To enable both settings, separate them with a comma E.G.
-                    `always,gated`.
-                  </dd>
-                </dl>
-              </td>
-            </tr>
-            <tr>
-              <th scope="row">Headers</th>
-              <td>
-                <dl>
-                  <dt>User-Agent</dt>
-                  <dd>If no `ua` querystring value is configured, the User-Agent header's value will be used for polyfill targeting instead.</dd>
-                  <dt>Accept-Encoding</dt>
-                  <dd>If no `compression` querystring value is configured, the Accept-Encoding header's value will be used to decide if
-                    compression should be used on the polyfill</dd>
-                </dl>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
+
+      <table class="o-table o-table--horizontal-lines o-table--row-headings">
+        <tbody>
+          <tr>
+            <th scope="row">Method</th>
+            <td>
+              <code>GET</code>
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">
+              Path
+            </th>
+            <td>
+              <code>/v3/polyfill.min.js</code>
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Querystring</th>
+            <td>
+              <dl>
+                <dt>
+                  <code>
+                    <var>callback</var>
+                  </code>
+                </dt>
+                <dd>
+                  Name of the JavaScript function to call after the polyfill bundle is loaded.
+                </dd>
+                <dt>
+                  <code>
+                    <var>unknown</var>
+                  </code>
+                </dt>
+                <dd>
+                  What to do for browsers which are not supported. Possible values are `ignore` and `polyfill`. Setting to `ignore` will return
+                  no polyfills to unsuported browsers. Setting to `polyfill` will return all requested polyfills to unsupported browsers.
+                </dd>
+                <dt>
+                  <code>
+                    <var>flags</var>
+                  </code>
+                </dt>
+                <dd>
+                  Configuration settings for every polyfill being requested. Possible values are `always` and `gated`. Setting `always` will
+                  return all requested polyfills to every browser. Setting `gated` will wrap every polyfill within a feature detection,
+                  only adding the polyfill if the feature was not detected. To enable both settings, separate them with a comma E.G.
+                  `always,gated`.
+                </dd>
+              </dl>
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Headers</th>
+            <td>
+              <dl>
+                <dt>User-Agent</dt>
+                <dd>If no `ua` querystring value is configured, the User-Agent header's value will be used for polyfill targeting instead.</dd>
+                <dt>Accept-Encoding</dt>
+                <dd>If no `compression` querystring value is configured, the Accept-Encoding header's value will be used to decide if
+                  compression should be used on the polyfill</dd>
+              </dl>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
       <h3 id="response">Response</h3>
-      <div classname="o-techdocs-table-wrapper">
-        <table>
-          <tbody>
-            <tr>
-              <th scope="row">Status</th>
-              <td>
-                <code>200</code> on success
-                <br>
-                <code>401</code> if authentication failed
-                <br>
-                <code>403</code> if authorization failed
-                <br>
-                <code>404</code> if there are no non-hidden demos for the
-                <var>:repo-id</var> and
-                <var>:version-id</var>
-              </td>
-            </tr>
-            <tr>
-              <th scope="row">Headers</th>
-              <td>
-                <dl>
-                  <dt>Content-Type</dt>
-                  <dd>
-                    <code>application/javascript;charset=UTF-8</code>
-                    <br>
-                  </dd>
-                  <dt>Normalized-User-Agent</dt>
-                  <dd>
-                    The User-Agent that was detected and was used for polyfill targeting.
-                    <br>
-                  </dd>
-                </dl>
-              </td>
-            </tr>
-            <tr>
-              <th scope="row">Body</th>
-              <td>
-                The bundle of JavaScript polyfills.
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
+
+      <table class="o-table o-table--horizontal-lines o-table--row-headings">
+        <tbody>
+          <tr>
+            <th scope="row">Status</th>
+            <td>
+              <code>200</code> on success
+              <br>
+              <code>401</code> if authentication failed
+              <br>
+              <code>403</code> if authorization failed
+              <br>
+              <code>404</code> if there are no non-hidden demos for the
+              <var>:repo-id</var> and
+              <var>:version-id</var>
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Headers</th>
+            <td>
+              <dl>
+                <dt>Content-Type</dt>
+                <dd>
+                  <code>application/javascript;charset=UTF-8</code>
+                  <br>
+                </dd>
+                <dt>Normalized-User-Agent</dt>
+                <dd>
+                  The User-Agent that was detected and was used for polyfill targeting.
+                  <br>
+                </dd>
+              </dl>
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Body</th>
+            <td>
+              The bundle of JavaScript polyfills.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
       <h3>Example request:</h3>
       <h4>Requesting the polyfill sets: ES5, ES6, and ES7. Wrapping each polyfill in a feature detect</h4>
       <pre><code>https://polyfill.io/v3/polyfill.js?features=es5,es6,es7&amp;flags=gated</code></pre>

--- a/packages/polyfill-service/website/src/pages/polyfills.hbs
+++ b/packages/polyfill-service/website/src/pages/polyfills.hbs
@@ -1,60 +1,57 @@
 {{#> layouts/base}}
   {{#*inline "sidebar"}}
-    <section class="o-forms o-forms--wide">
-			<div class="o-forms__group">
-				<label class="o-forms__label" for="filter">Filter polyfills</label>
-				<div class="o-forms__additional-info">Filter the polyfills in the "Avaliable Polyfills" list.</div>
-				<input name="filter" id="filter" type="text" class="o-forms__text"
-					placeholder="Type to filter by name">
+    <div>
+			<div class="o-forms">
+				<label aria-describedby="filter-info" class="o-forms__label" for="filter">Filter polyfills</label>
+				<div id="filter-info" class="o-forms__additional-info">Filter the polyfills in the "Avaliable Polyfills" list.</div>
+				<input name="filter" id="filter" type="text" class="o-forms__text" placeholder="Type to filter by name">
 			</div>
-			<div class="o-forms__group">
-				<label for="callback" class="o-forms__label">Callback</label>
-				<div class="o-forms__additional-info">Name of the function to call after the polyfills are loaded.</div>
-				<input type="text" id="callback" class="o-forms__text"
-					name="callback">
+			<div class="o-forms">
+				<label aria-describedby="callback-info" for="callback" class="o-forms__label">Callback</label>
+				<div id="callback-info" class="o-forms__additional-info">Name of the function to call after the polyfills are loaded.</div>
+				<input type="text" id="callback" class="o-forms__text" name="callback">
 			</div>
-			<div class="o-forms__group">
-				<label class="o-forms__label">Minify bundle</label>
-				<div class="o-forms__additional-info">Check the boxes of the polyfills you want to have in your bundle.</div>
+			<fieldset class="o-forms">
+				<legend aria-describedby="bundle-info" class="o-forms__label">Minify bundle</legend>
+				<div id="bundle-info" class="o-forms__additional-info">Check the boxes of the polyfills you want to have in your bundle.</div>
 				<div class="o-forms__group o-forms__group--inline-together">
 					<input type="radio" name="minified" class="o-forms__radio-button" id="minified1" checked>
-					<label for="minified1" class="o-forms__label">Yes</label>
+					<label for="minified1" aria-label="Minify bundle" class="o-forms__label">Yes</label>
 					<input type="radio" name="minified" class="o-forms__radio-button o-forms__radio-button--negative" id="minified2">
-					<label for="minified2" class="o-forms__label">No</label>
+					<label for="minified2" aria-label="Do not minify bundle" class="o-forms__label">No</label>
 				</div>
-			</div>
-			<div class="o-forms__group">
-				<label class="o-forms__label">Real User Monitoring</label>
-				<div class="o-forms__additional-info">Help us tune our browser targeting to better serve your particular users.</div>
+			</fieldset>
+			<fieldset class="o-forms">
+				<legend aria-describedby="rum-info" class="o-forms__label">Real User Monitoring</legend>
+				<div id="rum-info" class="o-forms__additional-info">Help us tune our browser targeting to better serve your particular users.</div>
 				<div class="o-forms__group o-forms__group--inline-together">
 					<input type="radio" name="rum" class="o-forms__radio-button" id="rum1">
-					<label for="rum1" class="o-forms__label">Yes</label>
+					<label for="rum1" aria-label="Send real user metrics." class="o-forms__label">Yes</label>
 					<input type="radio" name="rum" class="o-forms__radio-button o-forms__radio-button--negative" id="rum2" checked>
-					<label for="rum2" class="o-forms__label">No</label>
+					<label for="rum2" aria-label="Do not send real user metrics." class="o-forms__label">No</label>
 				</div>
-			</div>
-			<div class="o-forms__group">
-				<label class="o-forms__label">Feature Detects</label>
-				<div class="o-forms__additional-info">Have every polyfill wrapped in a feature detect, which will only execute the polyfill if the native API is not present.</div>
-				<div
-					class="o-forms__group o-forms__group--inline-together">
+			</fieldset>
+			<fieldset class="o-forms">
+				<legend aria-describedby="feature-info" class="o-forms__label">Feature Detects</legend>
+				<div id="feature-info" class="o-forms__additional-info">Have every polyfill wrapped in a feature detect, which will only execute the polyfill if the native API is not present.</div>
+				<div class="o-forms__group o-forms__group--inline-together">
 					<input type="radio" name="gated" class="o-forms__radio-button" id="gated1">
-					<label for="gated1" class="o-forms__label">Yes</label>
+					<label for="gated1" aria-label="Enable feature detects." class="o-forms__label">Yes</label>
 					<input type="radio" name="gated" class="o-forms__radio-button o-forms__radio-button--negative" id="gated2" checked>
-					<label for="gated2" class="o-forms__label">No</label>
-			</div>
-			</div>
-			<div class="o-forms__group">
-				<label class="o-forms__label">Always load polyfills</label>
-				<div class="o-forms__additional-info">Have every polyfill be included regardless of whether it is required by the browser making the request.</div>
+					<label for="gated2" aria-label="Disable feature detects." class="o-forms__label">No</label>
+				</div>
+			</fieldset>
+			<fieldset class="o-forms">
+				<legend aria-describedby="always-info" class="o-forms__label">Always load polyfills</legend>
+				<div id="always-info" class="o-forms__additional-info">Have every polyfill be included regardless of whether it is required by the browser making the request.</div>
 				<div class="o-forms__group o-forms__group--inline-together">
 					<input type="radio" name="always" class="o-forms__radio-button" id="always1">
-					<label for="always1" class="o-forms__label">Yes</label>
+					<label for="always1" aria-label="Include every polyfill, regardless of the browser" class="o-forms__label">Yes</label>
 					<input type="radio" name="always" class="o-forms__radio-button o-forms__radio-button--negative" id="always2" checked>
-					<label for="always2" class="o-forms__label">No</label>
+					<label for="always2" aria-label="Include only polyfills the requesting browser needs" class="o-forms__label">No</label>
 				</div>
-			</div>
-		</section>
+			</fieldset>
+		</div>
   {{/inline}}
   {{#*inline "main"}}
     <div>
@@ -82,19 +79,17 @@
 				</div>
 			</div>
 		</div>
-		<div class="o-forms o-forms--wide">
-			<div>
-				<legend class="o-forms__label">Avaliable Polyfills</legend>
-				<div class="o-forms__additional-info">Check the boxes of the polyfills or polyfill-sets you want to have in your bundle.</div>
-			</div>
+		<fieldset class="o-forms o-forms--wide">
+			<legend aria-describedby="avaliable-polyfills-info" class="o-forms__label">Avaliable Polyfills</legend>
+			<div id="avaliable-polyfills-info" class="o-forms__additional-info">Check the boxes of the polyfills or polyfill-sets you want to have in your bundle.</div>
 			<div class="o-forms__group o-forms__group--inline" id="features-list">
 			{{#each polyfills}}
 				<div data-feature-name="{{name}}">
 					<input id="{{name}}" name="{{name}}" type="checkbox" class="o-forms__checkbox">
 					<label class="o-forms__label" id="{{snakecase name}}_label" for="{{name}}">{{name}}</label>
-					<span title="Links" class="extra-info" id="{{name}}-tooltip-target">☰</span>
+					<button title="Links" class="extra-info" id="{{name}}-tooltip-target" aria-label="More about {{name}} (opens tooltip).">☰</button>
 
-					<div data-o-component="o-tooltip" data-o-tooltip-position="right" data-o-tooltip-target="{{name}}-tooltip-target" data-o-tooltip-toggle-on-click="true">
+					<div id="{{name}}-tooltip-element" data-o-component="o-tooltip" data-o-tooltip-position="right" data-o-tooltip-target="{{name}}-tooltip-target" data-o-tooltip-toggle-on-click="true">
 						<div class="o-tooltip-content">
 							<ul>
 								{{#if license}}
@@ -113,7 +108,7 @@
 				</div>
 			{{/each}}
 			</div>
-		</div>
+		</fieldset>
   {{/inline}}
 	{{#*inline "scripts-block"}}
 	<script defer async src="static/polyfills.js"></script>

--- a/packages/polyfill-service/website/src/sass/main.scss
+++ b/packages/polyfill-service/website/src/sass/main.scss
@@ -1,8 +1,6 @@
 // @import url("https://www.ft.com/__origami/service/build/v2/bundles/css?modules=o-header-services%402.2.2%2Co-fonts%40%5E3.0.0%2Co-normalise%40%5E1.0.0%2Co-footer-services%40%5E1.0.2&brand=internal");
 $o-layout-is-silent: false;
 @import 'o-layout/main.scss';
-$o-techdocs-is-silent: false;
-@import 'o-techdocs/main.scss';
 $o-fonts-is-silent: false;
 @import 'o-fonts/main.scss';
 $o-typography-is-silent: false;
@@ -28,6 +26,10 @@ $o-message-is-silent: false;
 
 [aria-hidden=true] {
     display: none;
+}
+
+[data-o-component="o-tooltip"] {
+	display: none;
 }
 
 .bundle-tabs {
@@ -56,6 +58,16 @@ $o-message-is-silent: false;
 }
 
 .extra-info {
+	// start: undo button styles
+	appearance: none;
+	background: none;
+	color: inherit;
+	border: 0;
+	padding: 0;
+	font: inherit;
+	cursor: pointer;
+	outline: inherit;
+	// end: undo button styles
 	text-align: right;
 	display: block;
 	float: right;
@@ -106,6 +118,10 @@ a.anchor {
 
 .o-layout--documentation ul ul {
 	padding: 1em;
+}
+
+.o-layout__sidebar>:first-child {
+	margin-top: 1rem;
 }
 
 .logo {


### PR DESCRIPTION
- Remove o-techdocs in favour of using o-table.
- Update use of o-forms on the polyfill page:
    - Use legend and fieldset.
    - Use aria-describedby to tie the label/legend to the additional info.
    - Apply aria-label to yes/no checkboxes to be more descriptive E.g. "Minify bundle"/"Do not minify bundle".
- Hide tooltips by default to avoid a flash, as the tooltip content is rendered then hidden.
- Update the tooltip target to a button.

Before:
<img width="1280" alt="screen shot 2018-10-19 at 17 45 41" src="https://user-images.githubusercontent.com/10405691/47232609-05430b80-d3c8-11e8-94ab-bc2b2a249b70.png">

After (note input spacing in the sidebar):
<img width="1280" alt="screen shot 2018-10-19 at 17 45 00" src="https://user-images.githubusercontent.com/10405691/47232619-0ffda080-d3c8-11e8-9e8b-7cabbec8d31a.png">

Before:
<img width="1280" alt="screen shot 2018-10-19 at 17 46 32" src="https://user-images.githubusercontent.com/10405691/47232628-1724ae80-d3c8-11e8-92a0-5f8d8502913f.png">

After:
<img width="1280" alt="screen shot 2018-10-19 at 17 44 45" src="https://user-images.githubusercontent.com/10405691/47232638-2146ad00-d3c8-11e8-93a3-9d574900150d.png">
