### PR TITLE
Fix formatting in polyfill-library readme

### DIFF
--- a/packages/polyfill-library/README.md
+++ b/packages/polyfill-library/README.md
@@ -32,7 +32,7 @@ const polyfillBundle = polyfillLibary.getPolyfillString({
 
 Create a PolyfillLibrary instance.
 
-`@param {String} [polyfillsPath]` - The folder location on the file system where the polyfill sources exist. Defaults to the location of the polyfill sources which come bundled with the polyfill-library module.
+- `@param {String} [polyfillsPath]` - The folder location on the file system where the polyfill sources exist. Defaults to the location of the polyfill sources which come bundled with the polyfill-library module.
 
 ### `polyfillLibrary.listAllPolyfills()`
 
@@ -44,7 +44,7 @@ Returns a Promise which resolves with an array of all the polyfills within the c
 
 Get the metadata for a specific polyfill within the collection of polyfill sources.
 
-`@param {String} featureName` - The name of a polyfill whose metadata should be returned.
+- `@param {String} featureName` - The name of a polyfill whose metadata should be returned.
 
 Returns a Promise which resolves with the metadata or with `undefined` if no metadata exists for the polyfill.
 
@@ -52,13 +52,13 @@ Returns a Promise which resolves with the metadata or with `undefined` if no met
 
 Create an options object for use with `getPolyfills` or `getPolyfillString`.
 
-`@param {object} opts` - Valid keys are uaString, minify, unknown, excludes, rum and features.
-`@param {Boolean} [opts.minify=true]` - Whether to return the minified or raw implementation of the polyfills.
-`@param {'ignore'|'polyfill'} [opts.unknown='ignore']` - Whether to return all polyfills or no polyfills if the user-agent is unknown or unsupported.
-`@param {Object} [opts.features={}]` - Which features should be returned if the user-agent does not support them natively.
-`@param {Array<String>} [opts.excludes=[]]` - Which features should be excluded from the returned object.
-`@param {String} [opts.uaString='']` - The user-agent string to check each feature against.
-`@param {Boolean} [opts.rum=false]` - Whether to add a script to the polyfill bundle which reports anonymous usage data.
+- `@param {object} opts` - Valid keys are uaString, minify, unknown, excludes, rum and features.
+- `@param {Boolean} [opts.minify=true]` - Whether to return the minified or raw implementation of the polyfills.
+- `@param {'ignore'|'polyfill'} [opts.unknown='ignore']` - Whether to return all polyfills or no polyfills if the user-agent is unknown or unsupported.
+- `@param {Object} [opts.features={}]` - Which features should be returned if the user-agent does not support them natively.
+- `@param {Array<String>} [opts.excludes=[]]` - Which features should be excluded from the returned object.
+- `@param {String} [opts.uaString='']` - The user-agent string to check each feature against.
+- `@param {Boolean} [opts.rum=false]` - Whether to add a script to the polyfill bundle which reports anonymous usage data.
 
 Returns an object which has merged `opts` with the defaults option values.
 
@@ -66,13 +66,13 @@ Returns an object which has merged `opts` with the defaults option values.
 
 Given a set of features that should be polyfilled in 'opts.features' (with flags i.e. `{<featurename>: {flags:Set[<flaglist>]}, ...}`), determine which have a configuration valid for the given opts.uaString, and return a promise of set of canonical (unaliased) features (with flags) and polyfills.
 
-`@param {object} opts` - Valid keys are uaString, minify, unknown, excludes, rum and features.
-`@param {Boolean} [opts.minify=true]` - Whether to return the minified or raw implementation of the polyfills.
-`@param {'ignore'|'polyfill'} [opts.unknown='ignore']` - Whether to return all polyfills or no polyfills if the user-agent is unknown or unsupported.
-`@param {Object} [opts.features={}]` - Which features should be returned if the user-agent does not support them natively.
-`@param {Array<String>} [opts.excludes=[]]` - Which features should be excluded from the returned object.
-`@param {String} [opts.uaString='']` - The user-agent string to check each feature against.
-`@param {Boolean} [opts.rum=false]` - Whether to add a script to the polyfill bundle which reports anonymous usage data.
+- `@param {object} opts` - Valid keys are uaString, minify, unknown, excludes, rum and features.
+- `@param {Boolean} [opts.minify=true]` - Whether to return the minified or raw implementation of the polyfills.
+- `@param {'ignore'|'polyfill'} [opts.unknown='ignore']` - Whether to return all polyfills or no polyfills if the user-agent is unknown or unsupported.
+- `@param {Object} [opts.features={}]` - Which features should be returned if the user-agent does not support them natively.
+- `@param {Array<String>} [opts.excludes=[]]` - Which features should be excluded from the returned object.
+- `@param {String} [opts.uaString='']` - The user-agent string to check each feature against.
+- `@param {Boolean} [opts.rum=false]` - Whether to add a script to the polyfill bundle which reports anonymous usage data.
 
 Returns a Promise which resolves to an Object which contains the canonicalised feature definitions filtered for UA.
 
@@ -80,14 +80,14 @@ Returns a Promise which resolves to an Object which contains the canonicalised f
 
 Create a polyfill bundle.
 
-`@param {object} opts` - Valid keys are uaString, minify, unknown, excludes, rum and features.
-`@param {Boolean} [opts.minify=true]` - Whether to return the minified or raw implementation of the polyfills.
-`@param {'ignore'|'polyfill'} [opts.unknown='ignore']` - Whether to return all polyfills or no polyfills if the user-agent is unknown or unsupported.
-`@param {Object} [opts.features={}]` - Which features should be returned if the user-agent does not support them natively.
-`@param {Array<String>} [opts.excludes=[]]` - Which features should be excluded from the returned object.
-`@param {String} [opts.uaString='']` - The user-agent string to check each feature against.
-`@param {Boolean} [opts.rum=false]` - Whether to add a script to the polyfill bundle which reports anonymous usage data.
-`@param {Boolean} [opts.stream=false]` - Whether to return a stream or a string of the polyfill bundle.
+- `@param {object} opts` - Valid keys are uaString, minify, unknown, excludes, rum and features.
+- `@param {Boolean} [opts.minify=true]` - Whether to return the minified or raw implementation of the polyfills.
+- `@param {'ignore'|'polyfill'} [opts.unknown='ignore']` - Whether to return all polyfills or no polyfills if the user-agent is unknown or unsupported.
+- `@param {Object} [opts.features={}]` - Which features should be returned if the user-agent does not support them natively.
+- `@param {Array<String>} [opts.excludes=[]]` - Which features should be excluded from the returned object.
+- `@param {String} [opts.uaString='']` - The user-agent string to check each feature against.
+- `@param {Boolean} [opts.rum=false]` - Whether to add a script to the polyfill bundle which reports anonymous usage data.
+- `@param {Boolean} [opts.stream=false]` - Whether to return a stream or a string of the polyfill bundle.
 
 Returns a polyfill bundle as either a utf-8 ReadStream or as a Promise of a utf-8 String.
 


### PR DESCRIPTION
The [polyfill-library readme](https://github.com/Financial-Times/polyfill-service/tree/master/packages/polyfill-library) currently renders all `@param` lines as one long line: 

![image](https://user-images.githubusercontent.com/250617/47445647-5b8dc100-d7b1-11e8-863a-1aa3907a8588.png)

This PR changes it to use list syntax so it's easier to read.