### PR TITLE
Add scripts to update configs for polyfills based on the compatibility results from running the tests on BrowserStack

### DIFF
--- a/packages/polyfill-library/polyfills/DOMTokenList/prototype/@@iterator/config.json
+++ b/packages/polyfill-library/polyfills/DOMTokenList/prototype/@@iterator/config.json
@@ -2,7 +2,7 @@
 	"browsers": {
 		"edge": "<13",
 		"edge_mob": "<13",
-		"ie": "9-12",
+		"ie": "9 - 12",
 		"ie_mob": "9 - 12",
 		"safari": "<9",
 		"chrome": "<50",

--- a/packages/polyfill-service/package-lock.json
+++ b/packages/polyfill-service/package-lock.json
@@ -3382,9 +3382,9 @@
       }
     },
     "chardet": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
     "charenc": {
@@ -5612,6 +5612,61 @@
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
+        "chardet": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+          "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+          "dev": true
+        },
+        "external-editor": {
+          "version": "2.2.0",
+          "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+          "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+          "dev": true,
+          "requires": {
+            "chardet": "^0.4.0",
+            "iconv-lite": "^0.4.17",
+            "tmp": "^0.0.33"
+          }
+        },
+        "inquirer": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+          "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.0",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^2.0.4",
+            "figures": "^2.0.0",
+            "lodash": "^4.3.0",
+            "mute-stream": "0.0.7",
+            "run-async": "^2.2.0",
+            "rx-lite": "^4.0.8",
+            "rx-lite-aggregates": "^4.0.8",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^4.0.0",
+            "through": "^2.3.6"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
         "strip-ansi": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -6229,14 +6284,25 @@
       }
     },
     "external-editor": {
-      "version": "2.2.0",
-      "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-      "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
+      "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
       "dev": true,
       "requires": {
-        "chardet": "^0.4.0",
-        "iconv-lite": "^0.4.17",
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
         "tmp": "^0.0.33"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.4.24",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        }
       }
     },
     "extglob": {
@@ -9893,22 +9959,21 @@
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "inquirer": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.0.tgz",
+      "integrity": "sha512-QIEQG4YyQ2UYZGDC4srMZ7BjHOmNk1lR2JQj5UknBapklm6WHA+VVH7N+sUdX3A7NeCfGF8o4X1S3Ao7nAcIeg==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^3.0.0",
         "chalk": "^2.0.0",
         "cli-cursor": "^2.1.0",
         "cli-width": "^2.0.0",
-        "external-editor": "^2.0.4",
+        "external-editor": "^3.0.0",
         "figures": "^2.0.0",
-        "lodash": "^4.3.0",
+        "lodash": "^4.17.10",
         "mute-stream": "0.0.7",
         "run-async": "^2.2.0",
-        "rx-lite": "^4.0.8",
-        "rx-lite-aggregates": "^4.0.8",
+        "rxjs": "^6.1.0",
         "string-width": "^2.1.0",
         "strip-ansi": "^4.0.0",
         "through": "^2.3.6"
@@ -9925,6 +9990,15 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
+        },
+        "rxjs": {
+          "version": "6.3.3",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
+          "integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
+          }
         },
         "string-width": {
           "version": "2.1.1",

--- a/packages/polyfill-service/package.json
+++ b/packages/polyfill-service/package.json
@@ -82,6 +82,7 @@
     "gulp-sourcemaps": "^2.6.4",
     "handlebars-helpers": "^0.10.0",
     "hasha": "^3.0.0",
+    "inquirer": "^6.2.0",
     "is-ci": "^1.1.0",
     "loud-rejection": "^1.6.0",
     "make-fetch-happen": "^4.0.1",

--- a/packages/polyfill-service/tasks/node/checkcompatdata.js
+++ b/packages/polyfill-service/tasks/node/checkcompatdata.js
@@ -1,0 +1,135 @@
+"use strict";
+
+const fs = require("fs-extra");
+const path = require("path");
+const semver = require("semver");
+const inquirer = require("inquirer");
+const PolyfillLibrary = require("../../../polyfill-library");
+const polyfillLibrary = new PolyfillLibrary();
+
+async function main() {
+	const file = path.join(__dirname, "/../../test/results/compat.json");
+	// Ensure file exists before proceeding.
+	if (!fs.existsSync(file)) {
+		throw new Error("Compat results file does not exists, to create the file you need to run the command: `npm run generate-compat-data`.");
+	}
+	const compat = await fs.readJSON(file);
+	const questions = [];
+	for (let feature of Object.keys(compat)) {
+		feature = feature.split(" ")[0];
+		const featureMetadata = await polyfillLibrary.describePolyfill(feature);
+		if (!featureMetadata) {
+			throw new Error(`${feature} does not exists within the polyfill-library.`);
+		}
+
+		for (const browser of Object.keys(compat[feature])) {
+			for (const [version, support] of Object.entries(compat[feature][browser])) {
+				if (support === "native") {
+					if (featureMetadata.browsers && featureMetadata.browsers[browser] && semver.satisfies(semver.coerce(version), featureMetadata.browsers[browser])) {
+						const currentRange = featureMetadata.browsers[browser];
+						questions.push({
+							type: "input",
+							name: feature + "|" + browser,
+							message: `${browser}/${version} supports ${feature} natively. Please update the configuration for ${feature} to no longer target ${browser}/${version}. Current range is ${currentRange}.`,
+							default: function() {
+								return JSON.stringify({ [browser]: `<${version}` });
+							},
+							validate: function(value) {
+								const obj = JSON.parse(value);
+								const valid = semver.validRange(Object.values(obj)[0]);
+								if (valid) {
+									return true;
+								}
+
+								return "Please enter a valid semver range";
+							}
+						});
+					}
+				}
+				if (support === "polyfilled") {
+					if (!featureMetadata.browsers || !featureMetadata.browsers[browser] || !semver.satisfies(semver.coerce(version), featureMetadata.browsers[browser])) {
+						questions.push({
+							type: "input",
+							name: feature + "|" + browser,
+							message: `${browser}/${version} requires a polyfill for ${feature}. Please update the configuration for ${feature} to target ${browser}/${version}.`,
+							default: function() {
+								return JSON.stringify({ [browser]: `<${Number.parseFloat(version) + 1}` });
+							},
+							validate: function(value) {
+								const obj = JSON.parse(value);
+								const valid = semver.validRange(Object.values(obj)[0]);
+								if (valid) {
+									return true;
+								}
+
+								return "Please enter a valid semver range";
+							}
+						});
+					}
+				}
+
+				if (support === "missing") {
+					if (!featureMetadata.browsers || !featureMetadata.browsers[browser] || !semver.satisfies(semver.coerce(version), featureMetadata.browsers[browser])) {
+						questions.push({
+							type: "input",
+							name: feature + "|" + browser,
+							message: `${browser}/${version} requires a polyfill for ${feature}. Please update the configuration for ${feature} to target ${browser}/${version}.`,
+							default: function() {
+								return JSON.stringify({ [browser]: `<${Number.parseFloat(version) + 1}` });
+							},
+							validate: function(value) {
+								const obj = JSON.parse(value);
+								const valid = semver.validRange(Object.values(obj)[0]);
+								if (valid) {
+									return true;
+								}
+
+								return "Please enter a valid semver range";
+							}
+						});
+					}
+				}
+			}
+		}
+	}
+
+	async function updateFeature(feature, update) {
+		let configPath = path.join(__dirname, "../../../polyfill-library/polyfills", feature.join("/"), "config.json");
+		const fileExists = fs.existsSync(configPath);
+		if (!fileExists) {
+			configPath = path.join(__dirname, "../../../polyfill-library/polyfills", feature.join("."), "config.json");
+		}
+		const config = await fs.readJSON(configPath);
+		config.browsers = config.browsers || {};
+		config.browsers = Object.assign(config.browsers, JSON.parse(update));
+		await fs.outputJSON(configPath, config, { spaces: 2 });
+	}
+	if (questions.length > 0) {
+		const answers = await inquirer.prompt(questions);
+		for (const [featureWithBrowser, value] of Object.entries(answers)) {
+			const [feature] = featureWithBrowser.split("|");
+			if (typeof value === "object") {
+				for (const [featureWithBrowser2, value2] of Object.entries(value)) {
+					const [feature2] = featureWithBrowser2.split("|");
+					if (typeof value2 === "object") {
+						for (const [featureWithBrowser3, value3] of Object.entries(value2)) {
+							const [feature3] = featureWithBrowser3.split("|");
+							await updateFeature([feature, feature2, feature3], value3);
+						}
+					} else {
+						await updateFeature([feature, feature2], value2);
+					}
+				}
+			} else {
+				await updateFeature([feature], value);
+			}
+		}
+	} else {
+		console.log("All browsers have correctly configured polyfills. Nice!");
+	}
+}
+
+main().catch(e => {
+	console.error(e);
+	process.exitCode = 1;
+});

--- a/packages/polyfill-service/tasks/node/checkfeaturemetadata.js
+++ b/packages/polyfill-service/tasks/node/checkfeaturemetadata.js
@@ -1,0 +1,24 @@
+"use strict";
+
+const semver = require("semver");
+const PolyfillLibrary = require("polyfill-library");
+const polyfillLibrary = new PolyfillLibrary();
+
+(async function() {
+	const polyfills = await polyfillLibrary.listAllPolyfills();
+
+	for (const polyfill of polyfills) {
+		const metadata = await polyfillLibrary.describePolyfill(polyfill);
+		// TODO:
+		// Ensure all polyfills have a browsers field. Why would we have a polyfill which target no browsers?!
+		// Ensure doc and spec links return a 200.
+		// Ensure that a detectSource property exists.
+		if (metadata && metadata.browsers) {
+			for (const [browser, range] of Object.entries(metadata.browsers)) {
+				if (!semver.validRange(range)) {
+					throw new Error(`The polyfill ${polyfill} contains an invalid SemVer range for ${browser}.`);
+				}
+			}
+		}
+	}
+})();

--- a/packages/polyfill-service/tasks/node/compattable.js
+++ b/packages/polyfill-service/tasks/node/compattable.js
@@ -1,0 +1,73 @@
+"use strict";
+
+const fs = require("fs-extra");
+const path = require("path");
+
+const { difference, flattenDeep, intersection } = require("lodash");
+
+const file = path.join(__dirname, "../../test/results/results.json");
+const compatFile = path.join(__dirname, "/../../test/results/compat.json");
+const browsers = require("./browsers.json");
+
+function buildData(builtCompatTable, browserName, version, feature, support) {
+	if (!builtCompatTable[feature]) {
+		builtCompatTable[feature] = {};
+	}
+
+	if (!builtCompatTable[feature][browserName]) {
+		builtCompatTable[feature][browserName] = {};
+	}
+
+	builtCompatTable[feature][browserName][version] = support;
+}
+
+async function main() {
+	// Ensure test results file exists before proceeding.
+	if (!fs.existsSync(file)) {
+		throw new Error("Test results file does not exists, to create the file you need to run the command: `npm run generate-compat-data`.");
+	}
+
+	const compat = await fs.readJSON(file);
+	const builtCompatTable = {};
+
+	// Ensure all browsers in the test results file are contained within the browsers.json file.
+	// This is to make sure we are not including test-results from browsers we no longer test against.
+	const testedBrowsers = flattenDeep(
+		Object.entries(compat).map(([name, versionResults]) => {
+			return Object.keys(versionResults).map(version => `${name}/${version}`);
+		})
+	);
+
+	if (!testedBrowsers.every(browser => browsers.includes(browser))) {
+		throw new Error(
+			"Some browsers in the tests results file are not being tested by BrowserStack. Run the command `npm run update-browserstack-browsers && npm run generate-compat-data` to update the test results with the correct browsers."
+		);
+	}
+
+	Object.keys(compat).forEach(browserName => {
+		const versions = compat[browserName];
+		Object.keys(versions).forEach(version => {
+			const testResults = versions[version];
+			if (!testResults.all || !testResults.control) {
+				throw new Error(`Missing test results for ${browserName}/${version}. Run the command ${"`"}npm run generate-compat-data${"`"} to update the test results.`);
+			}
+
+			const allTests = Array.from(testResults.control.testedSuites);
+			const failedNative = Array.from(testResults.control.failingSuites);
+			const failedPolyfilled = Array.from(testResults.all.failingSuites);
+
+			const missing = intersection(failedPolyfilled, failedNative);
+			const polyfilled = difference(failedNative, failedPolyfilled);
+			const native = difference(allTests, failedNative);
+
+			native.forEach(feature => buildData(builtCompatTable, browserName, version, feature, "native"));
+			polyfilled.forEach(feature => buildData(builtCompatTable, browserName, version, feature, "polyfilled"));
+			missing.forEach(feature => buildData(builtCompatTable, browserName, version, feature, "missing"));
+		});
+	});
+
+	await fs.outputJSON(compatFile, builtCompatTable, { spaces: 2 });
+	console.log("Updated compat.json");
+}
+
+main();

--- a/packages/polyfill-service/tasks/node/spawn.js
+++ b/packages/polyfill-service/tasks/node/spawn.js
@@ -9,7 +9,8 @@ const cwd = path.join(__dirname, "../../");
 const spawnOptions = { stdio: "pipe", cwd: cwd };
 const availableTasks = {
 	service: { cmd: "./node_modules/.bin/serverless offline start", waitForToken: "Serverless: Offline listening on http://localhost:3000" },
-	"remote-test": { cmd: "node tasks/node/remotetest", waitForExit: true }
+	"remote-test": { cmd: "node tasks/node/remotetest", waitForExit: true },
+	"remote-test-compat": { cmd: "node tasks/node/remotetest --targeted --control --all", waitForExit: true }
 };
 
 const taskRunners = argv._.map(taskName => {


### PR DESCRIPTION
I have added a script which will run the tests:
- With polyfills targeted to the browser and browser version
- Without any polyfills
- With all polyfills

These 3 test modes enable us to figure out whether a particular browser version requires a polyfill for a feature or not. Using the data gathered from running these 3 test modes we can than have a script which suggests what browser versions should be served a polyfill and which ones should not.