### PR TITLE
Polyfill Intl in Chrome<=61 to avoid exceptions on Android

### DIFF
--- a/packages/polyfill-library/polyfills/Intl/config.json
+++ b/packages/polyfill-library/polyfills/Intl/config.json
@@ -5,7 +5,7 @@
 		"ie_mob": "10",
 		"firefox": "<29",
 		"opera": "<15",
-		"chrome": "<=34",
+		"chrome": "<=61",
 		"safari": "<10",
 		"ios_saf": "<10",
 		"firefox_mob": "*",


### PR DESCRIPTION
I launched a new project recently and added the Polyfill service to it. Great stuff folks! 👏

Here's the URL I use:

```
https://cdn.polyfill.io/v2/polyfill.min.js?features=Map,fetch,Intl.~locale.ru,Intl.~locale.en
```

After configuring Google Analytics to create an event from `window.onerror`, I began to register a flow of exceptions like this one:

```
ReferenceError: Intl is not defined
at r.compileArgument (https://example.com/_next/static/chunks/commons.45e204731d33a6ac0441.js:55:46099)
at r.compileMessage (https://example.com/_next/static/chunks/commons.45e204731d33a6ac0441.js:55:45470)
at r.compile (https://example.com/_next/static/chunks/commons.45e204731d33a6ac0441.js:55:45125)
at u._compilePattern (https://example.com/_next/static/chunks/commons.45e204731d33a6ac0441.js:55:43040)
...
```

Interestingly, the majority of such exceptions have come from Chrome on Android; the versions are 46, 53 and 61. A few more instances have been triggered by a more rarely used _UC Browser_, which I'm planning to handle by adding `&unknown=polyfill` to the URL.

Given that there is no such browser as `chrome_mob` in your library, I'm wondering if we could increase the maximum version of any Chrome for which Intl is polyfilled. I know that this would mean an increased bundle size for some Desktop Chrome users, however, the prevalence of each version ≤61 [seems to be ≤0.1%](https://caniuse.com/#search=Intl) (click on _date relative_). If this bump happens, a [table with bundle sizes](https://polyfill.io/v2/docs/features/#understanding-polyfill-sizes) will need to be updated in the docs. It seems to focus on pretty old versions for the end of 2018 anyway.

Sorry in advance if the same issue has already been raised – I could not find it. Otherwise, I'm looking forward to hear what you folks think! 🙂