### PR TITLE
Use src attribute, not href for the default bundle tag

### DIFF
--- a/views/url-builder.html
+++ b/views/url-builder.html
@@ -73,7 +73,7 @@
 				<div id="tabContent1" class="o-tabs__tabpanel">
 					<div>
 						<button id="copy-html" class="o-buttons o-buttons--mono bundle-copy-button">Copy HTML to clipboard</button>
-						<pre class="bundle-box"><code class="o-syntax-highlight--html bundle-box-code" id="polyfill-bundle-html">&lt;script crossorigin="anonymous" href="https://polyfill.io/v3/polyfill.min.js"&gt;&lt;/script&gt;</code></pre>
+						<pre class="bundle-box"><code class="o-syntax-highlight--html bundle-box-code" id="polyfill-bundle-html">&lt;script crossorigin="anonymous" src="https://polyfill.io/v3/polyfill.min.js"&gt;&lt;/script&gt;</code></pre>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
If you don’t add any custom polyfills the default script tag uses a `href` attribute when it should use a src attribute.

<img width="583" alt="screen shot 2019-02-08 at 16 35 55" src="https://user-images.githubusercontent.com/11544418/52491775-c4ae0e80-2bbf-11e9-96e3-cf626756ba24.png">
