### PR TITLE
Use custom shielding header instead of Fastly-FF because Fastly-FF is set when a Fastly service is the origin for another Fastly service.

### DIFF
--- a/fastly/vcl/breadcrumbs.vcl
+++ b/fastly/vcl/breadcrumbs.vcl
@@ -19,10 +19,10 @@ sub breadcrumb_pass {
 }
 
 sub breadcrumb_fetch {
-	set beresp.http.X-VCL-Route = req.http.X-VCL-Route;
 	set beresp.http.X-PreFetch-Pass = req.http.X-PreFetch-Pass;
 	set beresp.http.X-PreFetch-Miss = req.http.X-PreFetch-Miss;
-	set beresp.http.X-PostFetch = ",VCL_FETCH(status: " beresp.status ")";
+	set beresp.http.X-PostFetch = ",VCL_FETCH(status: " beresp.status if (beresp.http.X-VCL-Route, "; BERESP_VCL_ROUTE: " beresp.http.X-VCL-Route, "")")";
+	set beresp.http.X-VCL-Route = req.http.X-VCL-Route;
 }
 
 sub breadcrumb_deliver {

--- a/fastly/vcl/polyfill-service.vcl
+++ b/fastly/vcl/polyfill-service.vcl
@@ -32,15 +32,15 @@ sub set_backend {
   	# Set some sort of default, that shouldn't get used.
   	set req.backend = F_v3_eu;
 
-	# declare local var.EU_shield_server_name STRING;
-	# set var.EU_shield_server_name = "-LCY$";
+	declare local var.EU_shield_server_name STRING;
+	set var.EU_shield_server_name = "LCY";
 
-	# declare local var.US_shield_server_name STRING;
-	# set var.US_shield_server_name = "-IAD$";
+	declare local var.US_shield_server_name STRING;
+	set var.US_shield_server_name = "IAD";
 
 	# Route EU requests to the nearest healthy shield or origin.
   	if (var.region == "EU") {
-		if (server.datacenter != "LCY" && req.http.Request_Came_From_Shield != "LCY" && var.shield_eu_is_healthy) {
+		if (server.datacenter != var.EU_shield_server_name && req.http.Request_Came_From_Shield != var.EU_shield_server_name && var.shield_eu_is_healthy) {
 			set req.backend = ssl_shield_london_city_uk;
 		} elseif (var.v3_eu_is_healthy) {
 			set req.backend = F_v3_eu;
@@ -59,7 +59,7 @@ sub set_backend {
 
 	# Route US requests to the nearest healthy shield or origin.
   	if (var.region == "US") {
-		if (server.datacenter != "IAD" && req.http.Request_Came_From_Shield != "IAD" && var.shield_us_is_healthy) {
+		if (server.datacenter != var.US_shield_server_name && req.http.Request_Came_From_Shield != var.US_shield_server_name && var.shield_us_is_healthy) {
 			set req.backend = ssl_shield_iad_va_us;
 		} elseif (var.v3_us_is_healthy) {
 			set req.backend = F_v3_us;

--- a/fastly/vcl/polyfill-service.vcl
+++ b/fastly/vcl/polyfill-service.vcl
@@ -40,7 +40,7 @@ sub set_backend {
 
 	# Route EU requests to the nearest healthy shield or origin.
   	if (var.region == "EU") {
-		if (server.identity !~ "-LCY$" && var.shield_eu_is_healthy && req.http.Request_Came_From_Shield != "EU") {
+		if (server.datacenter != "LCY" && var.shield_eu_is_healthy && req.http.Request_Came_From_Shield != "LCY") {
 			set req.backend = ssl_shield_london_city_uk;
 		} elseif (var.v3_eu_is_healthy) {
 			set req.backend = F_v3_eu;
@@ -59,7 +59,7 @@ sub set_backend {
 
 	# Route US requests to the nearest healthy shield or origin.
   	if (var.region == "US") {
-		if (server.identity !~ "-IAD$" && var.shield_us_is_healthy && req.http.Request_Came_From_Shield != "US") {
+		if (server.datacenter != "IAD" && var.shield_us_is_healthy && req.http.Request_Came_From_Shield != "IAD") {
 			set req.backend = ssl_shield_iad_va_us;
 		} elseif (var.v3_us_is_healthy) {
 			set req.backend = F_v3_us;
@@ -141,9 +141,9 @@ sub vcl_hash {
 
 sub shielding_header {
 	if (req.backend == ssl_shield_iad_va_us) {
-		set req.http.Request_Came_From_Shield = "US";
+		set req.http.Request_Came_From_Shield = server.datacenter;
 	} elsif (req.backend == ssl_shield_london_city_uk) {
-		set req.http.Request_Came_From_Shield = "EU";
+		set req.http.Request_Came_From_Shield = server.datacenter;
 	}
 }
 

--- a/fastly/vcl/polyfill-service.vcl
+++ b/fastly/vcl/polyfill-service.vcl
@@ -162,6 +162,7 @@ sub vcl_pass {
 }
 
 sub vcl_fetch {
+	set beresp.http.Request_Came_From_Shield = req.http.Request_Came_From_Shield;
 	if (req.http.Fastly-Debug) {
 		call breadcrumb_fetch;
 	}
@@ -207,7 +208,7 @@ sub vcl_deliver {
 		set resp.http.Access-Control-Allow-Methods = "GET,HEAD,OPTIONS";
 	}
 
-	if (req.url ~ "^/v3/polyfill(\.min)?\.js" && !req.http.Request_Came_From_Shield) {
+	if (req.url ~ "^/v3/polyfill(\.min)?\.js" && !resp.http.Request_Came_From_Shield && req.backend != ssl_shield_iad_va_us && req.backend != ssl_shield_london_city_uk) {
 		# Need to add "Vary: User-Agent" in after vcl_fetch to avoid the 
 		# "Vary: User-Agent" entering the Varnish cache.
 		# We need "Vary: User-Agent" in the browser cache because a browser

--- a/fastly/vcl/polyfill-service.vcl
+++ b/fastly/vcl/polyfill-service.vcl
@@ -40,7 +40,7 @@ sub set_backend {
 
 	# Route EU requests to the nearest healthy shield or origin.
   	if (var.region == "EU") {
-		if (server.datacenter != "LCY" && var.shield_eu_is_healthy && req.http.Request_Came_From_Shield != "LCY") {
+		if (server.datacenter != "LCY" && req.http.Request_Came_From_Shield != "LCY" && var.shield_eu_is_healthy) {
 			set req.backend = ssl_shield_london_city_uk;
 		} elseif (var.v3_eu_is_healthy) {
 			set req.backend = F_v3_eu;
@@ -59,7 +59,7 @@ sub set_backend {
 
 	# Route US requests to the nearest healthy shield or origin.
   	if (var.region == "US") {
-		if (server.datacenter != "IAD" && var.shield_us_is_healthy && req.http.Request_Came_From_Shield != "IAD") {
+		if (server.datacenter != "IAD" && req.http.Request_Came_From_Shield != "IAD" && var.shield_us_is_healthy) {
 			set req.backend = ssl_shield_iad_va_us;
 		} elseif (var.v3_us_is_healthy) {
 			set req.backend = F_v3_us;

--- a/fastly/vcl/polyfill-service.vcl
+++ b/fastly/vcl/polyfill-service.vcl
@@ -32,15 +32,15 @@ sub set_backend {
   	# Set some sort of default, that shouldn't get used.
   	set req.backend = F_v3_eu;
 
-	declare local var.EU_shield_server_name STRING;
-	set var.EU_shield_server_name = "-LCY$";
+	# declare local var.EU_shield_server_name STRING;
+	# set var.EU_shield_server_name = "-LCY$";
 
-	declare local var.US_shield_server_name STRING;
-	set var.US_shield_server_name = "-IAD$";
+	# declare local var.US_shield_server_name STRING;
+	# set var.US_shield_server_name = "-IAD$";
 
 	# Route EU requests to the nearest healthy shield or origin.
   	if (var.region == "EU") {
-		if (server.identity !~ var.EU_shield_server_name && var.shield_eu_is_healthy && req.http.Request_Came_From_Shield != "EU") {
+		if (server.identity !~ "-LCY$" && var.shield_eu_is_healthy && req.http.Request_Came_From_Shield != "EU") {
 			set req.backend = ssl_shield_london_city_uk;
 		} elseif (var.v3_eu_is_healthy) {
 			set req.backend = F_v3_eu;
@@ -59,7 +59,7 @@ sub set_backend {
 
 	# Route US requests to the nearest healthy shield or origin.
   	if (var.region == "US") {
-		if (server.identity !~ var.US_shield_server_name && var.shield_us_is_healthy && req.http.Request_Came_From_Shield != "US") {
+		if (server.identity !~ "-IAD$" && var.shield_us_is_healthy && req.http.Request_Came_From_Shield != "US") {
 			set req.backend = ssl_shield_iad_va_us;
 		} elseif (var.v3_us_is_healthy) {
 			set req.backend = F_v3_us;


### PR DESCRIPTION
There are many Fastly services out there which have https://polyfill.io as their origin, when that happens Fastly will set a header named `Fastly-FF` (Fastly Forwarded For) to help understand that it was a request which came from another Fastly service. If wanting to use a Fastly POP (Point Of Presence) as a ["shield"](https://docs.fastly.com/guides/performance-tuning/shielding), Fastly recommend using the `Fastly-FF` header to detect when the request has come from another Fastly POP which was not the designated shield. This doesn't work fully because it also would detect other Fastly services such as https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js when it should not detect them.

To resolve this issue, we can not use `Fastly-FF` and need to recreate it in VCL.