### PR TITLE
Add a regression test covering Vary headers where a Fastly-FF header is present

### DIFF
--- a/test/integration/regression/external-fastly-proxy.test.js
+++ b/test/integration/regression/external-fastly-proxy.test.js
@@ -1,0 +1,21 @@
+/* eslint-env mocha */
+
+"use strict";
+
+const request = require("supertest");
+const assert = require("proclaim");
+const host = require("../helpers").host;
+
+describe("Requests made from an external Fastly proxy have correct headers", function() {
+	it(`responds to a polyfill request with Fastly headers with a full set of Vary headers`, function() {
+		this.timeout(30000);
+		return request(host)
+			.get("/v3/polyfill.min.js")
+			.set("Fastly-FF", "1")
+			.expect(200)
+			.expect("Vary", "User-Agent, Accept-Encoding")
+			.then(response => {
+				assert.isString(response.text);
+			});
+	});
+});


### PR DESCRIPTION
There was a change (https://github.com/Financial-Times/polyfill-service/blame/839da3d75256b82a23393932182cd24b59b8c3a5/fastly/vcl/polyfill-service.vcl#L193-L201) moving some logic to behind a `Fastly-FF` check to support shielding.  Unfortunately there are third-party consumers of this project (including the FT) who use Fastly as a proxy to the polyfill service, so the `Fastly-FF` header is also set there, which can cause issues.

This adds a regression test looking at one of the externally available headers which could act as a canary for this.