### PR TITLE
Ensure the ua parameter is url decoded for situations where Fastly run through the VCL on multiple nodes for a single request

### DIFF
--- a/fastly/vcl/main.vcl
+++ b/fastly/vcl/main.vcl
@@ -127,7 +127,7 @@ sub normalise_querystring_parameters_for_polyfill_bundle {
 		}
 		set var.querystring = querystring.set(var.querystring, "ua", req.http.Normalized-User-Agent);
 	} else {
-		set var.querystring = querystring.set(var.querystring, "ua", re.group.1);
+		set var.querystring = querystring.set(var.querystring, "ua", urldecode(re.group.1));
 	}
 
 	# If callback is not set, set to default value ""

--- a/test/integration/regression/gh-1922.test.js
+++ b/test/integration/regression/gh-1922.test.js
@@ -8,7 +8,7 @@ const host = require("../helpers").host;
 
 describe("https://github.com/Financial-Times/polyfill-service/issues/1922", function() {
 	this.timeout(30000);
-	describe("GET /v3/normalise_querystring_parameters_for_polyfill_bundle?callback=&compression=br&excludes=&features=IntersectionObserver%2Cdefault%2Cfetch&flags=&rum=0&ua=chrome%2F72.0.0&unknown=ignore&version=3.25.1", function() {
+	describe(`GET ${host}/v3/normalise_querystring_parameters_for_polyfill_bundle?callback=&compression=br&excludes=&features=IntersectionObserver%2Cdefault%2Cfetch&flags=&rum=0&ua=chrome%2F72.0.0&unknown=ignore&version=3.25.1`, function() {
 		it("responds with same javascript when ua parameter is url encoded", async function() {
 			const nonUrlEncodedUa = (await axios.get(
 				host +
@@ -18,7 +18,7 @@ describe("https://github.com/Financial-Times/polyfill-service/issues/1922", func
 				host +
 					"/v3/normalise_querystring_parameters_for_polyfill_bundle?callback=&compression=br&excludes=&features=IntersectionObserver%2Cdefault%2Cfetch&flags=&rum=0&ua=chrome%2F72.0.0&unknown=ignore&version=3.25.1"
 			)).data;
-			proclaim.strictEqual(nonUrlEncodedUa, urlEncodedUa);
+			proclaim.deepStrictEqual(nonUrlEncodedUa, urlEncodedUa);
 		});
 	});
 });

--- a/test/integration/regression/gh-1922.test.js
+++ b/test/integration/regression/gh-1922.test.js
@@ -1,0 +1,24 @@
+/* eslint-env mocha */
+
+"use strict";
+
+const axios = require("axios");
+const proclaim = require("proclaim");
+const host = require("../helpers").host;
+
+describe("https://github.com/Financial-Times/polyfill-service/issues/1922", function() {
+	this.timeout(30000);
+	describe("GET /v3/normalise_querystring_parameters_for_polyfill_bundle?callback=&compression=br&excludes=&features=IntersectionObserver%2Cdefault%2Cfetch&flags=&rum=0&ua=chrome%2F72.0.0&unknown=ignore&version=3.25.1", function() {
+		it("responds with same javascript when ua parameter is url encoded", async function() {
+			const nonUrlEncodedUa = (await axios.get(
+				host +
+					"/v3/normalise_querystring_parameters_for_polyfill_bundle?callback=&compression=br&excludes=&features=IntersectionObserver%2Cdefault%2Cfetch&flags=&rum=0&ua=chrome/72.0.0&unknown=ignore&version=3.25.1"
+			)).data;
+			const urlEncodedUa = (await axios.get(
+				host +
+					"/v3/normalise_querystring_parameters_for_polyfill_bundle?callback=&compression=br&excludes=&features=IntersectionObserver%2Cdefault%2Cfetch&flags=&rum=0&ua=chrome%2F72.0.0&unknown=ignore&version=3.25.1"
+			)).data;
+			proclaim.strictEqual(nonUrlEncodedUa, urlEncodedUa);
+		});
+	});
+});


### PR DESCRIPTION
Fixes #1922 