### PR TITLE
Show aliases as part of the url builder

### DIFF
--- a/src/assets/css/index.scss
+++ b/src/assets/css/index.scss
@@ -98,6 +98,7 @@ $o-tooltip-is-silent: false;
 .o-tooltip .o-tooltip-content {
 	hyphens: unset;
 	white-space: nowrap;
+	max-height: 50vh;
 
 	> :last-child {
 		margin-bottom: 8px;

--- a/src/assets/css/index.scss
+++ b/src/assets/css/index.scss
@@ -84,7 +84,7 @@ $o-tooltip-is-silent: false;
 		flex-grow: 1;
 	}
 
-	button {
+	.tooltip-button {
 		@include oButtons($theme: 'mono');
 		@include oButtonsIconButton(
 			$icon-name: 'more',

--- a/src/assets/url-builder.njk
+++ b/src/assets/url-builder.njk
@@ -82,7 +82,7 @@ oLayoutStyle: "o-layout--query"
 			<div class="polyfill" data-feature-name="{{item.name}}-polyfill">
 				<input id="{{item.name}}-polyfill" name="{{item.name}}" type="checkbox" class="o-forms__checkbox">
 				<label class="o-forms__label" id="{{item.labelID}}" for="{{item.name}}-polyfill">{{item.name}}</label>
-				<button title="Links" id="{{item.name}}-tooltip-target" aria-label="More about {{item.name}} (opens tooltip)."></button>
+				<button class="tooltip-button" title="Links" id="{{item.name}}-tooltip-target" aria-label="More about {{item.name}} (opens tooltip)."></button>
 
 				<div id="{{item.name}}-tooltip-element" data-o-component="o-tooltip" data-o-tooltip-position="right" data-o-tooltip-target="{{item.name}}-tooltip-target" data-o-tooltip-toggle-on-click="true">
 					<div class="o-tooltip-content">
@@ -99,7 +99,7 @@ oLayoutStyle: "o-layout--query"
 			<div class="polyfill" data-feature-name="{{item.name}}-polyfill">
 				<input id="{{item.name}}-polyfill" name="{{item.name}}" type="checkbox" class="o-forms__checkbox">
 				<label class="o-forms__label" id="{{item.labelID}}" for="{{item.name}}-polyfill">{{item.name}}</label>
-				<button title="Links" id="{{item.name}}-tooltip-target" aria-label="More about {{item.name}} (opens tooltip)."></button>
+				<button class="tooltip-button" title="Links" id="{{item.name}}-tooltip-target" aria-label="More about {{item.name}} (opens tooltip)."></button>
 
 				<div id="{{item.name}}-tooltip-element" data-o-component="o-tooltip" data-o-tooltip-position="right" data-o-tooltip-target="{{item.name}}-tooltip-target" data-o-tooltip-toggle-on-click="true">
 					<div class="o-tooltip-content">

--- a/src/assets/url-builder.njk
+++ b/src/assets/url-builder.njk
@@ -78,6 +78,23 @@ oLayoutStyle: "o-layout--query"
 		<legend aria-describedby="avaliable-polyfills-info" class="o-forms__label">Available Polyfills</legend>
 		<div id="avaliable-polyfills-info" class="o-forms__additional-info">Check the boxes of the polyfills or polyfill-sets you want to have in your bundle.</div>
 		<div class="o-forms__group o-forms__group--inline" id="features-list">
+		{% for item in polyfills.polyfillAliases %}
+			<div class="polyfill" data-feature-name="{{item.name}}-polyfill">
+				<input id="{{item.name}}-polyfill" name="{{item.name}}" type="checkbox" class="o-forms__checkbox">
+				<label class="o-forms__label" id="{{item.labelID}}" for="{{item.name}}-polyfill">{{item.name}}</label>
+				<button title="Links" id="{{item.name}}-tooltip-target" aria-label="More about {{item.name}} (opens tooltip)."></button>
+
+				<div id="{{item.name}}-tooltip-element" data-o-component="o-tooltip" data-o-tooltip-position="right" data-o-tooltip-target="{{item.name}}-tooltip-target" data-o-tooltip-toggle-on-click="true">
+					<div class="o-tooltip-content">
+						<ul>
+						{% for polyfill in item.polyfills %}
+							<li>{{polyfill}}</li>
+						{% endfor %}
+						</ul>
+					</div>
+				</div>
+			</div>
+		{% endfor %}
 		{% for item in polyfills.polyfills %}
 			<div class="polyfill" data-feature-name="{{item.name}}-polyfill">
 				<input id="{{item.name}}-polyfill" name="{{item.name}}" type="checkbox" class="o-forms__checkbox">

--- a/src/data/polyfills.js
+++ b/src/data/polyfills.js
@@ -11,19 +11,21 @@ module.exports = async () => {
 		const aliases = await polyfillLibrary.listAliases();
 		for (const alias of Object.keys(aliases).sort()) {
 			if (!alias.startsWith("caniuse") && !alias.startsWith("default-") && !alias.startsWith("modernizr")) {
-				if (alias === "default") {
-					polyfillAliases.push({
-						name: alias,
-						labelID: `${snakeCase(alias)}_label`,
-						polyfills: aliases[alias],
-						isDefaultSet: true
-					});
-				} else if (alias !== "all") {
-					polyfillAliases.push({
-						name: alias,
-						labelID: `${snakeCase(alias)}_label`,
-						polyfills: aliases[alias]
-					});
+				if (aliases[alias].length > 1) {
+					if (alias === "default") {
+						polyfillAliases.push({
+							name: alias,
+							labelID: `${snakeCase(alias)}_label`,
+							polyfills: aliases[alias],
+							isDefaultSet: true
+						});
+					} else if (alias !== "all") {
+						polyfillAliases.push({
+							name: alias,
+							labelID: `${snakeCase(alias)}_label`,
+							polyfills: aliases[alias]
+						});
+					}
 				}
 			}
 		}

--- a/src/data/polyfills.js
+++ b/src/data/polyfills.js
@@ -13,13 +13,15 @@ module.exports = async () => {
 			if (!alias.startsWith("caniuse") && !alias.startsWith("default-") && !alias.startsWith("modernizr")) {
 				if (alias === "default") {
 					polyfillAliases.push({
-						alias,
+						name: alias,
+						labelID: `${snakeCase(alias)}_label`,
 						polyfills: aliases[alias],
 						isDefaultSet: true
 					});
-				} else {
+				} else if (alias !== "all") {
 					polyfillAliases.push({
-						alias,
+						name: alias,
+						labelID: `${snakeCase(alias)}_label`,
 						polyfills: aliases[alias]
 					});
 				}


### PR DESCRIPTION
This is a first pass at showing the aliases on the url builder page, it could do with more ui/ux thought going into it.
![image](https://user-images.githubusercontent.com/1569131/55090113-71781880-50a6-11e9-8764-1b1d5a1fe845.png)
