### PR TITLE
Correct "href" for "src" in the default url builder HTML.

### DIFF
--- a/src/assets/url-builder.njk
+++ b/src/assets/url-builder.njk
@@ -15,7 +15,7 @@ oLayoutStyle: "o-layout--query"
 	</div>
 	<div id="html" class="o-tabs__tabpanel">
 		<button id="copy-html" class="copy-button">Copy HTML to clipboard</button>
-		<pre><code class="o-syntax-highlight--html bundle-box-code" id="polyfill-bundle-html">&lt;script crossorigin="anonymous" href="https://polyfill.io/v3/polyfill.min.js"&gt;&lt;/script&gt;</code></pre>
+		<pre><code class="o-syntax-highlight--html bundle-box-code" id="polyfill-bundle-html">&lt;script crossorigin="anonymous" src="https://polyfill.io/v3/polyfill.min.js"&gt;&lt;/script&gt;</code></pre>
 	</div>
 </div>
 


### PR DESCRIPTION
The "src" attribute is already displayed correctly when a Polyfill
has been selected.

Resolves: https://github.com/Financial-Times/polyfill-service/issues/1947