### PR TITLE
update to @financial-times/polyfill-useragent-normaliser@1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1797,12 +1797,19 @@
       }
     },
     "@financial-times/polyfill-useragent-normaliser": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@financial-times/polyfill-useragent-normaliser/-/polyfill-useragent-normaliser-1.0.6.tgz",
-      "integrity": "sha512-beQ8vwlsd1FKyTI88zCluQamDg8OJOKbLz4mnTMNLAKiBihbXwPLCgOVkpnCUSkLcKu/vKyobgZtnqnRtICTUg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/polyfill-useragent-normaliser/-/polyfill-useragent-normaliser-1.1.0.tgz",
+      "integrity": "sha512-IdVf3GHH/QXPSbSfksbi7kN5t+9d29VCtF7B2hKvhmae2RjqgVS1Jlxeuny4oBSJ899fLSUYFoeK2hyk8jzfAA==",
       "requires": {
-        "@financial-times/useragent_parser": "1.0.2",
+        "@financial-times/useragent_parser": "^1.2.1",
         "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "@financial-times/useragent_parser": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@financial-times/useragent_parser/-/useragent_parser-1.2.1.tgz",
+          "integrity": "sha512-pAHRen99xeSKJyRd4bWdA5DQyn8NAvykVjPKzvDs8AsYzUxADRzy40/cWd2wdjLEOlm5VO3IIZRJS0ljnMl0sQ=="
+        }
       }
     },
     "@financial-times/useragent_parser": {
@@ -11653,6 +11660,15 @@
         "yaku": "0.18.6"
       },
       "dependencies": {
+        "@financial-times/polyfill-useragent-normaliser": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/@financial-times/polyfill-useragent-normaliser/-/polyfill-useragent-normaliser-1.0.6.tgz",
+          "integrity": "sha512-beQ8vwlsd1FKyTI88zCluQamDg8OJOKbLz4mnTMNLAKiBihbXwPLCgOVkpnCUSkLcKu/vKyobgZtnqnRtICTUg==",
+          "requires": {
+            "@financial-times/useragent_parser": "1.0.2",
+            "semver": "^5.6.0"
+          }
+        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -21151,6 +21167,15 @@
         "yaku": "0.18.6"
       },
       "dependencies": {
+        "@financial-times/polyfill-useragent-normaliser": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/@financial-times/polyfill-useragent-normaliser/-/polyfill-useragent-normaliser-1.0.6.tgz",
+          "integrity": "sha512-beQ8vwlsd1FKyTI88zCluQamDg8OJOKbLz4mnTMNLAKiBihbXwPLCgOVkpnCUSkLcKu/vKyobgZtnqnRtICTUg==",
+          "requires": {
+            "@financial-times/useragent_parser": "1.0.2",
+            "semver": "^5.6.0"
+          }
+        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@financial-times/origami-service": "^4.1.0",
-    "@financial-times/polyfill-useragent-normaliser": "^1.0.6",
+    "@financial-times/polyfill-useragent-normaliser": "^1.1.0",
     "compression": "^1.7.4",
     "denodeify": "^1.2.1",
     "dotenv": "^8.0.0",


### PR DESCRIPTION
Upgrade to polyfill-useragent-normaliser 1.1.0 which includes fixes for [detecting in-app browsers on iOS](https://github.com/Financial-Times/polyfill-useragent-normaliser/commit/66fd0e0bd927da28a20b93097df1383c0c6dd055) (including Instagram and Snapchat) as well as [detecting Pale Moon compat as Firefox](https://github.com/Financial-Times/polyfill-useragent-normaliser/commit/0b1892ac22bd78e0bd65187cba72589f7849f5da) among [other changes](https://github.com/Financial-Times/polyfill-useragent-normaliser/compare/v1.0.6...v1.1.0)