### PR TITLE
update polyfill-library to latest version

### DIFF
--- a/fastly/vcl/main.vcl
+++ b/fastly/vcl/main.vcl
@@ -111,7 +111,7 @@ sub normalise_querystring_parameters_for_polyfill_bundle {
 	if (req.url.qs !~ "(?i)[^&=]*version=([^&]+)") {
 		set var.querystring = var.querystring "&version=";
 	} else {
-		if (re.group.1 == "3.38.0" || re.group.1 == "3.37.0" || re.group.1 == "3.36.0" || re.group.1 == "3.35.0" || re.group.1 == "3.34.0" || re.group.1 == "3.28.1" || re.group.1 == "3.27.4" || re.group.1 == "3.25.3" || re.group.1 == "3.25.2" || re.group.1 == "3.25.1") {
+		if (re.group.1 == "3.39.0" ||re.group.1 == "3.38.0" || re.group.1 == "3.37.0" || re.group.1 == "3.36.0" || re.group.1 == "3.35.0" || re.group.1 == "3.34.0" || re.group.1 == "3.28.1" || re.group.1 == "3.27.4" || re.group.1 == "3.25.3" || re.group.1 == "3.25.2" || re.group.1 == "3.25.1") {
 			set var.querystring = querystring.set(var.querystring, "version", re.group.1);
 		} else {
 			set var.querystring = var.querystring "&version=";

--- a/package-lock.json
+++ b/package-lock.json
@@ -11713,9 +11713,9 @@
       "dev": true
     },
     "polyfill-library": {
-      "version": "3.38.0",
-      "resolved": "https://registry.npmjs.org/polyfill-library/-/polyfill-library-3.38.0.tgz",
-      "integrity": "sha512-HxhaVbgznssyBwntnKyOqnB1ckjPSt6cjf6tNWAeppWBHlMJAFVWIiN9ssMqdFggllTervIbLE0S95UuBuxfrA==",
+      "version": "3.39.0",
+      "resolved": "https://registry.npmjs.org/polyfill-library/-/polyfill-library-3.39.0.tgz",
+      "integrity": "sha512-da5JLCT0UHby7CUuLi4jBntUI8oIHxL6CsQ3I70V7n0tTvITQVKgQrsELashaWz8yrW7rKxVqdhBp/YPKzaerA==",
       "requires": {
         "@financial-times/polyfill-useragent-normaliser": "^1.2.0",
         "@iarna/toml": "^2.2.3",
@@ -11805,7 +11805,7 @@
       }
     },
     "polyfill-library-3.25.1": {
-      "version": "npm:polyfill-library@3.25.1",
+      "version": "npm:polyfill-library-3.25.1@3.25.1",
       "resolved": "https://registry.npmjs.org/polyfill-library/-/polyfill-library-3.25.1.tgz",
       "integrity": "sha512-MuQ9lszx4NkCONupStLZqJQvdE8WVEG6QToS0D3Glup8sHxl2IljLJNGzeEaSs2EY//U51RJeWGpwuhq1y0H7Q==",
       "requires": {
@@ -11977,7 +11977,7 @@
       }
     },
     "polyfill-library-3.25.3": {
-      "version": "npm:polyfill-service@3.25.3",
+      "version": "npm:polyfill-library-3.25.3@3.25.3",
       "resolved": "https://registry.npmjs.org/polyfill-service/-/polyfill-service-3.25.3.tgz",
       "integrity": "sha512-gYFh3htyCJJR/hp2GFEZB0gGfmJjtBWHaVK3uOYnp3qdyPVhD0Nbv6CFt+kDJT7Vi4eXvRwoOM/pA04NK90c3g==",
       "requires": {
@@ -21172,7 +21172,7 @@
       }
     },
     "polyfill-library-3.27.4": {
-      "version": "npm:polyfill-library@3.27.4",
+      "version": "npm:polyfill-library-3.27.4@3.27.4",
       "resolved": "https://registry.npmjs.org/polyfill-library/-/polyfill-library-3.27.4.tgz",
       "integrity": "sha512-OUAZqc1ZoNyHvwS3qwXSfRdhzrheURDPrPDqIAvNgyzXIhdfuGJn5YJP7n/pWamUlglRCoiSpV0Qdd0H6IL2Hw==",
       "requires": {
@@ -21237,7 +21237,7 @@
       }
     },
     "polyfill-library-3.28.1": {
-      "version": "npm:polyfill-library@3.28.1",
+      "version": "npm:polyfill-library-3.28.1@3.28.1",
       "resolved": "https://registry.npmjs.org/polyfill-library/-/polyfill-library-3.28.1.tgz",
       "integrity": "sha512-31k9fnOQIxxzrJbgOaT50QCys6Wjb382O5dKqSLp70nRU/QMTs4oIVzUlZ6QeoLFypiTMOPZHJnKvRyxM59IZA==",
       "requires": {
@@ -21312,7 +21312,7 @@
       }
     },
     "polyfill-library-3.34.0": {
-      "version": "npm:polyfill-library@3.34.0",
+      "version": "npm:polyfill-library-3.34.0@3.34.0",
       "resolved": "https://registry.npmjs.org/polyfill-library/-/polyfill-library-3.34.0.tgz",
       "integrity": "sha512-Eug5j+ANwflBqpGv0sVcbIjsEFzot5kZmAmxC6LrB9HOT1q7TFVB68JlK5aPO0dFgLfb52G/i2taXbkPJ0hjmA==",
       "requires": {
@@ -21381,7 +21381,7 @@
       }
     },
     "polyfill-library-3.35.0": {
-      "version": "npm:polyfill-library@3.35.0",
+      "version": "npm:polyfill-library-3.35.0@3.35.0",
       "resolved": "https://registry.npmjs.org/polyfill-library/-/polyfill-library-3.35.0.tgz",
       "integrity": "sha512-rXbv9XfVGGQ3a3T7R/xn55vu80+t0Rb3ix6a3KUMrb6IIScx+CX8GQurXdQfEGXTSTGVARYFr9XprCXC0l6YjA==",
       "requires": {
@@ -21474,7 +21474,7 @@
       }
     },
     "polyfill-library-3.36.0": {
-      "version": "npm:polyfill-library@3.36.0",
+      "version": "npm:polyfill-library-3.36.0@3.36.0",
       "resolved": "https://registry.npmjs.org/polyfill-library/-/polyfill-library-3.36.0.tgz",
       "integrity": "sha512-znAPCvMVBenvFhb+QM+EBUC+DNFDhJ54SySyIbpjQuvkGCfOjQDhcYWuIKwIiRXwNp0/F6GWWpfK0gLTAV/Afg==",
       "requires": {
@@ -21570,7 +21570,7 @@
       }
     },
     "polyfill-library-3.37.0": {
-      "version": "npm:polyfill-library@3.37.0",
+      "version": "npm:polyfill-library-3.37.0@3.37.0",
       "resolved": "https://registry.npmjs.org/polyfill-library/-/polyfill-library-3.37.0.tgz",
       "integrity": "sha512-lHLbkqr4CnZjadpWFt+z0cqYMY8LaKHzGpFhL/uk1/CuqH4pXJPnjEJstHYntVo+i9G9fOxKWjyFiqACO2O5GA==",
       "requires": {
@@ -21662,6 +21662,98 @@
           "version": "2.0.4",
           "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
           "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
+        }
+      }
+    },
+    "polyfill-library-3.38.0": {
+      "version": "npm:polyfill-library@3.38.0",
+      "resolved": "https://registry.npmjs.org/polyfill-library/-/polyfill-library-3.38.0.tgz",
+      "integrity": "sha512-HxhaVbgznssyBwntnKyOqnB1ckjPSt6cjf6tNWAeppWBHlMJAFVWIiN9ssMqdFggllTervIbLE0S95UuBuxfrA==",
+      "requires": {
+        "@financial-times/polyfill-useragent-normaliser": "^1.2.0",
+        "@iarna/toml": "^2.2.3",
+        "@webcomponents/template": "^1.4.0",
+        "Base64": "^1.0.0",
+        "abort-controller": "^2.0.2",
+        "audio-context-polyfill": "^1.0.0",
+        "diff": "1.4.0",
+        "event-source-polyfill": "^0.0.9",
+        "from2-string": "^1.1.0",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.10",
+        "html5shiv": "^3.7.3",
+        "intersection-observer": "^0.4.1",
+        "intl": "^1.2.5",
+        "js-polyfills": "^0.1.40",
+        "json3": "^3.3.2",
+        "lazystream": "^1.0.0",
+        "merge2": "^1.0.3",
+        "mkdirp": "^0.5.0",
+        "mnemonist": "^0.27.2",
+        "mutationobserver-shim": "^0.3.2",
+        "picturefill": "^3.0.1",
+        "resize-observer-polyfill": "^1.5.1",
+        "rimraf": "^2.6.2",
+        "spdx-licenses": "^1.0.0",
+        "stream-cache": "^0.0.2",
+        "stream-from-promise": "^1.0.0",
+        "stream-to-string": "^1.1.0",
+        "toposort": "^2.0.2",
+        "uglify-js": "^2.7.5",
+        "unorm": "^1.6.0",
+        "usertiming": "^0.1.8",
+        "web-animations-js": "^2.2.5",
+        "whatwg-fetch": "^3.0.0",
+        "wicg-inert": "^2.1.2",
+        "yaku": "0.18.6"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "deep-is": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+          "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+        },
+        "is2": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is2/-/is2-2.0.1.tgz",
+          "integrity": "sha512-+WaJvnaA7aJySz2q/8sLjMb2Mw14KTplHmSwcSpZ/fWJPkUmqw3YTzSWbPJ7OAwRvdYTWF2Wg+yYJ1AdP5Z8CA==",
+          "requires": {
+            "deep-is": "^0.1.3",
+            "ip-regex": "^2.1.0",
+            "is-url": "^1.2.2"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        },
+        "spdx-licenses": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/spdx-licenses/-/spdx-licenses-1.0.0.tgz",
+          "integrity": "sha512-BmeFZRYH9XXf56omx0LuiG+gBXRqwmrKsOtcsGTJh8tw9U0cgRKTrOnyDpP1uvI1AVEkoRKYaAvR902ByotFOw==",
+          "requires": {
+            "debug": "4.1.1",
+            "is2": "2.0.1"
+          }
+        },
+        "uglify-js": {
+          "version": "2.8.29",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+          "requires": {
+            "source-map": "~0.5.1",
+            "uglify-to-browserify": "~1.0.0",
+            "yargs": "~3.10.0"
+          }
         }
       }
     },
@@ -26004,9 +26096,9 @@
       "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs="
     },
     "wicg-inert": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/wicg-inert/-/wicg-inert-2.1.2.tgz",
-      "integrity": "sha512-7mgGbUPdgXAyR8pTX6b5eGplIuBB2mw+gjtGwhVjPCXS8kswpOugGFZCO1aehaiJKGOAoFnK0/YNreHBpfiqXw=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/wicg-inert/-/wicg-inert-2.1.3.tgz",
+      "integrity": "sha512-3AezUQILDlNeoVHUn6ntyHoEO6HJT32yPkNr9HJQ5Y1/cLXe4jWRelo79nO6hWzcy/cEAa3PWfdRNfU7mW3YRw=="
     },
     "wide-align": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "dotenv": "^8.0.0",
     "express-extractheaders": "^3.0.0",
     "iltorb": "^2.4.3",
-    "polyfill-library": "^3.38.0",
+    "polyfill-library": "3.39.0",
     "polyfill-library-3.25.1": "npm:polyfill-library@3.25.1",
     "polyfill-library-3.25.3": "npm:polyfill-service@3.25.3",
     "polyfill-library-3.27.4": "npm:polyfill-library@3.27.4",
@@ -54,6 +54,7 @@
     "polyfill-library-3.35.0": "npm:polyfill-library@3.35.0",
     "polyfill-library-3.36.0": "npm:polyfill-library@3.36.0",
     "polyfill-library-3.37.0": "npm:polyfill-library@3.37.0",
+    "polyfill-library-3.38.0": "npm:polyfill-library@3.38.0",
     "require-all": "^3.0.0",
     "serve-static": "^1.14.1",
     "throng": "^4.0.0"

--- a/server/routes/v3/polyfill.js
+++ b/server/routes/v3/polyfill.js
@@ -12,6 +12,7 @@ const polyfillio_3_34_0 = require("polyfill-library-3.34.0");
 const polyfillio_3_35_0 = require("polyfill-library-3.35.0");
 const polyfillio_3_36_0 = require("polyfill-library-3.36.0");
 const polyfillio_3_37_0 = require("polyfill-library-3.37.0");
+const polyfillio_3_38_0 = require("polyfill-library-3.38.0");
 
 async function respondWithBundle(response, params, bundle) {
 	const file = await compressBundle(params.compression, bundle);
@@ -34,6 +35,11 @@ module.exports = app => {
 		switch (params.version) {
 			case latestVersion: {
 				const bundle = await polyfillio.getPolyfillString(params);
+				await respondWithBundle(response, params, bundle);
+				break;
+			}
+			case "3.38.0": {
+				const bundle = await polyfillio_3_38_0.getPolyfillString(params);
 				await respondWithBundle(response, params, bundle);
 				break;
 			}


### PR DESCRIPTION
The new version of polyfill-library will serve IntersectionObserver to iOS 12.1 and fixes Element.prototype.classList for IE 8 through to IE 11.