### PR TITLE
update polyfill-library to 3.42 and add 3.40 and 3.41 as historical versions that can still be used

### DIFF
--- a/fastly/vcl/main.vcl
+++ b/fastly/vcl/main.vcl
@@ -111,7 +111,7 @@ sub normalise_querystring_parameters_for_polyfill_bundle {
 	if (req.url.qs !~ "(?i)[^&=]*version=([^&]+)") {
 		set var.querystring = var.querystring "&version=";
 	} else {
-		if (re.group.1 == "3.40.0" || re.group.1 == "3.39.0" || re.group.1 == "3.38.0" || re.group.1 == "3.37.0" || re.group.1 == "3.36.0" || re.group.1 == "3.35.0" || re.group.1 == "3.34.0" || re.group.1 == "3.28.1" || re.group.1 == "3.27.4" || re.group.1 == "3.25.3" || re.group.1 == "3.25.2" || re.group.1 == "3.25.1") {
+		if (re.group.1 == "3.42.0" || re.group.1 == "3.41.0" || re.group.1 == "3.40.0" || re.group.1 == "3.39.0" || re.group.1 == "3.38.0" || re.group.1 == "3.37.0" || re.group.1 == "3.36.0" || re.group.1 == "3.35.0" || re.group.1 == "3.34.0" || re.group.1 == "3.28.1" || re.group.1 == "3.27.4" || re.group.1 == "3.25.3" || re.group.1 == "3.25.2" || re.group.1 == "3.25.1") {
 			set var.querystring = querystring.set(var.querystring, "version", re.group.1);
 		} else {
 			set var.querystring = var.querystring "&version=";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "polyfill-service",
-  "version": "4.12.0",
+  "version": "4.13.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11663,9 +11663,9 @@
       "dev": true
     },
     "polyfill-library": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/polyfill-library/-/polyfill-library-3.40.0.tgz",
-      "integrity": "sha512-al9Zv1c4uhpgOKTLsyhXgD7De/xzk7r946UMlQFbS/LmcOgA2WjZg5byPbqW4cZy1X3aSJN1Kfx86rR5O4/clg==",
+      "version": "3.42.0",
+      "resolved": "https://registry.npmjs.org/polyfill-library/-/polyfill-library-3.42.0.tgz",
+      "integrity": "sha512-CXM/Hq9mGYhD3p0zj/jclYZgNQMAePBgNyrMIA3uwWV/kcAZA+Z7dvhZ1z7vOwywNTSIi7CcvYYEZny0ukbVnQ==",
       "requires": {
         "@financial-times/polyfill-useragent-normaliser": "^1.2.0",
         "@iarna/toml": "^2.2.3",
@@ -11691,6 +11691,7 @@
         "picturefill": "^3.0.1",
         "resize-observer-polyfill": "^1.5.1",
         "rimraf": "^2.6.2",
+        "smoothscroll-polyfill": "^0.4.4",
         "spdx-licenses": "^1.0.0",
         "stream-cache": "^0.0.2",
         "stream-from-promise": "^1.0.0",
@@ -11755,7 +11756,7 @@
       }
     },
     "polyfill-library-3.25.1": {
-      "version": "npm:polyfill-library@3.25.1",
+      "version": "3.25.1",
       "resolved": "https://registry.npmjs.org/polyfill-library/-/polyfill-library-3.25.1.tgz",
       "integrity": "sha512-MuQ9lszx4NkCONupStLZqJQvdE8WVEG6QToS0D3Glup8sHxl2IljLJNGzeEaSs2EY//U51RJeWGpwuhq1y0H7Q==",
       "requires": {
@@ -11922,7 +11923,7 @@
       }
     },
     "polyfill-library-3.25.3": {
-      "version": "npm:polyfill-service@3.25.3",
+      "version": "3.25.3",
       "resolved": "https://registry.npmjs.org/polyfill-service/-/polyfill-service-3.25.3.tgz",
       "integrity": "sha512-gYFh3htyCJJR/hp2GFEZB0gGfmJjtBWHaVK3uOYnp3qdyPVhD0Nbv6CFt+kDJT7Vi4eXvRwoOM/pA04NK90c3g==",
       "requires": {
@@ -21117,7 +21118,7 @@
       }
     },
     "polyfill-library-3.27.4": {
-      "version": "npm:polyfill-library@3.27.4",
+      "version": "3.27.4",
       "resolved": "https://registry.npmjs.org/polyfill-library/-/polyfill-library-3.27.4.tgz",
       "integrity": "sha512-OUAZqc1ZoNyHvwS3qwXSfRdhzrheURDPrPDqIAvNgyzXIhdfuGJn5YJP7n/pWamUlglRCoiSpV0Qdd0H6IL2Hw==",
       "requires": {
@@ -21182,7 +21183,7 @@
       }
     },
     "polyfill-library-3.28.1": {
-      "version": "npm:polyfill-library@3.28.1",
+      "version": "3.28.1",
       "resolved": "https://registry.npmjs.org/polyfill-library/-/polyfill-library-3.28.1.tgz",
       "integrity": "sha512-31k9fnOQIxxzrJbgOaT50QCys6Wjb382O5dKqSLp70nRU/QMTs4oIVzUlZ6QeoLFypiTMOPZHJnKvRyxM59IZA==",
       "requires": {
@@ -21262,7 +21263,7 @@
       }
     },
     "polyfill-library-3.34.0": {
-      "version": "npm:polyfill-library@3.34.0",
+      "version": "3.34.0",
       "resolved": "https://registry.npmjs.org/polyfill-library/-/polyfill-library-3.34.0.tgz",
       "integrity": "sha512-Eug5j+ANwflBqpGv0sVcbIjsEFzot5kZmAmxC6LrB9HOT1q7TFVB68JlK5aPO0dFgLfb52G/i2taXbkPJ0hjmA==",
       "requires": {
@@ -21336,7 +21337,7 @@
       }
     },
     "polyfill-library-3.35.0": {
-      "version": "npm:polyfill-library@3.35.0",
+      "version": "3.35.0",
       "resolved": "https://registry.npmjs.org/polyfill-library/-/polyfill-library-3.35.0.tgz",
       "integrity": "sha512-rXbv9XfVGGQ3a3T7R/xn55vu80+t0Rb3ix6a3KUMrb6IIScx+CX8GQurXdQfEGXTSTGVARYFr9XprCXC0l6YjA==",
       "requires": {
@@ -21429,7 +21430,7 @@
       }
     },
     "polyfill-library-3.36.0": {
-      "version": "npm:polyfill-library@3.36.0",
+      "version": "3.36.0",
       "resolved": "https://registry.npmjs.org/polyfill-library/-/polyfill-library-3.36.0.tgz",
       "integrity": "sha512-znAPCvMVBenvFhb+QM+EBUC+DNFDhJ54SySyIbpjQuvkGCfOjQDhcYWuIKwIiRXwNp0/F6GWWpfK0gLTAV/Afg==",
       "requires": {
@@ -21525,7 +21526,7 @@
       }
     },
     "polyfill-library-3.37.0": {
-      "version": "npm:polyfill-library@3.37.0",
+      "version": "3.37.0",
       "resolved": "https://registry.npmjs.org/polyfill-library/-/polyfill-library-3.37.0.tgz",
       "integrity": "sha512-lHLbkqr4CnZjadpWFt+z0cqYMY8LaKHzGpFhL/uk1/CuqH4pXJPnjEJstHYntVo+i9G9fOxKWjyFiqACO2O5GA==",
       "requires": {
@@ -21621,7 +21622,7 @@
       }
     },
     "polyfill-library-3.38.0": {
-      "version": "npm:polyfill-library@3.38.0",
+      "version": "3.38.0",
       "resolved": "https://registry.npmjs.org/polyfill-library/-/polyfill-library-3.38.0.tgz",
       "integrity": "sha512-HxhaVbgznssyBwntnKyOqnB1ckjPSt6cjf6tNWAeppWBHlMJAFVWIiN9ssMqdFggllTervIbLE0S95UuBuxfrA==",
       "requires": {
@@ -21713,7 +21714,7 @@
       }
     },
     "polyfill-library-3.39.0": {
-      "version": "npm:polyfill-library@3.39.0",
+      "version": "3.39.0",
       "resolved": "https://registry.npmjs.org/polyfill-library/-/polyfill-library-3.39.0.tgz",
       "integrity": "sha512-da5JLCT0UHby7CUuLi4jBntUI8oIHxL6CsQ3I70V7n0tTvITQVKgQrsELashaWz8yrW7rKxVqdhBp/YPKzaerA==",
       "requires": {
@@ -23935,6 +23936,11 @@
       "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.3.4.tgz",
       "integrity": "sha512-KP0ZYk5hJNBS8/eIjGkFDCzGQIoZ1mnfQRYS5WM3273z+fxGWXeN0fkwf2ebEweydv9tioZIHGZKoF21U07/nw==",
       "dev": true
+    },
+    "smoothscroll-polyfill": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/smoothscroll-polyfill/-/smoothscroll-polyfill-0.4.4.tgz",
+      "integrity": "sha512-TK5ZA9U5RqCwMpfoMq/l1mrH0JAR7y7KRvOBx0n2869aLxch+gT9GhN3yUfjiw+d/DiF1mKo14+hd62JyMmoBg=="
     },
     "snapdragon": {
       "version": "0.8.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11756,7 +11756,7 @@
       }
     },
     "polyfill-library-3.25.1": {
-      "version": "3.25.1",
+      "version": "npm:polyfill-library-3.25.1@3.25.1",
       "resolved": "https://registry.npmjs.org/polyfill-library/-/polyfill-library-3.25.1.tgz",
       "integrity": "sha512-MuQ9lszx4NkCONupStLZqJQvdE8WVEG6QToS0D3Glup8sHxl2IljLJNGzeEaSs2EY//U51RJeWGpwuhq1y0H7Q==",
       "requires": {
@@ -11923,7 +11923,7 @@
       }
     },
     "polyfill-library-3.25.3": {
-      "version": "3.25.3",
+      "version": "npm:polyfill-library-3.25.3@3.25.3",
       "resolved": "https://registry.npmjs.org/polyfill-service/-/polyfill-service-3.25.3.tgz",
       "integrity": "sha512-gYFh3htyCJJR/hp2GFEZB0gGfmJjtBWHaVK3uOYnp3qdyPVhD0Nbv6CFt+kDJT7Vi4eXvRwoOM/pA04NK90c3g==",
       "requires": {
@@ -21118,7 +21118,7 @@
       }
     },
     "polyfill-library-3.27.4": {
-      "version": "3.27.4",
+      "version": "npm:polyfill-library-3.27.4@3.27.4",
       "resolved": "https://registry.npmjs.org/polyfill-library/-/polyfill-library-3.27.4.tgz",
       "integrity": "sha512-OUAZqc1ZoNyHvwS3qwXSfRdhzrheURDPrPDqIAvNgyzXIhdfuGJn5YJP7n/pWamUlglRCoiSpV0Qdd0H6IL2Hw==",
       "requires": {
@@ -21183,7 +21183,7 @@
       }
     },
     "polyfill-library-3.28.1": {
-      "version": "3.28.1",
+      "version": "npm:polyfill-library-3.28.1@3.28.1",
       "resolved": "https://registry.npmjs.org/polyfill-library/-/polyfill-library-3.28.1.tgz",
       "integrity": "sha512-31k9fnOQIxxzrJbgOaT50QCys6Wjb382O5dKqSLp70nRU/QMTs4oIVzUlZ6QeoLFypiTMOPZHJnKvRyxM59IZA==",
       "requires": {
@@ -21263,7 +21263,7 @@
       }
     },
     "polyfill-library-3.34.0": {
-      "version": "3.34.0",
+      "version": "npm:polyfill-library-3.34.0@3.34.0",
       "resolved": "https://registry.npmjs.org/polyfill-library/-/polyfill-library-3.34.0.tgz",
       "integrity": "sha512-Eug5j+ANwflBqpGv0sVcbIjsEFzot5kZmAmxC6LrB9HOT1q7TFVB68JlK5aPO0dFgLfb52G/i2taXbkPJ0hjmA==",
       "requires": {
@@ -21337,7 +21337,7 @@
       }
     },
     "polyfill-library-3.35.0": {
-      "version": "3.35.0",
+      "version": "npm:polyfill-library-3.35.0@3.35.0",
       "resolved": "https://registry.npmjs.org/polyfill-library/-/polyfill-library-3.35.0.tgz",
       "integrity": "sha512-rXbv9XfVGGQ3a3T7R/xn55vu80+t0Rb3ix6a3KUMrb6IIScx+CX8GQurXdQfEGXTSTGVARYFr9XprCXC0l6YjA==",
       "requires": {
@@ -21430,7 +21430,7 @@
       }
     },
     "polyfill-library-3.36.0": {
-      "version": "3.36.0",
+      "version": "npm:polyfill-library-3.36.0@3.36.0",
       "resolved": "https://registry.npmjs.org/polyfill-library/-/polyfill-library-3.36.0.tgz",
       "integrity": "sha512-znAPCvMVBenvFhb+QM+EBUC+DNFDhJ54SySyIbpjQuvkGCfOjQDhcYWuIKwIiRXwNp0/F6GWWpfK0gLTAV/Afg==",
       "requires": {
@@ -21526,7 +21526,7 @@
       }
     },
     "polyfill-library-3.37.0": {
-      "version": "3.37.0",
+      "version": "npm:polyfill-library-3.37.0@3.37.0",
       "resolved": "https://registry.npmjs.org/polyfill-library/-/polyfill-library-3.37.0.tgz",
       "integrity": "sha512-lHLbkqr4CnZjadpWFt+z0cqYMY8LaKHzGpFhL/uk1/CuqH4pXJPnjEJstHYntVo+i9G9fOxKWjyFiqACO2O5GA==",
       "requires": {
@@ -21622,7 +21622,7 @@
       }
     },
     "polyfill-library-3.38.0": {
-      "version": "3.38.0",
+      "version": "npm:polyfill-library-3.38.0@3.38.0",
       "resolved": "https://registry.npmjs.org/polyfill-library/-/polyfill-library-3.38.0.tgz",
       "integrity": "sha512-HxhaVbgznssyBwntnKyOqnB1ckjPSt6cjf6tNWAeppWBHlMJAFVWIiN9ssMqdFggllTervIbLE0S95UuBuxfrA==",
       "requires": {
@@ -21714,9 +21714,193 @@
       }
     },
     "polyfill-library-3.39.0": {
-      "version": "3.39.0",
+      "version": "npm:polyfill-library-3.39.0@3.39.0",
       "resolved": "https://registry.npmjs.org/polyfill-library/-/polyfill-library-3.39.0.tgz",
       "integrity": "sha512-da5JLCT0UHby7CUuLi4jBntUI8oIHxL6CsQ3I70V7n0tTvITQVKgQrsELashaWz8yrW7rKxVqdhBp/YPKzaerA==",
+      "requires": {
+        "@financial-times/polyfill-useragent-normaliser": "^1.2.0",
+        "@iarna/toml": "^2.2.3",
+        "@webcomponents/template": "^1.4.0",
+        "Base64": "^1.0.0",
+        "abort-controller": "^2.0.2",
+        "audio-context-polyfill": "^1.0.0",
+        "diff": "1.4.0",
+        "event-source-polyfill": "^0.0.9",
+        "from2-string": "^1.1.0",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.10",
+        "html5shiv": "^3.7.3",
+        "intersection-observer": "^0.4.1",
+        "intl": "^1.2.5",
+        "js-polyfills": "^0.1.40",
+        "json3": "^3.3.2",
+        "lazystream": "^1.0.0",
+        "merge2": "^1.0.3",
+        "mkdirp": "^0.5.0",
+        "mnemonist": "^0.27.2",
+        "mutationobserver-shim": "^0.3.2",
+        "picturefill": "^3.0.1",
+        "resize-observer-polyfill": "^1.5.1",
+        "rimraf": "^2.6.2",
+        "spdx-licenses": "^1.0.0",
+        "stream-cache": "^0.0.2",
+        "stream-from-promise": "^1.0.0",
+        "stream-to-string": "^1.1.0",
+        "toposort": "^2.0.2",
+        "uglify-js": "^2.7.5",
+        "unorm": "^1.6.0",
+        "usertiming": "^0.1.8",
+        "web-animations-js": "^2.2.5",
+        "whatwg-fetch": "^3.0.0",
+        "wicg-inert": "^2.1.2",
+        "yaku": "0.18.6"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "deep-is": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+          "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+        },
+        "is2": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is2/-/is2-2.0.1.tgz",
+          "integrity": "sha512-+WaJvnaA7aJySz2q/8sLjMb2Mw14KTplHmSwcSpZ/fWJPkUmqw3YTzSWbPJ7OAwRvdYTWF2Wg+yYJ1AdP5Z8CA==",
+          "requires": {
+            "deep-is": "^0.1.3",
+            "ip-regex": "^2.1.0",
+            "is-url": "^1.2.2"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        },
+        "spdx-licenses": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/spdx-licenses/-/spdx-licenses-1.0.0.tgz",
+          "integrity": "sha512-BmeFZRYH9XXf56omx0LuiG+gBXRqwmrKsOtcsGTJh8tw9U0cgRKTrOnyDpP1uvI1AVEkoRKYaAvR902ByotFOw==",
+          "requires": {
+            "debug": "4.1.1",
+            "is2": "2.0.1"
+          }
+        },
+        "uglify-js": {
+          "version": "2.8.29",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+          "requires": {
+            "source-map": "~0.5.1",
+            "uglify-to-browserify": "~1.0.0",
+            "yargs": "~3.10.0"
+          }
+        }
+      }
+    },
+    "polyfill-library-3.40.0": {
+      "version": "npm:polyfill-library@3.40.0",
+      "resolved": "https://registry.npmjs.org/polyfill-library/-/polyfill-library-3.40.0.tgz",
+      "integrity": "sha512-al9Zv1c4uhpgOKTLsyhXgD7De/xzk7r946UMlQFbS/LmcOgA2WjZg5byPbqW4cZy1X3aSJN1Kfx86rR5O4/clg==",
+      "requires": {
+        "@financial-times/polyfill-useragent-normaliser": "^1.2.0",
+        "@iarna/toml": "^2.2.3",
+        "@webcomponents/template": "^1.4.0",
+        "Base64": "^1.0.0",
+        "abort-controller": "^2.0.2",
+        "audio-context-polyfill": "^1.0.0",
+        "diff": "1.4.0",
+        "event-source-polyfill": "^0.0.9",
+        "from2-string": "^1.1.0",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.10",
+        "html5shiv": "^3.7.3",
+        "intersection-observer": "^0.4.1",
+        "intl": "^1.2.5",
+        "js-polyfills": "^0.1.40",
+        "json3": "^3.3.2",
+        "lazystream": "^1.0.0",
+        "merge2": "^1.0.3",
+        "mkdirp": "^0.5.0",
+        "mnemonist": "^0.27.2",
+        "mutationobserver-shim": "^0.3.2",
+        "picturefill": "^3.0.1",
+        "resize-observer-polyfill": "^1.5.1",
+        "rimraf": "^2.6.2",
+        "spdx-licenses": "^1.0.0",
+        "stream-cache": "^0.0.2",
+        "stream-from-promise": "^1.0.0",
+        "stream-to-string": "^1.1.0",
+        "toposort": "^2.0.2",
+        "uglify-js": "^2.7.5",
+        "unorm": "^1.6.0",
+        "usertiming": "^0.1.8",
+        "web-animations-js": "^2.2.5",
+        "whatwg-fetch": "^3.0.0",
+        "wicg-inert": "^2.1.2",
+        "yaku": "0.18.6"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "deep-is": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+          "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+        },
+        "is2": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is2/-/is2-2.0.1.tgz",
+          "integrity": "sha512-+WaJvnaA7aJySz2q/8sLjMb2Mw14KTplHmSwcSpZ/fWJPkUmqw3YTzSWbPJ7OAwRvdYTWF2Wg+yYJ1AdP5Z8CA==",
+          "requires": {
+            "deep-is": "^0.1.3",
+            "ip-regex": "^2.1.0",
+            "is-url": "^1.2.2"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        },
+        "spdx-licenses": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/spdx-licenses/-/spdx-licenses-1.0.0.tgz",
+          "integrity": "sha512-BmeFZRYH9XXf56omx0LuiG+gBXRqwmrKsOtcsGTJh8tw9U0cgRKTrOnyDpP1uvI1AVEkoRKYaAvR902ByotFOw==",
+          "requires": {
+            "debug": "4.1.1",
+            "is2": "2.0.1"
+          }
+        },
+        "uglify-js": {
+          "version": "2.8.29",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+          "requires": {
+            "source-map": "~0.5.1",
+            "uglify-to-browserify": "~1.0.0",
+            "yargs": "~3.10.0"
+          }
+        }
+      }
+    },
+    "polyfill-library-3.41.0": {
+      "version": "npm:polyfill-library@3.41.0",
+      "resolved": "https://registry.npmjs.org/polyfill-library/-/polyfill-library-3.41.0.tgz",
+      "integrity": "sha512-y61ke12JouCUCSe8vO3P1VsKx76YwyeA6Ze2LgXD7SImfKGkx22xGUrR5gCphwDDKiRxleabTTt7VWqC7jdTIQ==",
       "requires": {
         "@financial-times/polyfill-useragent-normaliser": "^1.2.0",
         "@iarna/toml": "^2.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "polyfill-service",
-  "version": "4.13.0",
+  "version": "4.14.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -94,5 +94,5 @@
     "sinon": "^7.3.2",
     "supertest": "^4.0.2"
   },
-  "version": "4.13.0"
+  "version": "4.14.0"
 }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "dotenv": "^8.0.0",
     "express-extractheaders": "^3.0.0",
     "iltorb": "^2.4.3",
-    "polyfill-library": "^3.40.0",
+    "polyfill-library": "^3.42.0",
     "polyfill-library-3.25.1": "npm:polyfill-library@3.25.1",
     "polyfill-library-3.25.3": "npm:polyfill-service@3.25.3",
     "polyfill-library-3.27.4": "npm:polyfill-library@3.27.4",
@@ -56,6 +56,8 @@
     "polyfill-library-3.37.0": "npm:polyfill-library@3.37.0",
     "polyfill-library-3.38.0": "npm:polyfill-library@3.38.0",
     "polyfill-library-3.39.0": "npm:polyfill-library@3.39.0",
+    "polyfill-library-3.40.0": "npm:polyfill-library@3.40.0",
+    "polyfill-library-3.41.0": "npm:polyfill-library@3.41.0",
     "require-all": "^3.0.0",
     "serve-static": "^1.14.1",
     "throng": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -92,5 +92,5 @@
     "sinon": "^7.3.2",
     "supertest": "^4.0.2"
   },
-  "version": "4.12.0"
+  "version": "4.13.0"
 }

--- a/server/routes/v3/polyfill.js
+++ b/server/routes/v3/polyfill.js
@@ -14,6 +14,8 @@ const polyfillio_3_36_0 = require("polyfill-library-3.36.0");
 const polyfillio_3_37_0 = require("polyfill-library-3.37.0");
 const polyfillio_3_38_0 = require("polyfill-library-3.38.0");
 const polyfillio_3_39_0 = require("polyfill-library-3.39.0");
+const polyfillio_3_40_0 = require("polyfill-library-3.40.0");
+const polyfillio_3_41_0 = require("polyfill-library-3.41.0");
 
 async function respondWithBundle(response, params, bundle) {
 	const file = await compressBundle(params.compression, bundle);
@@ -36,6 +38,16 @@ module.exports = app => {
 		switch (params.version) {
 			case latestVersion: {
 				const bundle = await polyfillio.getPolyfillString(params);
+				await respondWithBundle(response, params, bundle);
+				break;
+			}
+			case "3.41.0": {
+				const bundle = await polyfillio_3_41_0.getPolyfillString(params);
+				await respondWithBundle(response, params, bundle);
+				break;
+			}
+			case "3.40.0": {
+				const bundle = await polyfillio_3_40_0.getPolyfillString(params);
 				await respondWithBundle(response, params, bundle);
 				break;
 			}


### PR DESCRIPTION
3.42 release notes:
Added missing Type dependency for Object.preventExtensions

Don't serve object.preventextensions to browsers which support the es2015 defined behavior
as defined from here https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/preventExtensions#Browser_compatibility

Serve URL/URLSearchParams polyfill to Firefox versions below 44

Added element.scroll* polyfills