### PR TITLE
Top of the pops config updates

### DIFF
--- a/fastly/terraform/main.tf
+++ b/fastly/terraform/main.tf
@@ -80,3 +80,13 @@ resource "fastly_service_v1" "app" {
     name = "toppops_config"
   }
 }
+
+resource "fastly_service_dictionary_items_v1" "items" {
+  service_id    = fastly_service_v1.app.id
+  dictionary_id = "${ { for dictionary in fastly_service_v1.app.dictionary : dictionary.name => dictionary.dictionary_id }["secrets"]}"
+
+  items = {
+    datacenters : "LCY,NRT,HAM,BWI,DCA"
+    sample_percent : "0"
+  }
+}

--- a/fastly/terraform/main.tf
+++ b/fastly/terraform/main.tf
@@ -83,7 +83,7 @@ resource "fastly_service_v1" "app" {
 
 resource "fastly_service_dictionary_items_v1" "items" {
   service_id    = fastly_service_v1.app.id
-  dictionary_id = "${ { for dictionary in fastly_service_v1.app.dictionary : dictionary.name => dictionary.dictionary_id }["secrets"]}"
+  dictionary_id = "${ { for dictionary in fastly_service_v1.app.dictionary : dictionary.name => dictionary.dictionary_id }["toppops_config"]}"
 
   items = {
     datacenters : "LCY,NRT,HAM,BWI,DCA"

--- a/fastly/terraform/production_override.tf
+++ b/fastly/terraform/production_override.tf
@@ -86,7 +86,7 @@ resource "fastly_service_v1" "app" {
 
 resource "fastly_service_dictionary_items_v1" "items" {
   service_id    = fastly_service_v1.app.id
-  dictionary_id = "${ { for dictionary in fastly_service_v1.app.dictionary : dictionary.name => dictionary.dictionary_id }["secrets"]}"
+  dictionary_id = "${ { for dictionary in fastly_service_v1.app.dictionary : dictionary.name => dictionary.dictionary_id }["toppops_config"]}"
 
   items = {
     datacenters : "LCY,NRT,HAM,BWI,DCA"

--- a/fastly/terraform/production_override.tf
+++ b/fastly/terraform/production_override.tf
@@ -92,4 +92,8 @@ resource "fastly_service_dictionary_items_v1" "items" {
     datacenters : "LCY,NRT,HAM,BWI,DCA"
     sample_percent : "5"
   }
+
+  lifecycle {
+    ignore_changes = [items, ]
+  }
 }


### PR DESCRIPTION
Sample zero requests for all services by default.

Sample five percent of requests for production service at first and then allow updates to the config to happen all via the Fastly API/UI.