### PR TITLE
If the response is a 304, reset the age to 0

### DIFF
--- a/fastly/vcl/polyfill-service.vcl
+++ b/fastly/vcl/polyfill-service.vcl
@@ -218,6 +218,10 @@ sub vcl_deliver {
 		set resp.http.Vary = "User-Agent, Accept-Encoding";
 	}
 
+	if (resp.status == 304) {
+		set resp.http.Age = "0";
+	}
+
 	add resp.http.Server-Timing = fastly_info.state {", fastly;desc="Edge time";dur="} time.elapsed.msec;
 
 	if (req.http.Fastly-Debug) {

--- a/test/integration/regression/304-age.test.js
+++ b/test/integration/regression/304-age.test.js
@@ -18,12 +18,12 @@ describe("Request with a If-None-Match value which is the same as the ETag", fun
 					.get("/v3/polyfill.min.js")
 					.set("if-none-match", eTag)
 					.expect(304)
-					.expect("Age", 0);
+					.expect("Age", "0");
 			});
 	});
 });
 
-describe("Request with a If-None-Match value which is the different to the ETag", function() {
+describe("Request with a If-None-Match value which is different to the ETag", function() {
 	it(`responds with a 200 and an Age reset to 0`, function() {
 		this.timeout(30000);
 		return request(host)
@@ -36,7 +36,7 @@ describe("Request with a If-None-Match value which is the different to the ETag"
 					.get("/v3/polyfill.min.js")
 					.set("if-none-match", eTag)
 					.expect(304)
-					.expect("Age", 0);
+					.expect("Age", "0");
 			});
 	});
 });

--- a/test/integration/regression/304-age.test.js
+++ b/test/integration/regression/304-age.test.js
@@ -1,0 +1,42 @@
+/* eslint-env mocha */
+
+"use strict";
+
+const request = require("supertest");
+const host = require("../helpers").host;
+
+describe("Request with a If-None-Match value which is the same as the ETag", function() {
+	it(`responds with a 304 and an Age reset to 0`, function() {
+		this.timeout(30000);
+		return request(host)
+			.get("/v3/polyfill.min.js")
+			.expect(200)
+			.then(response => {
+				const eTag = response.headers["etag"];
+
+				return request(host)
+					.get("/v3/polyfill.min.js")
+					.set("if-none-match", eTag)
+					.expect(304)
+					.expect("Age", 0);
+			});
+	});
+});
+
+describe("Request with a If-None-Match value which is the different to the ETag", function() {
+	it(`responds with a 200 and an Age reset to 0`, function() {
+		this.timeout(30000);
+		return request(host)
+			.get("/v3/polyfill.min.js")
+			.expect(200)
+			.then(response => {
+				const eTag = response.headers["etag"];
+
+				return request(host)
+					.get("/v3/polyfill.min.js")
+					.set("if-none-match", eTag)
+					.expect(304)
+					.expect("Age", 0);
+			});
+	});
+});


### PR DESCRIPTION
This ensures that the age is never larger than the max-age cache-control directive

Fixes https://github.com/Financial-Times/polyfill-service/issues/2072
Fixes https://github.com/Financial-Times/polyfill-service/issues/2053