### PR TITLE
Fix HTML table formatting in RUNBOOK.md

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -83,63 +83,62 @@ This system is a Node.js [application](https://github.com/Financial-Times/polyfi
 ## More Information
 
 <table width=100% style="border:1px solid;">
-                                                                                <tr>
-                                                                                <td><b>Hours of Support</b></td>
-                                                                                <td>Engineering support is available in Business hours.</td>
-                                                                                </tr>
-                                                                                
-                                                                                <tr>
-                                                                                <td><b>Hardware</b></td>
-                                                                                <td>Heroku</td>
-                                                                                </tr>
-                                                                                
-                                                                                <tr>
-                                                                                <td><b>Network</b></td>
-                                                                                <td>Requires HTTP and HTTPS inbound</td>
-                                                                                </tr>
-                                                                                
-                                                                                <tr>
-                                                                                <td><b>Operating System</b></td>
-                                                                                <td>Unix-like (Heroku)</td>
-                                                                                </tr>
-                                                                                
-                                                                                <tr>
-                                                                                <td><b>Database</b></td>
-                                                                                <td>None (the service does not store any data)</td>
-                                                                                </tr>
-                                                                                
-                                                                                <tr>
-                                                                                <td><b>Backups</b></td>
-                                                                                <td>None (the service does not store any data)</td>
-                                                                                </tr>
-                                                                                
-                                                                                <tr>
-                                                                                <td><b>Technical Dependencies</b></td>
-                                                                                <td>NodeJS &gt;= 0.10.13</td>
-                                                                                </tr>
-                                                                                
-                                                                                <tr>
-                                                                                <td><b>Link to Architecture Diagram</b></td>
-                                                                                <td><a href='https://docs.google.com/a/ft.com/drawings/d/1eA_sYaSRkvOqIxdkN6LRpyHeOzv8Mxr51WMfXM1sS3Q/edit?usp=sharing'>On Google Drive</a></td>
-                                                                                </tr>
-                                                                                
-                                                                                
-                                                                                <tr>
-                                                                                <td><b>Link to Business Continuity Plan</b></td>
-                                                                                <td>None</td>
-                                                                                </tr>
-                                                                                
-                                                                                <tr>
-                                                                                <td><b>Agreed Maintenance Window(s)</b></td>
-                                                                                <td>None</td>
-                                                                                </tr>
-                                                                                
-                                                                                <tr>
-                                                                                <td><b>Useful Sites/Other Information</b></td>
-                                                                                <td>Full information on setting up and deploying the service is in the <a rel='nofollow' href='https://github.com/Financial-Times/polyfill-service'>README in the git repo</a>, which is publicly accessible on GitHub.<br/>
-                                                                                Control of the service is via the <a rel='nofollow' href='https://app.fastly.com/#analytics/4E1GeTez3EFH3cnwfyMAog'>Fastly dashboard</a> and <a rel='nofollow' href='https://dashboard-next.heroku.com/orgs/financial-times/apps/ft-polyfill-service/activity'>Heroku dashboard</a>, so check that you can access both of these.</td>
-                                                                                </tr>
-                                                                                </table>
+  <tr>
+    <td><b>Hours of Support</b></td>
+    <td>Engineering support is available in Business hours.</td>
+  </tr>
+
+  <tr>
+    <td><b>Hardware</b></td>
+    <td>Heroku</td>
+  </tr>
+
+  <tr>
+    <td><b>Network</b></td>
+    <td>Requires HTTP and HTTPS inbound</td>
+  </tr>
+
+  <tr>
+    <td><b>Operating System</b></td>
+    <td>Unix-like (Heroku)</td>
+  </tr>
+
+  <tr>
+    <td><b>Database</b></td>
+    <td>None (the service does not store any data)</td>
+  </tr>
+
+  <tr>
+    <td><b>Backups</b></td>
+    <td>None (the service does not store any data)</td>
+  </tr>
+
+  <tr>
+    <td><b>Technical Dependencies</b></td>
+    <td>NodeJS &gt;= 0.10.13</td>
+  </tr>
+
+  <tr>
+    <td><b>Link to Architecture Diagram</b></td>
+    <td><a href='https://docs.google.com/a/ft.com/drawings/d/1eA_sYaSRkvOqIxdkN6LRpyHeOzv8Mxr51WMfXM1sS3Q/edit?usp=sharing'>On Google Drive</a></td>
+  </tr>    
+
+  <tr>
+    <td><b>Link to Business Continuity Plan</b></td>
+    <td>None</td>
+  </tr>
+
+  <tr>
+    <td><b>Agreed Maintenance Window(s)</b></td>
+    <td>None</td>
+  </tr>
+
+  <tr>
+    <td><b>Useful Sites/Other Information</b></td>
+    <td>Full information on setting up and deploying the service is in the <a rel='nofollow' href='https://github.com/Financial-Times/polyfill-service'>README in the git repo</a>, which is publicly accessible on GitHub.<br/>
+    Control of the service is via the <a rel='nofollow' href='https://app.fastly.com/#analytics/4E1GeTez3EFH3cnwfyMAog'>Fastly dashboard</a> and <a rel='nofollow' href='https://dashboard-next.heroku.com/orgs/financial-times/apps/ft-polyfill-service/activity'>Heroku dashboard</a>, so check that you can access both of these.</td>
+  </tr>
+</table>
 
 ## First Line Troubleshooting
 
@@ -158,7 +157,7 @@ If only a few things aren't working, the Splunk logs (see monitoring) are the be
 ## Monitoring
 
 The development team does not receive monitoring alerts, but we have set up a number of standard application monitoring tools, and are available during business hours to help diagnose and resolve faults.
-                                                                                
+
 <table width="100%" style="margin: 0px; font-family: &quot;Open Sans&quot;, sans-serif; font-size: 13px; border: 1px solid black; background-color: white;"><tbody><tr><th style="background-image: initial; background-position: initial; background-size: initial; background-repeat: initial; background-attachment: initial; background-origin: initial; background-clip: initial; border-top: 1px solid rgb(204, 204, 204);">Tool</th><th style="background-image: initial; background-position: initial; background-size: initial; background-repeat: initial; background-attachment: initial; background-origin: initial; background-clip: initial; border-top: 1px solid rgb(204, 204, 204);">Dashboard</th><th style="background-image: initial; background-position: initial; background-size: initial; background-repeat: initial; background-attachment: initial; background-origin: initial; background-clip: initial; border-top: 1px solid rgb(204, 204, 204);">Notes</th></tr><tr><td style="vertical-align: top;">Health check</td><td style="vertical-align: top;"><a href="http://www.google.com/url?q=http%3A%2F%2Fcdn.polyfill.io%2F__health&amp;sa=D&amp;sntz=1&amp;usg=AFQjCNFhMAo9ghRrTPZaB_3TYMBeaYJA2g" rel="nofollow" style="color: rgb(158, 47, 80) !important;">http://cdn.polyfill.io/__health</a></td><td style="vertical-align: top;">Self-diagnostics page with guidance on fixing common problems. Check this first.&nbsp;</td></tr><tr><td style="vertical-align: top;">Good to go</td><td style="vertical-align: top;"><a href="http://www.google.com/url?q=http%3A%2F%2Fcdn.polyfill.io%2F__gtg&amp;sa=D&amp;sntz=1&amp;usg=AFQjCNGaVIRR4ov8HisbznItAxgs-1EoGQ" rel="nofollow" style="color: rgb(158, 47, 80) !important;">http://cdn.polyfill.io/__gtg</a></td><td style="vertical-align: top;"></td></tr><tr><td style="vertical-align: top;">Pingdom</td><td style="vertical-align: top;">A number of checks are available that begin 'Origami polyfill service', eg&nbsp;<a href="https://www.google.com/url?q=https%3A%2F%2Fmy.pingdom.com%2Freports%2Fuptime%23daterange%3D7days%26check%3D1338405%26tab%3Duptime_tab&amp;sa=D&amp;sntz=1&amp;usg=AFQjCNGZeL6XGzYmptihkRd7ykVASmc21A" style="color: rgb(158, 47, 80) !important;">this one</a></td><td style="vertical-align: top;"><span style="font-size: 13.3333px;">Control of the service is via the&nbsp;</span><a href="https://www.google.com/url?q=https%3A%2F%2Fapp.fastly.com%2F%23analytics%2F4E1GeTez3EFH3cnwfyMAog&amp;sa=D&amp;sntz=1&amp;usg=AFrqEzckqsCHomy3Cugwfbpm1-ind_CD4g" style="font-size: 13.3333px; color: rgb(158, 47, 80) !important;">Fastly dashboard</a><span style="font-size: 13.3333px;">&nbsp;and&nbsp;</span><a href="https://www.google.com/url?q=https%3A%2F%2Fdashboard-next.heroku.com%2Forgs%2Ffinancial-times%2Fapps%2Fft-polyfill-service%2Factivity&amp;sa=D&amp;sntz=1&amp;usg=AFrqEze3MmHbQj2j00oCqjMuKNhERp1Y3g" style="font-size: 13.3333px; color: rgb(158, 47, 80) !important;">Heroku dashboard</a><span style="font-size: 13.3333px;">, so check that you can access both of these.</span></td></tr></tbody></table>
 
 ## Failover Details
@@ -176,4 +175,3 @@ The application is deployed to QA whenever a new commit is pushed to the `master
 ## Key Management Details
 
 Not Applicable
-


### PR DESCRIPTION
Heavy indentation and empty lines between row definitions were causing
the HTML to be rendered as a code block instead of a table.

This fix removes whitespace but retains nesting levels and empty lines
- as long as the first line of each block is indented by less than four
spaces it will not be interpreted as a code block since single newlines
in Markdown are ignored.