### PR TITLE
Show aliases that are aliases for a single polyfill as polyfills

### DIFF
--- a/src/assets/url-builder.njk
+++ b/src/assets/url-builder.njk
@@ -39,7 +39,7 @@ oLayoutStyle: "o-layout--query"
 					<input name="callback" id="callback" type="text" class="o-forms__text" placeholder="Type to filter by name">
 			</span>
 		</label>
-		
+
 		<div class="o-forms-field o-forms-field--optional" role="group" aria-labelledby="minify-title" aria-describedby="minify-info">
 			<span class="o-forms-title">
 				<span class="o-forms-title__main" id="minify-title">Minify bundle</span>
@@ -66,7 +66,7 @@ oLayoutStyle: "o-layout--query"
 				<span class="o-forms-title__main" id="avaliable-polyfills-title">Available Polyfills</span>
 					<span class="o-forms-title__prompt" id="avaliable-polyfills-info">Check the boxes of the polyfills or polyfill-sets you want to have in your bundle.</span>
 			</span>
-	
+
 		<div class="o-forms-input o-forms-input--checkbox" id="features-list">
 		{% for item in polyfills.polyfillAliases %}
 			<div class="polyfill" data-feature-name="{{item.name}}-polyfill">
@@ -102,7 +102,7 @@ oLayoutStyle: "o-layout--query"
 				<div id="{{item.name}}-tooltip-element" data-o-component="o-tooltip" data-o-tooltip-position="right" data-o-tooltip-target="{{item.name}}-tooltip-target" data-o-tooltip-toggle-on-click="true">
 					<div class="o-tooltip-content">
 						<ul>
-							<li class='license'><a title='This polyfill has a specific licence' href='https://choosealicense.com/licenses/{{licenseLowerCase}}'>License: {{item.license}}</a></li>
+							{% if item.license %}<li class='license'><a title='This polyfill has a specific licence' href='https://choosealicense.com/licenses/{{licenseLowerCase}}'>License: {{item.license}}</a></li>{% endif %}
 							{% if spec %}<li><a href='{{item.spec}}'>Specification</a></li>{% endif %}
 							{% if docs %}<li><a href='{{item.docs}}'>Documentation</a></li>{% endif %}
 							<li><a href='https://github.com/Financial-Times/polyfill-library/tree/master/polyfills/{{item.baseDir}}'>Polyfill source</a></li>

--- a/src/assets/url-builder.njk
+++ b/src/assets/url-builder.njk
@@ -102,10 +102,11 @@ oLayoutStyle: "o-layout--query"
 				<div id="{{item.name}}-tooltip-element" data-o-component="o-tooltip" data-o-tooltip-position="right" data-o-tooltip-target="{{item.name}}-tooltip-target" data-o-tooltip-toggle-on-click="true">
 					<div class="o-tooltip-content">
 						<ul>
+							{% if item.aliasFor %}<li class='alias'>Alias for <code>{{item.aliasFor}}</code></li>{% endif %}
 							{% if item.license %}<li class='license'><a title='This polyfill has a specific licence' href='https://choosealicense.com/licenses/{{item.licenseLowerCase}}'>License: {{item.license}}</a></li>{% endif %}
 							{% if item.spec %}<li><a href='{{item.spec}}'>Specification</a></li>{% endif %}
 							{% if item.docs %}<li><a href='{{item.docs}}'>Documentation</a></li>{% endif %}
-							{% if item.baseDir}<li><a href='https://github.com/Financial-Times/polyfill-library/tree/master/polyfills/{{item.baseDir}}'>Polyfill source</a></li>{% endif %}
+							{% if item.baseDir %}<li><a href='https://github.com/Financial-Times/polyfill-library/tree/master/polyfills/{{item.baseDir}}'>Polyfill source</a></li>{% endif %}
 						</ul>
 					</div>
 				</div>

--- a/src/assets/url-builder.njk
+++ b/src/assets/url-builder.njk
@@ -102,7 +102,7 @@ oLayoutStyle: "o-layout--query"
 				<div id="{{item.name}}-tooltip-element" data-o-component="o-tooltip" data-o-tooltip-position="right" data-o-tooltip-target="{{item.name}}-tooltip-target" data-o-tooltip-toggle-on-click="true">
 					<div class="o-tooltip-content">
 						<ul>
-							{% if item.license %}<li class='license'><a title='This polyfill has a specific licence' href='https://choosealicense.com/licenses/{{licenseLowerCase}}'>License: {{item.license}}</a></li>{% endif %}
+							{% if item.license %}<li class='license'><a title='This polyfill has a specific licence' href='https://choosealicense.com/licenses/{{item.licenseLowerCase}}'>License: {{item.license}}</a></li>{% endif %}
 							{% if spec %}<li><a href='{{item.spec}}'>Specification</a></li>{% endif %}
 							{% if docs %}<li><a href='{{item.docs}}'>Documentation</a></li>{% endif %}
 							<li><a href='https://github.com/Financial-Times/polyfill-library/tree/master/polyfills/{{item.baseDir}}'>Polyfill source</a></li>

--- a/src/assets/url-builder.njk
+++ b/src/assets/url-builder.njk
@@ -105,7 +105,7 @@ oLayoutStyle: "o-layout--query"
 							{% if item.license %}<li class='license'><a title='This polyfill has a specific licence' href='https://choosealicense.com/licenses/{{item.licenseLowerCase}}'>License: {{item.license}}</a></li>{% endif %}
 							{% if item.spec %}<li><a href='{{item.spec}}'>Specification</a></li>{% endif %}
 							{% if item.docs %}<li><a href='{{item.docs}}'>Documentation</a></li>{% endif %}
-							<li><a href='https://github.com/Financial-Times/polyfill-library/tree/master/polyfills/{{item.baseDir}}'>Polyfill source</a></li>
+							{% if item.baseDir}<li><a href='https://github.com/Financial-Times/polyfill-library/tree/master/polyfills/{{item.baseDir}}'>Polyfill source</a></li>{% endif %}
 						</ul>
 					</div>
 				</div>

--- a/src/assets/url-builder.njk
+++ b/src/assets/url-builder.njk
@@ -103,8 +103,8 @@ oLayoutStyle: "o-layout--query"
 					<div class="o-tooltip-content">
 						<ul>
 							{% if item.license %}<li class='license'><a title='This polyfill has a specific licence' href='https://choosealicense.com/licenses/{{item.licenseLowerCase}}'>License: {{item.license}}</a></li>{% endif %}
-							{% if spec %}<li><a href='{{item.spec}}'>Specification</a></li>{% endif %}
-							{% if docs %}<li><a href='{{item.docs}}'>Documentation</a></li>{% endif %}
+							{% if item.spec %}<li><a href='{{item.spec}}'>Specification</a></li>{% endif %}
+							{% if item.docs %}<li><a href='{{item.docs}}'>Documentation</a></li>{% endif %}
 							<li><a href='https://github.com/Financial-Times/polyfill-library/tree/master/polyfills/{{item.baseDir}}'>Polyfill source</a></li>
 						</ul>
 					</div>

--- a/src/data/polyfills.js
+++ b/src/data/polyfills.js
@@ -53,13 +53,7 @@ module.exports = async () => {
 		}
 
 		// non-icu case-sensitive alphabetical sort
-		polyfills.sort((a, b) =>
-			a.name > b.name
-			? 1
-			: a.name < b.name
-			? -1
-			: 0
-		);
+		polyfills.sort((a, b) => (a.name > b.name ? 1 : a.name < b.name ? -1 : 0));
 	}
 
 	return {

--- a/src/data/polyfills.js
+++ b/src/data/polyfills.js
@@ -26,6 +26,11 @@ module.exports = async () => {
 							polyfills: aliases[alias]
 						});
 					}
+				} else {
+					polyfills.push({
+						name: alias,
+						labelID: `${snakeCase(alias)}_label`
+					});
 				}
 			}
 		}
@@ -45,6 +50,16 @@ module.exports = async () => {
 			}
 		}
 	}
+
+	// non-icu case-sensitive alphabetical sort
+	polyfills.sort((a, b) =>
+		a.name > b.name
+		? 1
+		: a.name < b.name
+		? -1
+		: 0
+	);
+
 	return {
 		polyfills,
 		polyfillAliases

--- a/src/data/polyfills.js
+++ b/src/data/polyfills.js
@@ -29,11 +29,13 @@ module.exports = async () => {
 				} else {
 					polyfills.push({
 						name: alias,
-						labelID: `${snakeCase(alias)}_label`
+						labelID: `${snakeCase(alias)}_label`,
+						aliasFor: aliases[alias]
 					});
 				}
 			}
 		}
+
 		for (const polyfill of await polyfillLibrary.listAllPolyfills()) {
 			// Polyfills which start with _ are internal functions used by other polyfills, they should not be displayed on the website.
 			if (!polyfill.startsWith("_") && !polyfill.startsWith("Intl.~locale")) {

--- a/src/data/polyfills.js
+++ b/src/data/polyfills.js
@@ -49,16 +49,16 @@ module.exports = async () => {
 				polyfills.push(polyfillInfo);
 			}
 		}
-	}
 
-	// non-icu case-sensitive alphabetical sort
-	polyfills.sort((a, b) =>
-		a.name > b.name
-		? 1
-		: a.name < b.name
-		? -1
-		: 0
-	);
+		// non-icu case-sensitive alphabetical sort
+		polyfills.sort((a, b) =>
+			a.name > b.name
+			? 1
+			: a.name < b.name
+			? -1
+			: 0
+		);
+	}
 
 	return {
 		polyfills,


### PR DESCRIPTION
I've used a primitive string sort instead of localeCompare here because in order
to preserve the caseFirst:"upper" style of the current code we would need to
install `full-icu`, which I've decided against seeing as the javascript items
being polyfilled are ascii.

I've also fixed a couple of bugs. The specs and docs links weren't showing, and
the license url was never being populated with the license name.

The tooltip for single-polyfill aliases shows `Alias for
<code>Polyfill.Name</code>`.

![a screenshot of the tooltip](https://user-images.githubusercontent.com/178266/73599693-01e07e80-453e-11ea-91f5-215b812b50af.png)


closes #1944 
