### PR TITLE
update to latest polyfill-libarry

### DIFF
--- a/fastly/vcl/main.vcl
+++ b/fastly/vcl/main.vcl
@@ -111,7 +111,7 @@ sub normalise_querystring_parameters_for_polyfill_bundle {
 	if (req.url.qs !~ "(?i)[^&=]*version=([^&]+)") {
 		set var.querystring = var.querystring "&version=";
 	} else {
-		if (re.group.1 == "3.53.1" || re.group.1 == "3.52.3" || re.group.1 == "3.52.2" || re.group.1 == "3.52.1" || re.group.1 == "3.52.0" || re.group.1 == "3.51.0" || re.group.1 == "3.50.2" || re.group.1 == "3.49.0" || re.group.1 == "3.48.0" || re.group.1 == "3.46.0" || re.group.1 == "3.45.0" || re.group.1 == "3.44.0" || re.group.1 == "3.43.0" || re.group.1 == "3.42.0" || re.group.1 == "3.41.0" || re.group.1 == "3.40.0" || re.group.1 == "3.39.0" || re.group.1 == "3.38.0" || re.group.1 == "3.37.0" || re.group.1 == "3.36.0" || re.group.1 == "3.35.0" || re.group.1 == "3.34.0" || re.group.1 == "3.28.1" || re.group.1 == "3.27.4" || re.group.1 == "3.25.3" || re.group.1 == "3.25.2" || re.group.1 == "3.25.1") {
+		if (re.group.1 == "3.89.4" || re.group.1 == "3.53.1" || re.group.1 == "3.52.3" || re.group.1 == "3.52.2" || re.group.1 == "3.52.1" || re.group.1 == "3.52.0" || re.group.1 == "3.51.0" || re.group.1 == "3.50.2" || re.group.1 == "3.49.0" || re.group.1 == "3.48.0" || re.group.1 == "3.46.0" || re.group.1 == "3.45.0" || re.group.1 == "3.44.0" || re.group.1 == "3.43.0" || re.group.1 == "3.42.0" || re.group.1 == "3.41.0" || re.group.1 == "3.40.0" || re.group.1 == "3.39.0" || re.group.1 == "3.38.0" || re.group.1 == "3.37.0" || re.group.1 == "3.36.0" || re.group.1 == "3.35.0" || re.group.1 == "3.34.0" || re.group.1 == "3.28.1" || re.group.1 == "3.27.4" || re.group.1 == "3.25.3" || re.group.1 == "3.25.2" || re.group.1 == "3.25.1") {
 			set var.querystring = querystring.set(var.querystring, "version", re.group.1);
 		} else {
 			set var.querystring = var.querystring "&version=";

--- a/package-lock.json
+++ b/package-lock.json
@@ -11930,9 +11930,9 @@
       "dev": true
     },
     "polyfill-library": {
-      "version": "3.53.1",
-      "resolved": "https://registry.npmjs.org/polyfill-library/-/polyfill-library-3.53.1.tgz",
-      "integrity": "sha512-pcLZb3hlH4fnGbfr1z5JN+MpypMv4/NX2x3kfWxNTC9v6zKEX5wjAPYIzwCPJMM56z0nrdxqFYKcxxHqRkPO1Q==",
+      "version": "3.89.4",
+      "resolved": "https://registry.npmjs.org/polyfill-library/-/polyfill-library-3.89.4.tgz",
+      "integrity": "sha512-9ZJUVCY8R6x5lHjTCEgr6tMmI98NEQ+Ch1vZYwzJ42A2CrJpkiiaHwPe6RXv3ODLHainSegMqFRR14uuIfAWng==",
       "requires": {
         "@financial-times/polyfill-useragent-normaliser": "^1.7.0",
         "@formatjs/intl-pluralrules": "^1.1.2",
@@ -14142,6 +14142,67 @@
       "version": "npm:polyfill-library@3.53.1",
       "resolved": "https://registry.npmjs.org/polyfill-library/-/polyfill-library-3.53.1.tgz",
       "integrity": "sha512-pcLZb3hlH4fnGbfr1z5JN+MpypMv4/NX2x3kfWxNTC9v6zKEX5wjAPYIzwCPJMM56z0nrdxqFYKcxxHqRkPO1Q==",
+      "requires": {
+        "@financial-times/polyfill-useragent-normaliser": "^1.7.0",
+        "@formatjs/intl-pluralrules": "^1.1.2",
+        "@formatjs/intl-relativetimeformat": "^3.0.2",
+        "@webcomponents/template": "^1.4.0",
+        "Base64": "^1.0.0",
+        "abort-controller": "^3.0.0",
+        "audio-context-polyfill": "^1.0.0",
+        "current-script-polyfill": "^1.0.0",
+        "diff": "4.0.2",
+        "event-source-polyfill": "^1.0.12",
+        "from2-string": "^1.1.0",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.10",
+        "html5shiv": "^3.7.3",
+        "intl": "^1.2.5",
+        "js-polyfills": "^0.1.40",
+        "json3": "^3.3.2",
+        "merge2": "^1.0.3",
+        "mkdirp": "^0.5.0",
+        "mnemonist": "^0.32.0",
+        "mutationobserver-shim": "^0.3.2",
+        "picturefill": "^3.0.1",
+        "resize-observer-polyfill": "^1.5.1",
+        "rimraf": "^3.0.0",
+        "smoothscroll-polyfill": "^0.4.4",
+        "spdx-licenses": "^1.0.0",
+        "stream-cache": "^0.0.2",
+        "stream-from-promise": "^1.0.0",
+        "stream-to-string": "^1.1.0",
+        "toposort": "^2.0.2",
+        "uglify-js": "^2.7.5",
+        "unorm": "^1.6.0",
+        "usertiming": "^0.1.8",
+        "web-animations-js": "^2.2.5",
+        "whatwg-fetch": "^3.0.0",
+        "wicg-inert": "^3.0.0",
+        "yaku": "0.19.3"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        },
+        "uglify-js": {
+          "version": "2.8.29",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+          "requires": {
+            "source-map": "~0.5.1",
+            "uglify-to-browserify": "~1.0.0",
+            "yargs": "~3.10.0"
+          }
+        }
+      }
+    },
+    "polyfill-library-3.89.4": {
+      "version": "npm:polyfill-library@3.89.4",
+      "resolved": "https://registry.npmjs.org/polyfill-library/-/polyfill-library-3.89.4.tgz",
+      "integrity": "sha512-9ZJUVCY8R6x5lHjTCEgr6tMmI98NEQ+Ch1vZYwzJ42A2CrJpkiiaHwPe6RXv3ODLHainSegMqFRR14uuIfAWng==",
       "requires": {
         "@financial-times/polyfill-useragent-normaliser": "^1.7.0",
         "@formatjs/intl-pluralrules": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "dotenv": "^8.2.0",
     "express-extractheaders": "^3.0.0",
     "merge2": "^1.3.0",
-    "polyfill-library": "^3.53.1",
+    "polyfill-library": "^3.89.4",
     "polyfill-library-3.25.1": "npm:polyfill-library@3.25.1",
     "polyfill-library-3.25.3": "npm:polyfill-library@3.25.3-library-only",
     "polyfill-library-3.27.4": "npm:polyfill-library@3.27.4",
@@ -73,6 +73,7 @@
     "polyfill-library-3.52.2": "npm:polyfill-library@3.52.2",
     "polyfill-library-3.52.3": "npm:polyfill-library@3.52.3",
     "polyfill-library-3.53.1": "npm:polyfill-library@3.53.1",
+    "polyfill-library-3.89.4": "npm:polyfill-library@3.89.4",
     "require-all": "^3.0.0",
     "serve-static": "^1.14.1",
     "throng": "^4.0.0"

--- a/server/routes/v3/polyfill.js
+++ b/server/routes/v3/polyfill.js
@@ -33,6 +33,7 @@ const polyfillio_3_52_1 = require("polyfill-library-3.52.1");
 const polyfillio_3_52_2 = require("polyfill-library-3.52.2");
 const polyfillio_3_52_3 = require("polyfill-library-3.52.3");
 const polyfillio_3_53_1 = require("polyfill-library-3.53.1");
+const polyfillio_3_89_4 = require("polyfill-library-3.89.4");
 
 const lastModified = new Date().toUTCString();
 async function respondWithBundle(response, parameters, bundle, next) {
@@ -84,6 +85,20 @@ module.exports = app => {
 					}
 				}
 				const bundle = await polyfillio.getPolyfillString(parameters);
+				await respondWithBundle(response, parameters, bundle, next);
+				break;
+			}
+			case "3.89.4": {
+				if (parameters.strict) {
+					const features = [].concat(await polyfillio.listAliases(), await polyfillio.listAllPolyfills());
+					const requestedFeaturesAllExist = parameters.features.every(feature => features.includes(feature));
+					if (!requestedFeaturesAllExist) {
+						const requestedFeaturesWhichDoNotExist = parameters.features.filter(feature => !features.includes(feature));
+						await respondWithMissingFeatures(response, requestedFeaturesWhichDoNotExist);
+						break;
+					}
+				}
+				const bundle = await polyfillio_3_89_4.getPolyfillString(parameters);
 				await respondWithBundle(response, parameters, bundle, next);
 				break;
 			}


### PR DESCRIPTION
https://github.com/Financial-Times/polyfill-library/compare/v3.53.2...v3.89.4

 Don't serve Symbol and Symbol.iterator polyfills to Chrome 49 
 do not polyfill Symbol.toStringTag on chrome 49 
 dont serve symbol.iterator or symbol to firefox 36 or above 
 serve domtokenlist iterators to firefox up to 49 
 serve symbol.tostring to firefox up to 50 
Ensure callback for HTMLCanvasElement.prototype.toBlob is not invoked synchronously
 Add URLSearchParams sort method 
Add CSS.supports polyfill -- https://github.com/Financial-Times/polyfill-library/commit/01c03adb4b5359c863c19f4f895accb68bd722bd
Serve WeakMap to Firefox versions < 40
Serve WeakMap to Chrome < 44
Serve WeakSet to Firefox versions < 40
Serve WeakSet to Chrome versions < 44
Serve console.markTimeline to Firefox < 75
Serve Symbol.split to firefox < 45
Serve Symbol.unscopables to Firefox < 45
Serve Symbol/species/ to Firefox < 41
Serve Symbol/species/ to Chrome < 51
Serve Symbol/toPrimitive/ to Firefox < 44
Serve Symbol/toPrimitive/ to Firefox < 50
Serve Symbol/toPrimitive/ to Chrome < 49
Serve Symbol/replace/ to Edge < 18
Serve Symbol/unscopables/ to Chrome < 49
Serve Symbol/search/ to Firefox < 45
Serve console/clear/ to Firefox < 39
Serve console/timeline/ to Firefox < 75
Serve console/timeline/ to Chrome < 81
Serve console/timeline/ to Edge < 17
Serve console/timelineEnd/ to Edge < 17
Serve console/timeStamp/ to Edge < 16
Serve console/markTimeline/ to Chrome < 68
Serve console/markTimeline/ to Edge < 17
Serve console/time/ to Chrome < 31
Serve URL to Chrome < 60
Serve URL to Edge < 18
Serve screen/orientation/ to Chrome < 49
Serve matchMedia to Chrome < 37
