### PR TITLE
Move to Docker deployments for Heroku

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -15,7 +15,7 @@ module.exports = (eleventyConfig) => {
         includes: `../includes/`,
         output: "./.cache_eleventy"
     }
-    const files = glob.sync(path.join(process.cwd(), dirs.input, "**/*"), { ignore: ['**/node_modules/**'] });
+    const files = glob.sync(path.join(process.cwd(), dirs.input, "**/*"), { ignore: ['**/node_modules/**', '.github/**'] });
     const exts = files.map(file => path.extname(file).replace('.', ''));
 
     // Make all files pass through to output folder

--- a/.github/workflows/deploy-to-dev-and-test.yml
+++ b/.github/workflows/deploy-to-dev-and-test.yml
@@ -15,9 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: git fetch --prune --unshallow
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 12.x
       - name: 'Terraform Format'
         uses: hashicorp/terraform-github-actions@v0.8.0
         with:
@@ -29,6 +26,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Remove the staging and production terraform configuration overrides
         run: rm -f terraform.tfstate fastly/terraform/qa_override.tf fastly/terraform/production_override.tf fastly/terraform/domains_override.tf
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - run: npm ci
       - name: Login to Heroku Container registry
         env:
           HEROKU_API_KEY: ${{ secrets.HEROKU_AUTH_TOKEN }}

--- a/.github/workflows/deploy-to-dev-and-test.yml
+++ b/.github/workflows/deploy-to-dev-and-test.yml
@@ -33,10 +33,12 @@ jobs:
         env:
           HEROKU_API_KEY: ${{ secrets.HEROKU_AUTH_TOKEN }}
         run: heroku container:login
-      - name: Build and push
+      - name: Build Docker image
+        run: docker build . --tag registry.heroku.com/origami-polyfill-service-int/web
+      - name: Push Docker image to Heroku
         env:
           HEROKU_API_KEY: ${{ secrets.HEROKU_AUTH_TOKEN }}
-        run: heroku container:push -a origami-polyfill-service-int web
+        run: docker push registry.heroku.com/origami-polyfill-service-int/web
       - name: Release
         env:
           HEROKU_API_KEY: ${{ secrets.HEROKU_AUTH_TOKEN }}

--- a/.github/workflows/deploy-to-dev-and-test.yml
+++ b/.github/workflows/deploy-to-dev-and-test.yml
@@ -29,7 +29,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Remove the staging and production terraform configuration overrides
         run: rm -f terraform.tfstate fastly/terraform/qa_override.tf fastly/terraform/production_override.tf fastly/terraform/domains_override.tf
-      - name: Deploy to Heroku
       - name: Login to Heroku Container registry
         env:
           HEROKU_API_KEY: ${{ secrets.HEROKU_AUTH_TOKEN }}

--- a/.github/workflows/deploy-to-dev-and-test.yml
+++ b/.github/workflows/deploy-to-dev-and-test.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 12.x
-      - run: npm ci
       - name: 'Terraform Format'
         uses: hashicorp/terraform-github-actions@v0.8.0
         with:
@@ -31,7 +30,18 @@ jobs:
       - name: Remove the staging and production terraform configuration overrides
         run: rm -f terraform.tfstate fastly/terraform/qa_override.tf fastly/terraform/production_override.tf fastly/terraform/domains_override.tf
       - name: Deploy to Heroku
-        run: git push https://heroku:${{ secrets.HEROKU_AUTH_TOKEN }}@git.heroku.com/origami-polyfill-service-int.git HEAD:master --force
+      - name: Login to Heroku Container registry
+        env: 
+          HEROKU_API_KEY: ${{ secrets.HEROKU_AUTH_TOKEN }}
+        run: heroku container:login 
+      - name: Build and push
+        env:
+          HEROKU_API_KEY: ${{ secrets.HEROKU_AUTH_TOKEN }}
+        run: heroku container:push -a origami-polyfill-service-int web 
+      - name: Release
+        env:
+          HEROKU_API_KEY: ${{ secrets.HEROKU_AUTH_TOKEN }}
+        run: heroku container:release -a origami-polyfill-service-int web 
       - name: 'Terraform Init'
         uses: hashicorp/terraform-github-actions@v0.8.0
         with:

--- a/.github/workflows/deploy-to-dev-and-test.yml
+++ b/.github/workflows/deploy-to-dev-and-test.yml
@@ -27,17 +27,17 @@ jobs:
         run: rm -f terraform.tfstate fastly/terraform/qa_override.tf fastly/terraform/production_override.tf fastly/terraform/domains_override.tf
       - name: Deploy to Heroku
       - name: Login to Heroku Container registry
-        env: 
+        env:
           HEROKU_API_KEY: ${{ secrets.HEROKU_AUTH_TOKEN }}
-        run: heroku container:login 
+        run: heroku container:login
       - name: Build and push
         env:
           HEROKU_API_KEY: ${{ secrets.HEROKU_AUTH_TOKEN }}
-        run: heroku container:push -a origami-polyfill-service-int web 
+        run: heroku container:push -a origami-polyfill-service-int web
       - name: Release
         env:
           HEROKU_API_KEY: ${{ secrets.HEROKU_AUTH_TOKEN }}
-        run: heroku container:release -a origami-polyfill-service-int web 
+        run: heroku container:release -a origami-polyfill-service-int web
       - name: 'Terraform Init'
         uses: hashicorp/terraform-github-actions@v0.8.0
         with:
@@ -108,7 +108,7 @@ jobs:
     steps:
       - run: "curl -X POST -H \"Fastly-Key: ${{ secrets.FASTLY_API_KEY }}\" https://api.fastly.com/service/${{ env.fastly_service_id }}/purge_all"
       - run: sleep 60
-  
+
   end-to-end-test:
     needs: [purge-cdn]
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-to-dev-and-test.yml
+++ b/.github/workflows/deploy-to-dev-and-test.yml
@@ -1,5 +1,9 @@
 name: Deploy to dev and test
-on: [pull_request]
+on:
+  push:
+    branches:
+      - '**'
+      - '!master'
 env:
   terraform_version: 'latest'
   terraform_working_dir: 'fastly/terraform/'

--- a/.github/workflows/deploy-to-dev-and-test.yml
+++ b/.github/workflows/deploy-to-dev-and-test.yml
@@ -1,9 +1,5 @@
 name: Deploy to dev and test
-on:
-  push:
-    branches:
-      - '*'
-      - '!master'
+on: [pull_request]
 env:
   terraform_version: 'latest'
   terraform_working_dir: 'fastly/terraform/'

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -17,15 +17,23 @@ jobs:
       env:
         HEROKU_API_KEY: ${{ secrets.HEROKU_AUTH_TOKEN }}
       run: heroku container:login
-    - name: Build and push
+    - name: Build Docker image
+      run: docker build . --tag registry.heroku.com/origami-polyfill-service-eu/web --tag registry.heroku.com/origami-polyfill-service-us/web
+    - name: Push Docker image to Heroku eu
       env:
         HEROKU_API_KEY: ${{ secrets.HEROKU_AUTH_TOKEN }}
-      run: heroku container:push -a origami-polyfill-service-eu web
-      run: heroku container:push -a origami-polyfill-service-us web
-    - name: Release
+      run: docker push registry.heroku.com/origami-polyfill-service-eu/web
+    - name: Push Docker image to Heroku us
+      env:
+        HEROKU_API_KEY: ${{ secrets.HEROKU_AUTH_TOKEN }}
+      run: docker push registry.heroku.com/origami-polyfill-service-us/web
+    - name: Release eu
       env:
         HEROKU_API_KEY: ${{ secrets.HEROKU_AUTH_TOKEN }}
       run: heroku container:release -a origami-polyfill-service-eu web
+    - name: Release us
+      env:
+        HEROKU_API_KEY: ${{ secrets.HEROKU_AUTH_TOKEN }}
       run: heroku container:release -a origami-polyfill-service-us web
     - name: Remove the development and staging terraform configuration overrides
       run: rm -f terraform.tfstate fastly/terraform/dev_override.tf fastly/terraform/qa_override.tf fastly/terraform/domains_override.tf

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -13,6 +13,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - run: git fetch --prune --unshallow
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    - run: npm ci
     - name: Login to Heroku Container registry
       env:
         HEROKU_API_KEY: ${{ secrets.HEROKU_AUTH_TOKEN }}

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -13,12 +13,20 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - run: git fetch --prune --unshallow
-    - uses: actions/setup-node@v1
-      with:
-        node-version: 12.x
-    - run: npm ci
-    - run: git push https://heroku:${{ secrets.HEROKU_AUTH_TOKEN }}@git.heroku.com/origami-polyfill-service-eu.git HEAD:refs/heads/master --force
-    - run: git push https://heroku:${{ secrets.HEROKU_AUTH_TOKEN }}@git.heroku.com/origami-polyfill-service-us.git HEAD:refs/heads/master --force
+    - name: Login to Heroku Container registry
+      env:
+        HEROKU_API_KEY: ${{ secrets.HEROKU_AUTH_TOKEN }}
+      run: heroku container:login
+    - name: Build and push
+      env:
+        HEROKU_API_KEY: ${{ secrets.HEROKU_AUTH_TOKEN }}
+      run: heroku container:push -a origami-polyfill-service-eu web
+      run: heroku container:push -a origami-polyfill-service-us web
+    - name: Release
+      env:
+        HEROKU_API_KEY: ${{ secrets.HEROKU_AUTH_TOKEN }}
+      run: heroku container:release -a origami-polyfill-service-eu web
+      run: heroku container:release -a origami-polyfill-service-us web
     - name: Remove the development and staging terraform configuration overrides
       run: rm -f terraform.tfstate fastly/terraform/dev_override.tf fastly/terraform/qa_override.tf fastly/terraform/domains_override.tf
     - name: 'Terraform Init'

--- a/.github/workflows/deploy-to-staging-and-test.yml
+++ b/.github/workflows/deploy-to-staging-and-test.yml
@@ -14,6 +14,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - run: git fetch --prune --unshallow
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    - run: npm ci
     - name: Login to Heroku Container registry
       env:
         HEROKU_API_KEY: ${{ secrets.HEROKU_AUTH_TOKEN }}

--- a/.github/workflows/deploy-to-staging-and-test.yml
+++ b/.github/workflows/deploy-to-staging-and-test.yml
@@ -18,15 +18,23 @@ jobs:
       env:
         HEROKU_API_KEY: ${{ secrets.HEROKU_AUTH_TOKEN }}
       run: heroku container:login
-    - name: Build and push
+    - name: Build Docker image
+      run: docker build . --tag registry.heroku.com/origami-polyfill-service-qa-eu/web --tag registry.heroku.com/origami-polyfill-service-qa-us/web
+    - name: Push Docker image to Heroku eu
       env:
         HEROKU_API_KEY: ${{ secrets.HEROKU_AUTH_TOKEN }}
-      run: heroku container:push -a origami-polyfill-service-qa-eu web
-      run: heroku container:push -a origami-polyfill-service-qa-us web
-    - name: Release
+      run: docker push registry.heroku.com/origami-polyfill-service-qa-eu/web
+    - name: Push Docker image to Heroku us
+      env:
+        HEROKU_API_KEY: ${{ secrets.HEROKU_AUTH_TOKEN }}
+      run: docker push registry.heroku.com/origami-polyfill-service-qa-us/web
+    - name: Release eu
       env:
         HEROKU_API_KEY: ${{ secrets.HEROKU_AUTH_TOKEN }}
       run: heroku container:release -a origami-polyfill-service-qa-eu web
+    - name: Release us
+      env:
+        HEROKU_API_KEY: ${{ secrets.HEROKU_AUTH_TOKEN }}
       run: heroku container:release -a origami-polyfill-service-qa-us web
     - name: Remove the development and production terraform configuration overrides
       run: rm -f terraform.tfstate fastly/terraform/dev_override.tf fastly/terraform/production_override.tf fastly/terraform/domains_override.tf

--- a/.github/workflows/deploy-to-staging-and-test.yml
+++ b/.github/workflows/deploy-to-staging-and-test.yml
@@ -14,12 +14,20 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - run: git fetch --prune --unshallow
-    - uses: actions/setup-node@v1
-      with:
-        node-version: 12.x
-    - run: npm ci
-    - run: git push https://heroku:${{ secrets.HEROKU_AUTH_TOKEN }}@git.heroku.com/origami-polyfill-service-qa-eu.git HEAD:master --force
-    - run: git push https://heroku:${{ secrets.HEROKU_AUTH_TOKEN }}@git.heroku.com/origami-polyfill-service-qa-us.git HEAD:master --force
+    - name: Login to Heroku Container registry
+      env:
+        HEROKU_API_KEY: ${{ secrets.HEROKU_AUTH_TOKEN }}
+      run: heroku container:login
+    - name: Build and push
+      env:
+        HEROKU_API_KEY: ${{ secrets.HEROKU_AUTH_TOKEN }}
+      run: heroku container:push -a origami-polyfill-service-qa-eu web
+      run: heroku container:push -a origami-polyfill-service-qa-us web
+    - name: Release
+      env:
+        HEROKU_API_KEY: ${{ secrets.HEROKU_AUTH_TOKEN }}
+      run: heroku container:release -a origami-polyfill-service-qa-eu web
+      run: heroku container:release -a origami-polyfill-service-qa-us web
     - name: Remove the development and production terraform configuration overrides
       run: rm -f terraform.tfstate fastly/terraform/dev_override.tf fastly/terraform/production_override.tf fastly/terraform/domains_override.tf
     - name: 'Terraform Init'
@@ -105,7 +113,7 @@ jobs:
     steps:
       - run: "curl -X POST -H \"Fastly-Key: ${{ secrets.FASTLY_API_KEY_STAGING }}\" https://api.fastly.com/service/${{ env.fastly_service_id }}/purge_all"
       - run: sleep 60
-  
+
   end-to-end-test:
     needs: [purge-cdn]
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apk add --update --no-cache python make g++ rust cargo
 USER node
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 ENV PATH=$PATH:/home/node/.npm-global/bin:/home/node/.cargo/bin
-RUN cargo install dupe-krill
+# RUN cargo install dupe-krill
 # copy by default will make the root user own the files, we want the node user to own the files
 COPY --chown=node:node package*.json .snyk /home/node/app/
 WORKDIR /home/node/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,19 @@
 FROM node:12-alpine AS build
+# packages needed for node-gyp and dupe-krill
 RUN apk add --update --no-cache python make g++ rust cargo
+# use a non-root user to make commands such as npm post-install scripts safer
 USER node
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 ENV PATH=$PATH:/home/node/.npm-global/bin:/home/node/.cargo/bin
 RUN cargo install dupe-krill
+# copy by default will make the root user own the files, we want the node user to own the files
 COPY --chown=node:node package*.json pnpm-lock.yaml .snyk /home/node/app/
 WORKDIR /home/node/app
 RUN npm install
 COPY --chown=node:node . /home/node/app/
-RUN ls -la
 RUN npm run build
 RUN npm prune --prod
+# hardlink duplicate files to save space (saves 50% for polyfill-service)
 RUN dupe-krill .
 
 FROM node:12-alpine

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY --chown=node:node . /home/node/app/
 RUN npm run build
 RUN npm prune --prod
 # hardlink duplicate files to save space (saves 50% for polyfill-service)
-RUN dupe-krill .
+# RUN dupe-krill .
 
 FROM node:12-alpine
 COPY --chown=node:node --from=build /home/node/app /home/node/app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:12-alpine AS build
+RUN apk add --update --no-cache python make g++ rust cargo
+USER node
+ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
+ENV PATH=$PATH:/home/node/.npm-global/bin:/home/node/.cargo/bin
+RUN cargo install dupe-krill
+COPY --chown=node:node package*.json pnpm-lock.yaml .snyk /home/node/app/
+WORKDIR /home/node/app
+RUN npm install
+COPY --chown=node:node . /home/node/app/
+RUN ls -la
+RUN npm run build
+RUN npm prune --prod
+RUN dupe-krill .
+
+FROM node:12-alpine
+COPY --chown=node:node --from=build /home/node/app /home/node/app/
+USER node
+EXPOSE 8080
+ENV NODE_ENV=production
+CMD ["node", "/home/node/app/server/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 ENV PATH=$PATH:/home/node/.npm-global/bin:/home/node/.cargo/bin
 RUN cargo install dupe-krill
 # copy by default will make the root user own the files, we want the node user to own the files
-COPY --chown=node:node package*.json pnpm-lock.yaml .snyk /home/node/app/
+COPY --chown=node:node package*.json .snyk /home/node/app/
 WORKDIR /home/node/app
 RUN npm install
 COPY --chown=node:node . /home/node/app/

--- a/test/.dockerignore
+++ b/test/.dockerignore
@@ -1,0 +1,1 @@
+node_modules


### PR DESCRIPTION
Our Heroku deployments takes 15-20 minutes to happen for each application. Because of our multi-region setup making deployments sequentially (and each deployment builds the artefact again), our deploy times take twice as long, 30-40 minutes.

If we move to deploying a prebuilt artefact, the deploys should happen in a few minutes each, whilst the building of the artefact will be several minutes but only need to happen once.

We could also look at distributing a polyfill-service docker image to the DockerHub public registry to allow self-hosting to happen via Docker for those users which use Docker :-)