### PR TITLE
update polyfill-library to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -868,6 +868,46 @@
         "@formatjs/intl-utils": "^3.8.1"
       }
     },
+    "@formatjs/intl-locale": {
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-locale/-/intl-locale-2.4.8.tgz",
+      "integrity": "sha512-AH41FTHJ+jPx/QYZQxfTy8Yfs480nidsPb7/VMFY7JRIjDG/PXFJBHqFUXV/rKwduTETc05+s9jFBieeNDTIrA==",
+      "requires": {
+        "@formatjs/ecma402-abstract": "1.5.0",
+        "@formatjs/intl-getcanonicallocales": "1.5.2",
+        "cldr-core": "^37.0.0",
+        "tslib": "^2.0.1"
+      },
+      "dependencies": {
+        "@formatjs/ecma402-abstract": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.5.0.tgz",
+          "integrity": "sha512-wXv36yo+mfWllweN0Fq7sUs7PUiNopn7I0JpLTe3hGu6ZMR4CV7LqK1llhB18pndwpKoafQKb1et2DCJAOW20Q==",
+          "requires": {
+            "tslib": "^2.0.1"
+          }
+        },
+        "@formatjs/intl-getcanonicallocales": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/@formatjs/intl-getcanonicallocales/-/intl-getcanonicallocales-1.5.2.tgz",
+          "integrity": "sha512-oOtLAHSocSaJUtqEXnt2gYvZyxfjBkM2r7JKkoij2K91v02zE1Wc//Wvs3eq08xiMxhC5OlkCflbngZirmBm/w==",
+          "requires": {
+            "cldr-core": "37.0.0",
+            "tslib": "^2.0.1"
+          }
+        },
+        "cldr-core": {
+          "version": "37.0.0",
+          "resolved": "https://registry.npmjs.org/cldr-core/-/cldr-core-37.0.0.tgz",
+          "integrity": "sha512-tNH5lbfsE9xzsjjXQjq1tlpMFcmnQYfssDy0zYIZKVtAY18MeQy0+1qlLxB2Z9dwCixGJV8cdhtFjBOub077Gw=="
+        },
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+        }
+      }
+    },
     "@formatjs/intl-numberformat": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/@formatjs/intl-numberformat/-/intl-numberformat-5.6.2.tgz",
@@ -9157,18 +9197,19 @@
       "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow=="
     },
     "polyfill-library": {
-      "version": "3.96.0",
-      "resolved": "https://registry.npmjs.org/polyfill-library/-/polyfill-library-3.96.0.tgz",
-      "integrity": "sha512-A60l+fyKZb4uVRZfx24HGCVyaMz0Xy9CuFRFymAviDC/ugEwo+QtgpZVpHEGxbK3F3UU88KcfL/TeiSQhPFIkw==",
+      "version": "3.98.0",
+      "resolved": "https://registry.npmjs.org/polyfill-library/-/polyfill-library-3.98.0.tgz",
+      "integrity": "sha512-Bh5EzIH8OP7uMwupsgDv+GA2/+7efr3jPE+HTfE6vDVZNnJwXwpire+LhGMxq3D59Vbo2m7faKAAQxbF6bzbZg==",
       "requires": {
         "@financial-times/polyfill-useragent-normaliser": "^1.7.0",
-        "@formatjs/intl-datetimeformat": "^2.0.2",
-        "@formatjs/intl-displaynames": "^3.0.2",
-        "@formatjs/intl-getcanonicallocales": "^1.2.10",
-        "@formatjs/intl-listformat": "^3.0.2",
-        "@formatjs/intl-numberformat": "^5.0.2",
-        "@formatjs/intl-pluralrules": "^3.0.2",
-        "@formatjs/intl-relativetimeformat": "^6.0.2",
+        "@formatjs/intl-datetimeformat": "3.1.0",
+        "@formatjs/intl-displaynames": "4.0.1",
+        "@formatjs/intl-getcanonicallocales": "1.5.2",
+        "@formatjs/intl-listformat": "5.0.1",
+        "@formatjs/intl-locale": "2.4.8",
+        "@formatjs/intl-numberformat": "6.0.0",
+        "@formatjs/intl-pluralrules": "4.0.0",
+        "@formatjs/intl-relativetimeformat": "8.0.0",
         "@juggle/resize-observer": "^3.2.0",
         "@webcomponents/template": "^1.4.0",
         "Base64": "^1.0.0",
@@ -9190,7 +9231,7 @@
         "mutationobserver-shim": "^0.3.2",
         "picturefill": "^3.0.1",
         "rimraf": "^3.0.0",
-        "seamless-scroll-polyfill": "^1.0.10",
+        "seamless-scroll-polyfill": "1.2.3",
         "spdx-licenses": "^1.0.0",
         "stream-cache": "^0.0.2",
         "stream-from-promise": "^1.0.0",
@@ -9205,10 +9246,86 @@
         "yaku": "1.0.1"
       },
       "dependencies": {
+        "@formatjs/ecma402-abstract": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.5.0.tgz",
+          "integrity": "sha512-wXv36yo+mfWllweN0Fq7sUs7PUiNopn7I0JpLTe3hGu6ZMR4CV7LqK1llhB18pndwpKoafQKb1et2DCJAOW20Q==",
+          "requires": {
+            "tslib": "^2.0.1"
+          }
+        },
+        "@formatjs/intl-datetimeformat": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@formatjs/intl-datetimeformat/-/intl-datetimeformat-3.1.0.tgz",
+          "integrity": "sha512-XKyDQ3xFgZK2w8GE2v+zE0nk/JqGKFE0UxTI716mp/+OVuws+dbQPiORfSrJceH7E3ZkfGrvO0BB8sksQNsZ+w==",
+          "requires": {
+            "@formatjs/ecma402-abstract": "1.5.0",
+            "tslib": "^2.0.1"
+          }
+        },
+        "@formatjs/intl-displaynames": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/@formatjs/intl-displaynames/-/intl-displaynames-4.0.1.tgz",
+          "integrity": "sha512-vhG9y+F0BudHU9ev0O9Tc5Uwz/MAcCzbBzceSnjcoUMyLLfFN6GSPBvU6+ocxWsfjhu/yL5ja+doZdhwDcSXrA==",
+          "requires": {
+            "@formatjs/ecma402-abstract": "1.5.0",
+            "tslib": "^2.0.1"
+          }
+        },
+        "@formatjs/intl-getcanonicallocales": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/@formatjs/intl-getcanonicallocales/-/intl-getcanonicallocales-1.5.2.tgz",
+          "integrity": "sha512-oOtLAHSocSaJUtqEXnt2gYvZyxfjBkM2r7JKkoij2K91v02zE1Wc//Wvs3eq08xiMxhC5OlkCflbngZirmBm/w==",
+          "requires": {
+            "cldr-core": "37.0.0",
+            "tslib": "^2.0.1"
+          }
+        },
+        "@formatjs/intl-listformat": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@formatjs/intl-listformat/-/intl-listformat-5.0.1.tgz",
+          "integrity": "sha512-x1gqI3xvTn8uTY0W+bL4ySW/5HFeQXkNNfsdoaRtX2b/HNa4fZoU1EaA6koAk9gUAWSR5Ofe1Ps49CXaMvwcTg==",
+          "requires": {
+            "@formatjs/ecma402-abstract": "1.5.0",
+            "tslib": "^2.0.1"
+          }
+        },
+        "@formatjs/intl-numberformat": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/@formatjs/intl-numberformat/-/intl-numberformat-6.0.0.tgz",
+          "integrity": "sha512-5GTxfMQlYdD+6aB6V4OWB9RMnu5VJ68zaMGQGSIibCBsxrEMGrQqvxqQwUaZNVkuww+HBxBPEY+CtlwW+VSdyQ==",
+          "requires": {
+            "@formatjs/ecma402-abstract": "1.5.0",
+            "tslib": "^2.0.1"
+          }
+        },
+        "@formatjs/intl-pluralrules": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@formatjs/intl-pluralrules/-/intl-pluralrules-4.0.0.tgz",
+          "integrity": "sha512-HWi7zEpSM46zgizvxwojDJTrh/tqxmldCHXkhR3bsbZwAlm2W8yCFLkPSMikNJp/WFvgnEjOjvGctU1A5TqStg==",
+          "requires": {
+            "@formatjs/ecma402-abstract": "1.5.0",
+            "tslib": "^2.0.1"
+          }
+        },
+        "@formatjs/intl-relativetimeformat": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-8.0.0.tgz",
+          "integrity": "sha512-GKJvd2+Sx0BJqsKt2rBbkgGAwfBjKVnvlRTZQ+OhgSEOeRBHOtaub1jUx8ScQoS5Xe0RFLvTLL2LSnajg6EXkw==",
+          "requires": {
+            "@formatjs/ecma402-abstract": "1.5.0",
+            "tslib": "^2.0.1"
+          }
+        },
         "camelcase": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
           "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
+        },
+        "cldr-core": {
+          "version": "37.0.0",
+          "resolved": "https://registry.npmjs.org/cldr-core/-/cldr-core-37.0.0.tgz",
+          "integrity": "sha512-tNH5lbfsE9xzsjjXQjq1tlpMFcmnQYfssDy0zYIZKVtAY18MeQy0+1qlLxB2Z9dwCixGJV8cdhtFjBOub077Gw=="
         },
         "cliui": {
           "version": "2.1.0",
@@ -9221,17 +9338,27 @@
           }
         },
         "mnemonist": {
-          "version": "0.38.0",
-          "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.0.tgz",
-          "integrity": "sha512-OrqILDYOEGVFooAbGid3/P9jdjWuZONlGHVyjfZnvg65+ZQ/QM5dOms+yADY/WURd1NFhCqjf/VJGFlnJToLJQ==",
+          "version": "0.38.1",
+          "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.1.tgz",
+          "integrity": "sha512-I674bCCj9p87Re+gv15ynDrP14XjcmLR7tBO22l3UoxQLniyIXdD9vid2sSxYkyOr0fZwJTA+dXRvrwANgdnyg==",
           "requires": {
             "obliterator": "^1.6.1"
           }
+        },
+        "seamless-scroll-polyfill": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/seamless-scroll-polyfill/-/seamless-scroll-polyfill-1.2.3.tgz",
+          "integrity": "sha512-emnwZtu6NrlBlvT6HrlbAOs024JX4orWew8H5owBOyUJ7eFXn8lGe4bsXTBD6AAWzP/p7LL86AjVIH8Apqec5w=="
         },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        },
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
         },
         "uglify-js": {
           "version": "2.8.29",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "dotenv": "^8.2.0",
     "express-extractheaders": "^3.0.0",
     "merge2": "^1.4.1",
-    "polyfill-library": "^3.96.0",
+    "polyfill-library": "^3.98.0",
     "polyfill-library-3.25.1": "npm:polyfill-library@3.25.1",
     "polyfill-library-3.25.3": "npm:polyfill-library@3.25.3-library-only",
     "polyfill-library-3.27.4": "npm:polyfill-library@3.27.4",


### PR DESCRIPTION
This update inlcudes:
- Intl polyfill updated
- Smooth scroll polyfill updated
- Added String.prototype.replaceAll
- Added DOMTokenList.prototype.replace
- Serve DOMRect polyfill to Edge versions < 79