### PR TITLE
build(deps): npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -832,32 +832,66 @@
       "integrity": "sha512-g6MJ5tVszip1wAOq41yk8Z0WJqjfpu3hKaos/IaechYC4RqIn8bTanNR/EGD6oeOdJ9/fTPbQQX5/3ZQwSTXtQ=="
     },
     "@formatjs/ecma402-abstract": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.2.2.tgz",
-      "integrity": "sha512-mLCoAPGlXCVskb/ojBO6iurGqwo6sZvAl8pRC4N25bz4LPWExAM9LsOo057zN3Br1JxUM3RZHG4YGnVt+nSRYQ=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.4.0.tgz",
+      "integrity": "sha512-Mv027hcLFjE45K8UJ8PjRpdDGfR0aManEFj1KzoN8zXNveHGEygpZGfFf/FTTMl+QEVSrPAUlyxaCApvmv47AQ==",
+      "requires": {
+        "tslib": "^2.0.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+        }
+      }
     },
     "@formatjs/intl-datetimeformat": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-datetimeformat/-/intl-datetimeformat-2.6.7.tgz",
-      "integrity": "sha512-LVp6swM9LyLv2N0jMvA4y2bxK9Z7GxO8E+2OnzgUxrG3o9uSLMzJ+06+6e8yNyOaRvcqxBBasJ70mZ1FuLBBmg==",
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-datetimeformat/-/intl-datetimeformat-2.8.4.tgz",
+      "integrity": "sha512-aCD6VoUvdLiJrAfKfHojbzX/e5inqvO+N9rj9kdOzCMTEdDGJ+Jd9SmXPn2YKb1glp785mYxAPp5vxjgErjq/g==",
       "requires": {
-        "@formatjs/ecma402-abstract": "^1.2.2"
+        "@formatjs/ecma402-abstract": "1.4.0",
+        "tslib": "^2.0.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+        }
       }
     },
     "@formatjs/intl-displaynames": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-displaynames/-/intl-displaynames-3.3.8.tgz",
-      "integrity": "sha512-HLoiQFCkwjq1ix7xmLC9DAp0sSXBmD2JuzfHiGKrWU8RIbNcHVzbIL4NgkuXkxvnkADXsK67OtfpuQs8kMZ0qw==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-displaynames/-/intl-displaynames-3.4.6.tgz",
+      "integrity": "sha512-XWVhTQjcyWweHm2Hi0n92hYILpktbnh8x5Sj5nSBIUNz4Os4uHDj2itJI3xCxl+aDNW8M7VRJ9m0OsnhI8qQrg==",
       "requires": {
-        "@formatjs/ecma402-abstract": "^1.2.2"
+        "@formatjs/ecma402-abstract": "1.4.0",
+        "tslib": "^2.0.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+        }
       }
     },
     "@formatjs/intl-getcanonicallocales": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-getcanonicallocales/-/intl-getcanonicallocales-1.4.5.tgz",
-      "integrity": "sha512-A+EmeFLR4X09viOhrFjVcWV4V2gjcJ6Yi1d38jTG/mWvhMFDQ7cQeR05H0sf82PmpAJUX9dyhNWOcDM/NUZs7A==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-getcanonicallocales/-/intl-getcanonicallocales-1.5.2.tgz",
+      "integrity": "sha512-oOtLAHSocSaJUtqEXnt2gYvZyxfjBkM2r7JKkoij2K91v02zE1Wc//Wvs3eq08xiMxhC5OlkCflbngZirmBm/w==",
       "requires": {
-        "cldr-core": "36.0.0"
+        "cldr-core": "37.0.0",
+        "tslib": "^2.0.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+        }
       }
     },
     "@formatjs/intl-listformat": {
@@ -866,6 +900,16 @@
       "integrity": "sha512-Y3xkbQVx60zNIKf3MOwIUr+TIdCWWB+xv+v9xNTXBOlhg108Lg3TtPDfSkyz1+CfTR0L7x9zX5tYYaRsRinHBQ==",
       "requires": {
         "@formatjs/intl-utils": "^3.8.1"
+      },
+      "dependencies": {
+        "@formatjs/intl-utils": {
+          "version": "3.8.4",
+          "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-3.8.4.tgz",
+          "integrity": "sha512-j5C6NyfKevIxsfLK8KwO1C0vvP7k1+h4A9cFpc+cr6mEwCc1sPkr17dzh0Ke6k9U5pQccAQoXdcNBl3IYa4+ZQ==",
+          "requires": {
+            "emojis-list": "^3.0.0"
+          }
+        }
       }
     },
     "@formatjs/intl-locale": {
@@ -909,36 +953,48 @@
       }
     },
     "@formatjs/intl-numberformat": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-numberformat/-/intl-numberformat-5.6.2.tgz",
-      "integrity": "sha512-+0dXoe8D/7Ci+8/NI4VF0JxDz4GaK5bCNYMEBOYFM+VFAGGWrwyOuEycR+b1so3MNqePou4cb7lLVr+vQfAOcg==",
+      "version": "5.7.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-numberformat/-/intl-numberformat-5.7.6.tgz",
+      "integrity": "sha512-ZlZfYtvbVHYZY5OG3RXizoCwxKxEKOrzEe2YOw9wbzoxF3PmFn0SAgojCFGLyNXkkR6xVxlylhbuOPf1dkIVNg==",
       "requires": {
-        "@formatjs/ecma402-abstract": "^1.2.2"
+        "@formatjs/ecma402-abstract": "1.4.0",
+        "tslib": "^2.0.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+        }
       }
     },
     "@formatjs/intl-pluralrules": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-pluralrules/-/intl-pluralrules-3.4.7.tgz",
-      "integrity": "sha512-CSftdNs8afT1VfB5vQFlSzhEZ+ckbkxzYxNXCeLYt66mXnuCukr7KCsZJHUTMyjlEAnFbfqXnKCtWDs5JMBrog==",
+      "version": "1.5.9",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-pluralrules/-/intl-pluralrules-1.5.9.tgz",
+      "integrity": "sha512-37E1ZG+Oqo3qrpUfumzNcFTV+V+NCExmTkkQ9Zw4FSlvJ4WhbbeYdieVapUVz9M0cLy8XrhCkfuM/Kn03iKReg==",
       "requires": {
-        "@formatjs/ecma402-abstract": "^1.2.2"
+        "@formatjs/intl-utils": "^2.3.0"
       }
     },
     "@formatjs/intl-relativetimeformat": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-6.2.4.tgz",
-      "integrity": "sha512-bhxHRPL6xQIF7XOD1HDYfC3Ip45Ccf2G4viMLyIXDaHPeVgRHM5jZ23FXdg01MQEZ/thb20hoeX56m76+IjI0Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-3.1.0.tgz",
+      "integrity": "sha512-xSW9RMJtZZTGAlT7qCom+0INLYgshowpBN0Xf+j4kME+U/g/ogTVRFeGvCZX3nDQ21vdTHAabR3AIGQRX7NU1g==",
       "requires": {
-        "@formatjs/intl-utils": "^3.8.1"
+        "@formatjs/intl-utils": "^1.1.0"
+      },
+      "dependencies": {
+        "@formatjs/intl-utils": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-1.6.0.tgz",
+          "integrity": "sha512-5D0C4tQgNFJNaJ17BYum0GfAcKNK3oa1VWzgkv/AN7i52fg4r69ZLcpEGpf6tZiX9Qld8CDwTQOeFt6fuOqgVw=="
+        }
       }
     },
     "@formatjs/intl-utils": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-3.8.4.tgz",
-      "integrity": "sha512-j5C6NyfKevIxsfLK8KwO1C0vvP7k1+h4A9cFpc+cr6mEwCc1sPkr17dzh0Ke6k9U5pQccAQoXdcNBl3IYa4+ZQ==",
-      "requires": {
-        "emojis-list": "^3.0.0"
-      }
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-2.3.0.tgz",
+      "integrity": "sha512-KWk80UPIzPmUg+P0rKh6TqspRw0G6eux1PuJr+zz47ftMaZ9QDwbGzHZbtzWkl5hgayM/qrKRutllRC7D/vVXQ=="
     },
     "@iarna/toml": {
       "version": "2.2.5",
@@ -3493,9 +3549,9 @@
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
     },
     "cldr-core": {
-      "version": "36.0.0",
-      "resolved": "https://registry.npmjs.org/cldr-core/-/cldr-core-36.0.0.tgz",
-      "integrity": "sha512-QLnAjt20rZe38c8h8OJ9jPND+O4o5O8Nw0TK/P3KpNn1cmOhMu0rk6Kc3ap96c5OStQ9gAngs9+Be2sum26NOw=="
+      "version": "37.0.0",
+      "resolved": "https://registry.npmjs.org/cldr-core/-/cldr-core-37.0.0.tgz",
+      "integrity": "sha512-tNH5lbfsE9xzsjjXQjq1tlpMFcmnQYfssDy0zYIZKVtAY18MeQy0+1qlLxB2Z9dwCixGJV8cdhtFjBOub077Gw=="
     },
     "clean-css": {
       "version": "4.2.3",
@@ -6227,9 +6283,9 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.7.tgz",
+      "integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ=="
     },
     "intersection-observer": {
       "version": "0.4.1",
@@ -11774,34 +11830,6 @@
         "yaku": "0.19.3"
       },
       "dependencies": {
-        "@formatjs/intl-pluralrules": {
-          "version": "1.5.9",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-pluralrules/-/intl-pluralrules-1.5.9.tgz",
-          "integrity": "sha512-37E1ZG+Oqo3qrpUfumzNcFTV+V+NCExmTkkQ9Zw4FSlvJ4WhbbeYdieVapUVz9M0cLy8XrhCkfuM/Kn03iKReg==",
-          "requires": {
-            "@formatjs/intl-utils": "^2.3.0"
-          }
-        },
-        "@formatjs/intl-relativetimeformat": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-3.1.0.tgz",
-          "integrity": "sha512-xSW9RMJtZZTGAlT7qCom+0INLYgshowpBN0Xf+j4kME+U/g/ogTVRFeGvCZX3nDQ21vdTHAabR3AIGQRX7NU1g==",
-          "requires": {
-            "@formatjs/intl-utils": "^1.1.0"
-          },
-          "dependencies": {
-            "@formatjs/intl-utils": {
-              "version": "1.6.0",
-              "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-1.6.0.tgz",
-              "integrity": "sha512-5D0C4tQgNFJNaJ17BYum0GfAcKNK3oa1VWzgkv/AN7i52fg4r69ZLcpEGpf6tZiX9Qld8CDwTQOeFt6fuOqgVw=="
-            }
-          }
-        },
-        "@formatjs/intl-utils": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-2.3.0.tgz",
-          "integrity": "sha512-KWk80UPIzPmUg+P0rKh6TqspRw0G6eux1PuJr+zz47ftMaZ9QDwbGzHZbtzWkl5hgayM/qrKRutllRC7D/vVXQ=="
-        },
         "camelcase": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
@@ -11920,34 +11948,6 @@
         "yaku": "0.19.3"
       },
       "dependencies": {
-        "@formatjs/intl-pluralrules": {
-          "version": "1.5.9",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-pluralrules/-/intl-pluralrules-1.5.9.tgz",
-          "integrity": "sha512-37E1ZG+Oqo3qrpUfumzNcFTV+V+NCExmTkkQ9Zw4FSlvJ4WhbbeYdieVapUVz9M0cLy8XrhCkfuM/Kn03iKReg==",
-          "requires": {
-            "@formatjs/intl-utils": "^2.3.0"
-          }
-        },
-        "@formatjs/intl-relativetimeformat": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-3.1.0.tgz",
-          "integrity": "sha512-xSW9RMJtZZTGAlT7qCom+0INLYgshowpBN0Xf+j4kME+U/g/ogTVRFeGvCZX3nDQ21vdTHAabR3AIGQRX7NU1g==",
-          "requires": {
-            "@formatjs/intl-utils": "^1.1.0"
-          },
-          "dependencies": {
-            "@formatjs/intl-utils": {
-              "version": "1.6.0",
-              "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-1.6.0.tgz",
-              "integrity": "sha512-5D0C4tQgNFJNaJ17BYum0GfAcKNK3oa1VWzgkv/AN7i52fg4r69ZLcpEGpf6tZiX9Qld8CDwTQOeFt6fuOqgVw=="
-            }
-          }
-        },
-        "@formatjs/intl-utils": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-2.3.0.tgz",
-          "integrity": "sha512-KWk80UPIzPmUg+P0rKh6TqspRw0G6eux1PuJr+zz47ftMaZ9QDwbGzHZbtzWkl5hgayM/qrKRutllRC7D/vVXQ=="
-        },
         "camelcase": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
@@ -12066,34 +12066,6 @@
         "yaku": "0.19.3"
       },
       "dependencies": {
-        "@formatjs/intl-pluralrules": {
-          "version": "1.5.9",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-pluralrules/-/intl-pluralrules-1.5.9.tgz",
-          "integrity": "sha512-37E1ZG+Oqo3qrpUfumzNcFTV+V+NCExmTkkQ9Zw4FSlvJ4WhbbeYdieVapUVz9M0cLy8XrhCkfuM/Kn03iKReg==",
-          "requires": {
-            "@formatjs/intl-utils": "^2.3.0"
-          }
-        },
-        "@formatjs/intl-relativetimeformat": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-3.1.0.tgz",
-          "integrity": "sha512-xSW9RMJtZZTGAlT7qCom+0INLYgshowpBN0Xf+j4kME+U/g/ogTVRFeGvCZX3nDQ21vdTHAabR3AIGQRX7NU1g==",
-          "requires": {
-            "@formatjs/intl-utils": "^1.1.0"
-          },
-          "dependencies": {
-            "@formatjs/intl-utils": {
-              "version": "1.6.0",
-              "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-1.6.0.tgz",
-              "integrity": "sha512-5D0C4tQgNFJNaJ17BYum0GfAcKNK3oa1VWzgkv/AN7i52fg4r69ZLcpEGpf6tZiX9Qld8CDwTQOeFt6fuOqgVw=="
-            }
-          }
-        },
-        "@formatjs/intl-utils": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-2.3.0.tgz",
-          "integrity": "sha512-KWk80UPIzPmUg+P0rKh6TqspRw0G6eux1PuJr+zz47ftMaZ9QDwbGzHZbtzWkl5hgayM/qrKRutllRC7D/vVXQ=="
-        },
         "camelcase": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
@@ -12212,34 +12184,6 @@
         "yaku": "0.19.3"
       },
       "dependencies": {
-        "@formatjs/intl-pluralrules": {
-          "version": "1.5.9",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-pluralrules/-/intl-pluralrules-1.5.9.tgz",
-          "integrity": "sha512-37E1ZG+Oqo3qrpUfumzNcFTV+V+NCExmTkkQ9Zw4FSlvJ4WhbbeYdieVapUVz9M0cLy8XrhCkfuM/Kn03iKReg==",
-          "requires": {
-            "@formatjs/intl-utils": "^2.3.0"
-          }
-        },
-        "@formatjs/intl-relativetimeformat": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-3.1.0.tgz",
-          "integrity": "sha512-xSW9RMJtZZTGAlT7qCom+0INLYgshowpBN0Xf+j4kME+U/g/ogTVRFeGvCZX3nDQ21vdTHAabR3AIGQRX7NU1g==",
-          "requires": {
-            "@formatjs/intl-utils": "^1.1.0"
-          },
-          "dependencies": {
-            "@formatjs/intl-utils": {
-              "version": "1.6.0",
-              "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-1.6.0.tgz",
-              "integrity": "sha512-5D0C4tQgNFJNaJ17BYum0GfAcKNK3oa1VWzgkv/AN7i52fg4r69ZLcpEGpf6tZiX9Qld8CDwTQOeFt6fuOqgVw=="
-            }
-          }
-        },
-        "@formatjs/intl-utils": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-2.3.0.tgz",
-          "integrity": "sha512-KWk80UPIzPmUg+P0rKh6TqspRw0G6eux1PuJr+zz47ftMaZ9QDwbGzHZbtzWkl5hgayM/qrKRutllRC7D/vVXQ=="
-        },
         "camelcase": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
@@ -12358,34 +12302,6 @@
         "yaku": "0.19.3"
       },
       "dependencies": {
-        "@formatjs/intl-pluralrules": {
-          "version": "1.5.9",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-pluralrules/-/intl-pluralrules-1.5.9.tgz",
-          "integrity": "sha512-37E1ZG+Oqo3qrpUfumzNcFTV+V+NCExmTkkQ9Zw4FSlvJ4WhbbeYdieVapUVz9M0cLy8XrhCkfuM/Kn03iKReg==",
-          "requires": {
-            "@formatjs/intl-utils": "^2.3.0"
-          }
-        },
-        "@formatjs/intl-relativetimeformat": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-3.1.0.tgz",
-          "integrity": "sha512-xSW9RMJtZZTGAlT7qCom+0INLYgshowpBN0Xf+j4kME+U/g/ogTVRFeGvCZX3nDQ21vdTHAabR3AIGQRX7NU1g==",
-          "requires": {
-            "@formatjs/intl-utils": "^1.1.0"
-          },
-          "dependencies": {
-            "@formatjs/intl-utils": {
-              "version": "1.6.0",
-              "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-1.6.0.tgz",
-              "integrity": "sha512-5D0C4tQgNFJNaJ17BYum0GfAcKNK3oa1VWzgkv/AN7i52fg4r69ZLcpEGpf6tZiX9Qld8CDwTQOeFt6fuOqgVw=="
-            }
-          }
-        },
-        "@formatjs/intl-utils": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-2.3.0.tgz",
-          "integrity": "sha512-KWk80UPIzPmUg+P0rKh6TqspRw0G6eux1PuJr+zz47ftMaZ9QDwbGzHZbtzWkl5hgayM/qrKRutllRC7D/vVXQ=="
-        },
         "camelcase": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
@@ -12504,34 +12420,6 @@
         "yaku": "0.19.3"
       },
       "dependencies": {
-        "@formatjs/intl-pluralrules": {
-          "version": "1.5.9",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-pluralrules/-/intl-pluralrules-1.5.9.tgz",
-          "integrity": "sha512-37E1ZG+Oqo3qrpUfumzNcFTV+V+NCExmTkkQ9Zw4FSlvJ4WhbbeYdieVapUVz9M0cLy8XrhCkfuM/Kn03iKReg==",
-          "requires": {
-            "@formatjs/intl-utils": "^2.3.0"
-          }
-        },
-        "@formatjs/intl-relativetimeformat": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-3.1.0.tgz",
-          "integrity": "sha512-xSW9RMJtZZTGAlT7qCom+0INLYgshowpBN0Xf+j4kME+U/g/ogTVRFeGvCZX3nDQ21vdTHAabR3AIGQRX7NU1g==",
-          "requires": {
-            "@formatjs/intl-utils": "^1.1.0"
-          },
-          "dependencies": {
-            "@formatjs/intl-utils": {
-              "version": "1.6.0",
-              "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-1.6.0.tgz",
-              "integrity": "sha512-5D0C4tQgNFJNaJ17BYum0GfAcKNK3oa1VWzgkv/AN7i52fg4r69ZLcpEGpf6tZiX9Qld8CDwTQOeFt6fuOqgVw=="
-            }
-          }
-        },
-        "@formatjs/intl-utils": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-2.3.0.tgz",
-          "integrity": "sha512-KWk80UPIzPmUg+P0rKh6TqspRw0G6eux1PuJr+zz47ftMaZ9QDwbGzHZbtzWkl5hgayM/qrKRutllRC7D/vVXQ=="
-        },
         "camelcase": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
@@ -12650,34 +12538,6 @@
         "yaku": "0.19.3"
       },
       "dependencies": {
-        "@formatjs/intl-pluralrules": {
-          "version": "1.5.9",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-pluralrules/-/intl-pluralrules-1.5.9.tgz",
-          "integrity": "sha512-37E1ZG+Oqo3qrpUfumzNcFTV+V+NCExmTkkQ9Zw4FSlvJ4WhbbeYdieVapUVz9M0cLy8XrhCkfuM/Kn03iKReg==",
-          "requires": {
-            "@formatjs/intl-utils": "^2.3.0"
-          }
-        },
-        "@formatjs/intl-relativetimeformat": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-3.1.0.tgz",
-          "integrity": "sha512-xSW9RMJtZZTGAlT7qCom+0INLYgshowpBN0Xf+j4kME+U/g/ogTVRFeGvCZX3nDQ21vdTHAabR3AIGQRX7NU1g==",
-          "requires": {
-            "@formatjs/intl-utils": "^1.1.0"
-          },
-          "dependencies": {
-            "@formatjs/intl-utils": {
-              "version": "1.6.0",
-              "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-1.6.0.tgz",
-              "integrity": "sha512-5D0C4tQgNFJNaJ17BYum0GfAcKNK3oa1VWzgkv/AN7i52fg4r69ZLcpEGpf6tZiX9Qld8CDwTQOeFt6fuOqgVw=="
-            }
-          }
-        },
-        "@formatjs/intl-utils": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-2.3.0.tgz",
-          "integrity": "sha512-KWk80UPIzPmUg+P0rKh6TqspRw0G6eux1PuJr+zz47ftMaZ9QDwbGzHZbtzWkl5hgayM/qrKRutllRC7D/vVXQ=="
-        },
         "camelcase": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
@@ -12796,34 +12656,6 @@
         "yaku": "0.19.3"
       },
       "dependencies": {
-        "@formatjs/intl-pluralrules": {
-          "version": "1.5.9",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-pluralrules/-/intl-pluralrules-1.5.9.tgz",
-          "integrity": "sha512-37E1ZG+Oqo3qrpUfumzNcFTV+V+NCExmTkkQ9Zw4FSlvJ4WhbbeYdieVapUVz9M0cLy8XrhCkfuM/Kn03iKReg==",
-          "requires": {
-            "@formatjs/intl-utils": "^2.3.0"
-          }
-        },
-        "@formatjs/intl-relativetimeformat": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-3.1.0.tgz",
-          "integrity": "sha512-xSW9RMJtZZTGAlT7qCom+0INLYgshowpBN0Xf+j4kME+U/g/ogTVRFeGvCZX3nDQ21vdTHAabR3AIGQRX7NU1g==",
-          "requires": {
-            "@formatjs/intl-utils": "^1.1.0"
-          },
-          "dependencies": {
-            "@formatjs/intl-utils": {
-              "version": "1.6.0",
-              "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-1.6.0.tgz",
-              "integrity": "sha512-5D0C4tQgNFJNaJ17BYum0GfAcKNK3oa1VWzgkv/AN7i52fg4r69ZLcpEGpf6tZiX9Qld8CDwTQOeFt6fuOqgVw=="
-            }
-          }
-        },
-        "@formatjs/intl-utils": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-2.3.0.tgz",
-          "integrity": "sha512-KWk80UPIzPmUg+P0rKh6TqspRw0G6eux1PuJr+zz47ftMaZ9QDwbGzHZbtzWkl5hgayM/qrKRutllRC7D/vVXQ=="
-        },
         "camelcase": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
@@ -12942,34 +12774,6 @@
         "yaku": "0.19.3"
       },
       "dependencies": {
-        "@formatjs/intl-pluralrules": {
-          "version": "1.5.9",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-pluralrules/-/intl-pluralrules-1.5.9.tgz",
-          "integrity": "sha512-37E1ZG+Oqo3qrpUfumzNcFTV+V+NCExmTkkQ9Zw4FSlvJ4WhbbeYdieVapUVz9M0cLy8XrhCkfuM/Kn03iKReg==",
-          "requires": {
-            "@formatjs/intl-utils": "^2.3.0"
-          }
-        },
-        "@formatjs/intl-relativetimeformat": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-3.1.0.tgz",
-          "integrity": "sha512-xSW9RMJtZZTGAlT7qCom+0INLYgshowpBN0Xf+j4kME+U/g/ogTVRFeGvCZX3nDQ21vdTHAabR3AIGQRX7NU1g==",
-          "requires": {
-            "@formatjs/intl-utils": "^1.1.0"
-          },
-          "dependencies": {
-            "@formatjs/intl-utils": {
-              "version": "1.6.0",
-              "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-1.6.0.tgz",
-              "integrity": "sha512-5D0C4tQgNFJNaJ17BYum0GfAcKNK3oa1VWzgkv/AN7i52fg4r69ZLcpEGpf6tZiX9Qld8CDwTQOeFt6fuOqgVw=="
-            }
-          }
-        },
-        "@formatjs/intl-utils": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-2.3.0.tgz",
-          "integrity": "sha512-KWk80UPIzPmUg+P0rKh6TqspRw0G6eux1PuJr+zz47ftMaZ9QDwbGzHZbtzWkl5hgayM/qrKRutllRC7D/vVXQ=="
-        },
         "camelcase": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
@@ -13088,34 +12892,6 @@
         "yaku": "0.19.3"
       },
       "dependencies": {
-        "@formatjs/intl-pluralrules": {
-          "version": "1.5.9",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-pluralrules/-/intl-pluralrules-1.5.9.tgz",
-          "integrity": "sha512-37E1ZG+Oqo3qrpUfumzNcFTV+V+NCExmTkkQ9Zw4FSlvJ4WhbbeYdieVapUVz9M0cLy8XrhCkfuM/Kn03iKReg==",
-          "requires": {
-            "@formatjs/intl-utils": "^2.3.0"
-          }
-        },
-        "@formatjs/intl-relativetimeformat": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-3.1.0.tgz",
-          "integrity": "sha512-xSW9RMJtZZTGAlT7qCom+0INLYgshowpBN0Xf+j4kME+U/g/ogTVRFeGvCZX3nDQ21vdTHAabR3AIGQRX7NU1g==",
-          "requires": {
-            "@formatjs/intl-utils": "^1.1.0"
-          },
-          "dependencies": {
-            "@formatjs/intl-utils": {
-              "version": "1.6.0",
-              "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-1.6.0.tgz",
-              "integrity": "sha512-5D0C4tQgNFJNaJ17BYum0GfAcKNK3oa1VWzgkv/AN7i52fg4r69ZLcpEGpf6tZiX9Qld8CDwTQOeFt6fuOqgVw=="
-            }
-          }
-        },
-        "@formatjs/intl-utils": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-2.3.0.tgz",
-          "integrity": "sha512-KWk80UPIzPmUg+P0rKh6TqspRw0G6eux1PuJr+zz47ftMaZ9QDwbGzHZbtzWkl5hgayM/qrKRutllRC7D/vVXQ=="
-        },
         "camelcase": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
@@ -13234,34 +13010,6 @@
         "yaku": "0.19.3"
       },
       "dependencies": {
-        "@formatjs/intl-pluralrules": {
-          "version": "1.5.9",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-pluralrules/-/intl-pluralrules-1.5.9.tgz",
-          "integrity": "sha512-37E1ZG+Oqo3qrpUfumzNcFTV+V+NCExmTkkQ9Zw4FSlvJ4WhbbeYdieVapUVz9M0cLy8XrhCkfuM/Kn03iKReg==",
-          "requires": {
-            "@formatjs/intl-utils": "^2.3.0"
-          }
-        },
-        "@formatjs/intl-relativetimeformat": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-3.1.0.tgz",
-          "integrity": "sha512-xSW9RMJtZZTGAlT7qCom+0INLYgshowpBN0Xf+j4kME+U/g/ogTVRFeGvCZX3nDQ21vdTHAabR3AIGQRX7NU1g==",
-          "requires": {
-            "@formatjs/intl-utils": "^1.1.0"
-          },
-          "dependencies": {
-            "@formatjs/intl-utils": {
-              "version": "1.6.0",
-              "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-1.6.0.tgz",
-              "integrity": "sha512-5D0C4tQgNFJNaJ17BYum0GfAcKNK3oa1VWzgkv/AN7i52fg4r69ZLcpEGpf6tZiX9Qld8CDwTQOeFt6fuOqgVw=="
-            }
-          }
-        },
-        "@formatjs/intl-utils": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-2.3.0.tgz",
-          "integrity": "sha512-KWk80UPIzPmUg+P0rKh6TqspRw0G6eux1PuJr+zz47ftMaZ9QDwbGzHZbtzWkl5hgayM/qrKRutllRC7D/vVXQ=="
-        },
         "camelcase": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
@@ -13385,6 +13133,31 @@
         "yaku": "1.0.1"
       },
       "dependencies": {
+        "@formatjs/intl-pluralrules": {
+          "version": "3.5.6",
+          "resolved": "https://registry.npmjs.org/@formatjs/intl-pluralrules/-/intl-pluralrules-3.5.6.tgz",
+          "integrity": "sha512-8CvrM8YGEpsdTq3po0VYrw/HiJCQhSiau1BH5J/QRm1C9RNBt3+N2TyjUrCYO+pTkDtn4cDS9MZi0ufVZLkZ9A==",
+          "requires": {
+            "@formatjs/ecma402-abstract": "1.4.0",
+            "tslib": "^2.0.1"
+          }
+        },
+        "@formatjs/intl-relativetimeformat": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-6.2.4.tgz",
+          "integrity": "sha512-bhxHRPL6xQIF7XOD1HDYfC3Ip45Ccf2G4viMLyIXDaHPeVgRHM5jZ23FXdg01MQEZ/thb20hoeX56m76+IjI0Q==",
+          "requires": {
+            "@formatjs/intl-utils": "^3.8.1"
+          }
+        },
+        "@formatjs/intl-utils": {
+          "version": "3.8.4",
+          "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-3.8.4.tgz",
+          "integrity": "sha512-j5C6NyfKevIxsfLK8KwO1C0vvP7k1+h4A9cFpc+cr6mEwCc1sPkr17dzh0Ke6k9U5pQccAQoXdcNBl3IYa4+ZQ==",
+          "requires": {
+            "emojis-list": "^3.0.0"
+          }
+        },
         "camelcase": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
@@ -13412,6 +13185,11 @@
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        },
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
         },
         "uglify-js": {
           "version": "2.8.29",
@@ -14754,9 +14532,9 @@
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "seamless-scroll-polyfill": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/seamless-scroll-polyfill/-/seamless-scroll-polyfill-1.2.2.tgz",
-      "integrity": "sha512-FW+rj6PKDYHGP7c7M26+/ZE8baebU6ai4S861dU3WTp9tDnxc7pEqDCjGe45WClRQP3g4SMFUaPECz0vwLeyWw=="
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/seamless-scroll-polyfill/-/seamless-scroll-polyfill-1.2.3.tgz",
+      "integrity": "sha512-emnwZtu6NrlBlvT6HrlbAOs024JX4orWew8H5owBOyUJ7eFXn8lGe4bsXTBD6AAWzP/p7LL86AjVIH8Apqec5w=="
     },
     "section-matter": {
       "version": "1.0.0",


### PR DESCRIPTION
### Updated (1)

| Package | Version | Source | Detail |
|:--------|:-------:|:------:|:-------|
| [ini](https://npm.im/ini) | `1.3.5` → `1.3.7` | [github](https://github.com/isaacs/ini) | **[Low]** Prototype Pollution ([ref](https://npmjs.com/advisories/1589)) |

***

This pull request is created by [npm-audit-fix-action](https://github.com/ybiquitous/npm-audit-fix-action). The used npm version is **6.14.8**.