### PR TITLE
Add missing polyfill-library versions to the url-builder page

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -42,9 +42,10 @@ owners to license your work under the terms of the [MIT License](../LICENSE.md).
 2. Create a new branch to make changes into. `git checkout -b [name]`
 3. In `package.json` rename the `polyfill-library` dependency to `polyfill-library-$version` and change the version to be an npm alias. E.G. `"polyfill-library": "^3.27.4"` becomes `"polyfill-library-3.27.4": "npm:polyfill-library@3.27.4"`
 4. In `server/routes/v3/polyfill.js` add a new map entry for the version of `polyfill-library` you have just added.
-5. In the terminal run `npm install polyfill-library@*`
-6. In `fastly/vcl/main.vcl:114` add the new version to the if statement for setting the version query parameter.
-7. Commit the file changes into git, push up the branch and open a pull-request
+5. In `src/data/polyfills.js` add a new entry to the `versions` array for the version of `polyfill-library` you have just added.
+6. In the terminal run `npm install polyfill-library@*`
+7. In `fastly/vcl/main.vcl:114` add the new version to the if statement for setting the version query parameter.
+8. Commit the file changes into git, push up the branch and open a pull-request
 
 ## Cutting a Release
 

--- a/src/data/polyfills.js
+++ b/src/data/polyfills.js
@@ -58,7 +58,6 @@ module.exports = async () => {
 		// non-icu case-sensitive alphabetical sort
 		polyfills.sort((a, b) => (a.name > b.name ? 1 : (a.name < b.name ? -1 : 0)));
 	}
-
 	return {
 		polyfills,
 		polyfillAliases,
@@ -87,7 +86,12 @@ module.exports = async () => {
 			"3.52.2",
 			"3.52.3",
 			"3.53.1",
-			"3.89.4"
+			"3.89.4",
+			"3.96.0",
+			"3.98.0",
+			"3.100.0",
+			"3.101.0",
+			"3.103.0",
 		]
 	};
 };


### PR DESCRIPTION
This fixes the issue reported in https://github.com/Financial-Times/polyfill-service/issues/2628