### PR TITLE
Stop redirecting polyfills.io to polyfill.io and instead use it as an alternative domain

### DIFF
--- a/fastly/vcl/polyfill-service.vcl
+++ b/fastly/vcl/polyfill-service.vcl
@@ -133,6 +133,7 @@ sub vcl_hash {
 	}
 
 	# We are not adding req.http.host to the hash because we want https://cdn.polyfill.io and https://polyfill.io to be a single object in the cache.
+	# As well as any other domains we support such as polyfills.io and cdn.polyfills.io
 	# set req.hash += req.http.host;
 	set req.hash += req.url;
 	# We include return(hash) to stop the function falling through to the default VCL built into varnish, which for vcl_hash will add req.url and req.http.Host to the hash.

--- a/fastly/vcl/redirects.vcl
+++ b/fastly/vcl/redirects.vcl
@@ -2,7 +2,8 @@ sub vcl_recv {
 	if (req.http.Host ~ "polyfills.io") {
 		# Fastly recommend using the 900-999 range of status codes for custom errors within an application's VCL.
 		# Do the canonicalise checks before the HTTPS check to avoid a double redirect
-		error 901 "Canonicalise";
+		# TODO: We are no longer redirecting this domain as an alternative domain for when polyfill.io is blocked: https://github.com/Financial-Times/polyfill-service/issues/2638
+		# error 901 "Canonicalise";
 	}
 	if (req.http.Host ~ "www.polyfills.io") {
 		# Fastly recommend using the 900-999 range of status codes for custom errors within an application's VCL.


### PR DESCRIPTION
This should help when polyfill.io is blocked such as it is now for some Malaysia ISPs

https://github.com/Financial-Times/polyfill-service/issues/2638