### PR TITLE
polyfill url builder fixes

### DIFF
--- a/src/assets/js/index.js
+++ b/src/assets/js/index.js
@@ -122,13 +122,6 @@ const defaultPolyfillBundleOptions = {
 
 const polyfillBundleOptions = Object.assign({}, defaultPolyfillBundleOptions);
 
-const featuresCache = {};
-const featuresRows = [...document.querySelectorAll("#features-list [data-feature-name]")];
-
-featuresRows.forEach(node => {
-	featuresCache[node.dataset.featureName.toLowerCase()] = node;
-});
-
 const renderFeatureList = ({ polyfillAliases, polyfills }) => {
 	let html = "";
 	for (const item of polyfillAliases) {
@@ -196,12 +189,15 @@ if (libraryVersionInput) {
 			polyfillBundleOptions.version = version;
 			updatePolyfillBundle(polyfillBundleOptions);
 			createTooltips();
+
+			// reset the polyfill name filter.
+			document.querySelector("#filter").value = '';
 		}
 	});
 }
 
 function resetFeaturesList() {
-	return [...featuresRows].forEach(function(element) {
+	return [...document.querySelectorAll("#features-list [data-feature-name]")].forEach(function(element) {
 		element.removeAttribute("aria-hidden");
 	});
 }
@@ -217,7 +213,13 @@ function filterFeatures(event) {
 	if (inputValue === "") {
 		resetFeaturesList();
 	} else {
-		Object.entries(featuresCache).forEach(function([key, node]) {
+		const featuresByName = {}
+		const featuresRows = [...document.querySelectorAll("#features-list [data-feature-name]")];
+
+		featuresRows.forEach(node => {
+			featuresByName[node.dataset.featureName] = node;
+		});
+		Object.entries(featuresByName).forEach(function([key, node]) {
 			if (key.toLowerCase().includes(inputValue.toLowerCase())) {
 				node.removeAttribute("aria-hidden");
 			} else {

--- a/src/assets/v3/library.11ty.js
+++ b/src/assets/v3/library.11ty.js
@@ -3,6 +3,8 @@
 const _ = require("lodash");
 const snakeCase = _.snakeCase;
 
+const latestLibraryVersion = "3.108.0";
+
 class Test {
 	data() {
 		return {
@@ -46,7 +48,7 @@ class Test {
 				"3.101.0",
 				"3.103.0",
 				"3.104.0",
-				"3.108.0",
+				latestLibraryVersion,
 			]
 		};
 	}
@@ -60,7 +62,7 @@ class Test {
 module.exports = Test;
 
 async function getPolyfillNamesFrom(libraryVersion) {
-	const library = require(`polyfill-library-${libraryVersion}`);
+	const library = libraryVersion === latestLibraryVersion ? require(`polyfill-library`) : require(`polyfill-library-${libraryVersion}`);
 
 	const polyfills = [];
 	const polyfillAliases = [];

--- a/src/assets/v3/url-builder.njk
+++ b/src/assets/v3/url-builder.njk
@@ -31,6 +31,7 @@ oLayoutStyle: "o-layout--query"
 					{% for version in polyfills.versions | reverse %}
 						{% if loop.first %}
 							<option value="" selected></option>
+							<option value="{{version}}" >{{version}}</option>
 						{% else %}
 							<option value="{{version}}" >{{version}}</option>
 						{% endif %}


### PR DESCRIPTION
- latest versions weren't showing up
- filter now works after changing version
- last (default) version is now also show explicitly, enabling pinned versions of the last version in the url.

<img width="278" alt="Screenshot 2021-09-22 at 09 12 44" src="https://user-images.githubusercontent.com/11521496/134299001-ea185bad-d38e-4f08-bb8b-a93c57ee2154.png">
<img width="757" alt="Screenshot 2021-09-22 at 09 12 52" src="https://user-images.githubusercontent.com/11521496/134299003-56f2626e-007f-4961-bd1d-a8300ce62943.png">
