### PR TITLE
Add a PurgeGroup surrogate-key to every response and purge on deploy

### DIFF
--- a/.github/workflows/create-netrc.sh
+++ b/.github/workflows/create-netrc.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Set error handling
+set -eu -o pipefail
+
+# Heroku CLI Authentication - Netrc file format
+# https://devcenter.heroku.com/articles/authentication#netrc-file-format
+
+cat > ~/.netrc << EOF
+machine api.heroku.com
+	login $HEROKU_LOGIN
+	password $HEROKU_AUTH_TOKEN
+machine git.heroku.com
+	login $HEROKU_LOGIN
+	password $HEROKU_AUTH_TOKEN
+machine code.heroku.com
+	login $HEROKU_LOGIN
+	password $HEROKU_AUTH_TOKEN
+EOF
+
+# Set umask - owner r+w only
+chmod 0600 ~/.netrc

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -3,6 +3,8 @@ on:
   release:
     types: [created]
 env:
+  eu_app: origami-polyfill-service-eu
+  us_app: origami-polyfill-service-us
   terraform_version: '0.12.29'
   terraform_working_dir: 'fastly/terraform/'
   fastly_service_id: ${{ secrets.FASTLY_SERVICE_ID_PROD }}
@@ -33,8 +35,8 @@ jobs:
       uses: softprops/turnstyle@v1
       with:
         same-branch-only: false
-    - run: git push https://heroku:${{ secrets.HEROKU_AUTH_TOKEN }}@git.heroku.com/origami-polyfill-service-eu.git HEAD:refs/heads/master --force
-    - run: git push https://heroku:${{ secrets.HEROKU_AUTH_TOKEN }}@git.heroku.com/origami-polyfill-service-us.git HEAD:refs/heads/master --force
+    - run: git push https://heroku:${{ secrets.HEROKU_AUTH_TOKEN }}@git.heroku.com/${{ env.eu_app }}.git HEAD:refs/heads/master --force
+    - run: git push https://heroku:${{ secrets.HEROKU_AUTH_TOKEN }}@git.heroku.com/${{ env.us_app }}.git HEAD:refs/heads/master --force
     - name: Remove the development and staging terraform configuration overrides
       run: rm -f terraform.tfstate fastly/terraform/dev_override.tf fastly/terraform/qa_override.tf fastly/terraform/domains_override.tf
     - name: 'Terraform Init'
@@ -117,3 +119,43 @@ jobs:
           system-code: "origami-polyfill-service"
           environment: prod
           slack-channels: "ft-changes,origami-deploys"
+
+  scale-up:    
+    needs: [deploy-to-production]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: bash .github/workflows/create-netrc.sh
+        env:
+          HEROKU_LOGIN: ${{ secrets.HEROKU_LOGIN }}
+          HEROKU_AUTH_TOKEN: ${{ secrets.HEROKU_AUTH_TOKEN }}
+      - run: heroku ps:scale web=10:performance-l --app ${{ env.eu_app }}
+      - run: heroku ps:scale web=10:performance-l --app ${{ env.us_app }}
+      # Wait for the applications to be fully booted before finishing the job
+      - run: sleep 60
+
+  purge-cdn:
+    needs: [scale-up]
+    runs-on: ubuntu-latest
+    timeout-minutes: 200
+    steps:
+      - run: >-
+          for PURGE_GROUP in `seq 0 999`;
+          do
+            curl --fail --show-error --silent -X POST -H "Fastly-Key: ${{ secrets.FASTLY_API_KEY }}" https://api.fastly.com/service/${{ env.fastly_service_id }}/purge/PurgeGroup${PURGE_GROUP}
+            sleep 5
+          done
+
+  scale-down:
+    needs: [purge-cdn]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: bash .github/workflows/create-netrc.sh
+        env:
+          HEROKU_LOGIN: ${{ secrets.HEROKU_LOGIN }}
+          HEROKU_AUTH_TOKEN: ${{ secrets.HEROKU_AUTH_TOKEN }}
+      # Wait for the cache to build back up before scaling back down
+      - run: sleep 300
+      - run: heroku ps:scale web=1:performance-l --app ${{ env.eu_app }}
+      - run: heroku ps:scale web=1:performance-l --app ${{ env.us_app }}

--- a/fastly/vcl/polyfill-service.vcl
+++ b/fastly/vcl/polyfill-service.vcl
@@ -157,6 +157,13 @@ sub vcl_fetch {
 		call breadcrumb_fetch;
 	}
 
+	# https://yann.mandragor.org/posts/purge-group-pattern/
+	if (beresp.http.Surrogate-Key && !std.strstr(beresp.http.Surrogate-Key, "PurgeGroup")) {
+		set beresp.http.Surrogate-Key = beresp.http.Surrogate-Key " PurgeGroup" randomint(0, 999);
+	} else if (!beresp.http.Surrogate-Key) {
+		set beresp.http.Surrogate-Key = "PurgeGroup" randomint(0, 999);
+	}
+
 	# These header are only required for HTML documents.
 	if (beresp.http.Content-Type ~ "text/html") {
 		# Enables the cross-site scripting filter built into most modern web browsers.

--- a/test/integration/v2/api.test.js
+++ b/test/integration/v2/api.test.js
@@ -16,7 +16,7 @@ describe("GET /v2/polyfill.js", function() {
 			.expect(200)
 			.expect("Content-Type", "text/javascript; charset=utf-8")
 			.expect("cache-control", "public, s-maxage=31536000, max-age=604800, stale-while-revalidate=604800, stale-if-error=604800")
-			.expect("surrogate-key", "polyfill-service")
+			.expect("surrogate-key", /polyfill-service/)
 			.then(response => {
 				assert.isString(response.text);
 				assert.doesNotThrow(() => new vm.Script(response.text));
@@ -34,7 +34,7 @@ describe("GET /v2/polyfill.js?callback=AAA&callback=BBB", function() {
 			.expect(200)
 			.expect("Content-Type", "text/javascript; charset=utf-8")
 			.expect("cache-control", "public, s-maxage=31536000, max-age=604800, stale-while-revalidate=604800, stale-if-error=604800")
-			.expect("surrogate-key", "polyfill-service")
+			.expect("surrogate-key", /polyfill-service/)
 			.then(response => {
 				assert.isString(response.text);
 				assert.doesNotThrow(() => new vm.Script(response.text));
@@ -52,7 +52,7 @@ describe("GET /v2/polyfill.min.js", function() {
 			.expect(200)
 			.expect("Content-Type", "text/javascript; charset=utf-8")
 			.expect("cache-control", "public, s-maxage=31536000, max-age=604800, stale-while-revalidate=604800, stale-if-error=604800")
-			.expect("surrogate-key", "polyfill-service")
+			.expect("surrogate-key", /polyfill-service/)
 			.then(response => {
 				assert.isString(response.text);
 				assert.doesNotThrow(() => new vm.Script(response.text));
@@ -70,7 +70,7 @@ describe("GET /v2/polyfill.js?features=all&ua=non-existent-ua&unknown=polyfill&f
 			.expect(200)
 			.expect("Content-Type", "text/javascript; charset=utf-8")
 			.expect("cache-control", "public, s-maxage=31536000, max-age=604800, stale-while-revalidate=604800, stale-if-error=604800")
-			.expect("surrogate-key", "polyfill-service")
+			.expect("surrogate-key", /polyfill-service/)
 			.then(response => {
 				assert.isString(response.text);
 				// vm.Script will cause the event loop to become blocked whilst it parses the large response
@@ -89,7 +89,7 @@ describe("GET /v2/polyfill.min.js?features=all&ua=non-existent-ua&unknown=polyfi
 			.expect(200)
 			.expect("Content-Type", "text/javascript; charset=utf-8")
 			.expect("cache-control", "public, s-maxage=31536000, max-age=604800, stale-while-revalidate=604800, stale-if-error=604800")
-			.expect("surrogate-key", "polyfill-service")
+			.expect("surrogate-key", /polyfill-service/)
 			.then(response => {
 				assert.isString(response.text);
 				// vm.Script will cause the event loop to become blocked whilst it parses the large response

--- a/test/integration/v3/polyfill.min.test.js
+++ b/test/integration/v3/polyfill.min.test.js
@@ -53,7 +53,7 @@ describe("HEAD /v3/polyfill.min.js", function() {
 			.expect(200)
 			.expect("Content-Type", "text/javascript; charset=utf-8")
 			.expect("cache-control", "public, s-maxage=31536000, max-age=604800, stale-while-revalidate=604800, stale-if-error=604800")
-			.expect("surrogate-key", "polyfill-service");
+			.expect("surrogate-key", /polyfill-service/);
 	});
 });
 
@@ -66,7 +66,7 @@ describe("GET /v3/polyfill.min.js", function() {
 			.expect(200)
 			.expect("Content-Type", "text/javascript; charset=utf-8")
 			.expect("cache-control", "public, s-maxage=31536000, max-age=604800, stale-while-revalidate=604800, stale-if-error=604800")
-			.expect("surrogate-key", "polyfill-service")
+			.expect("surrogate-key", /polyfill-service/)
 			.then(response => {
 				assert.isString(response.text);
 				assert.doesNotThrow(() => new vm.Script(response.text));
@@ -84,7 +84,7 @@ describe("GET /v3/polyfill.min.js?callback=AAA&callback=BBB", function() {
 			.expect(200)
 			.expect("Content-Type", "text/javascript; charset=utf-8")
 			.expect("cache-control", "public, s-maxage=31536000, max-age=604800, stale-while-revalidate=604800, stale-if-error=604800")
-			.expect("surrogate-key", "polyfill-service")
+			.expect("surrogate-key", /polyfill-service/)
 			.then(response => {
 				assert.isString(response.text);
 				assert.doesNotThrow(() => new vm.Script(response.text));
@@ -102,7 +102,7 @@ describe("GET /v3/polyfill.min.js?features=all&ua=non-existent-ua&unknown=polyfi
 			.expect(200)
 			.expect("Content-Type", "text/javascript; charset=utf-8")
 			.expect("cache-control", "public, s-maxage=31536000, max-age=604800, stale-while-revalidate=604800, stale-if-error=604800")
-			.expect("surrogate-key", "polyfill-service")
+			.expect("surrogate-key", /polyfill-service/)
 			.then(response => {
 				assert.isString(response.text);
 				// vm.Script will cause the event loop to become blocked whilst it parses the large response

--- a/test/integration/v3/polyfill.test.js
+++ b/test/integration/v3/polyfill.test.js
@@ -56,7 +56,7 @@ describe("HEAD /v3/polyfill.js", function() {
 			.expect("Access-Control-Allow-Origin", "*")
 			.expect("Access-Control-Allow-Methods", "GET,HEAD,OPTIONS")
 			.expect("cache-control", "public, s-maxage=31536000, max-age=604800, stale-while-revalidate=604800, stale-if-error=604800")
-			.expect("surrogate-key", "polyfill-service");
+			.expect("surrogate-key", /polyfill-service/);
 	});
 });
 
@@ -71,7 +71,7 @@ describe("GET /v3/polyfill.js", function() {
 			.expect("Access-Control-Allow-Origin", "*")
 			.expect("Access-Control-Allow-Methods", "GET,HEAD,OPTIONS")
 			.expect("cache-control", "public, s-maxage=31536000, max-age=604800, stale-while-revalidate=604800, stale-if-error=604800")
-			.expect("surrogate-key", "polyfill-service")
+			.expect("surrogate-key", /polyfill-service/)
 			.then(response => {
 				assert.isString(response.text);
 				assert.doesNotThrow(() => new vm.Script(response.text));
@@ -89,7 +89,7 @@ describe("GET /v3/polyfill.js?features=carrot&strict", function() {
 			.expect(200)
 			.expect("Content-Type", "text/javascript; charset=utf-8")
 			.expect("cache-control", "public, s-maxage=31536000, max-age=604800, stale-while-revalidate=604800, stale-if-error=604800")
-			.expect("surrogate-key", "polyfill-service")
+			.expect("surrogate-key", /polyfill-service/)
 			.then(response => {
 				assert.isString(response.text);
 				assert.doesNotThrow(() => new vm.Script(response.text));
@@ -109,7 +109,7 @@ describe("GET /v3/polyfill.js?callback=AAA&callback=BBB", function() {
 			.expect("Access-Control-Allow-Origin", "*")
 			.expect("Access-Control-Allow-Methods", "GET,HEAD,OPTIONS")
 			.expect("cache-control", "public, s-maxage=31536000, max-age=604800, stale-while-revalidate=604800, stale-if-error=604800")
-			.expect("surrogate-key", "polyfill-service")
+			.expect("surrogate-key", /polyfill-service/)
 			.then(response => {
 				assert.isString(response.text);
 				assert.doesNotThrow(() => new vm.Script(response.text));


### PR DESCRIPTION
This is an implementation of https://yann.mandragor.org/posts/purge-group-pattern/

This adds 1 of 1000 possible PurgeGroup surrogate keys to the response, which will then be used during deployment to slowly purge the cache and avoid a thundering-herd of requests going to the polyfill.io origin servers.

When a deployment to production happens:
- Scale the backends up
- Soft-purge each purge-group and sleep inbetween the purges to avoid the thundering-herd
- Sleep some more to let the caches build back up
- Scale the backends to original size and amount