### PR TITLE
Disable request logging when DISABLE_REQUEST_LOGGING is set

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -9,9 +9,12 @@ dotenv.config();
 const options = {
 	log: console,
 	name: "Origami Polyfill Service",
-	requestLogFormat: process.env.DISABLE_REQUEST_LOGGING ? null : undefined,
 	workers: process.env.WEB_CONCURRENCY || 1
 };
+
+if (process.env.DISABLE_REQUEST_LOGGING) {
+	options.requestLogFormat = null;
+}
 
 throng({
 	workers: options.workers,

--- a/server/index.js
+++ b/server/index.js
@@ -9,7 +9,7 @@ dotenv.config();
 const options = {
 	log: console,
 	name: "Origami Polyfill Service",
-	requestLogFormat: process.env.NODE_ENV === "production" ? null : undefined,
+	requestLogFormat: process.env.DISABLE_REQUEST_LOGGING ? null : undefined,
 	workers: process.env.WEB_CONCURRENCY || 1
 };
 

--- a/server/index.js
+++ b/server/index.js
@@ -9,6 +9,7 @@ dotenv.config();
 const options = {
 	log: console,
 	name: "Origami Polyfill Service",
+	requestLogFormat: process.env.NODE_ENV === "production" ? null : undefined,
 	workers: process.env.WEB_CONCURRENCY || 1
 };
 


### PR DESCRIPTION
Currently even if I set `NODE_ENV` to `production`, it logs each request. I think it's unnecessary.