### PR TITLE
Add compute-at-edge backend for 1/1000 v3/polyfill requests

### DIFF
--- a/.github/workflows/deploy-to-dev-and-test.yml
+++ b/.github/workflows/deploy-to-dev-and-test.yml
@@ -84,7 +84,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FASTLY_API_KEY: ${{ secrets.FASTLY_API_KEY }}
-      - name: 'Terraform Import Fastly Service Dictionary Items'
+      - name: 'Terraform Import Fastly Service Dictionary Top-pops Config Items'
         if: steps.witness.outputs.cache-hit != 'true'
         uses: hashicorp/terraform-github-actions@v0.8.0
         with:
@@ -92,7 +92,19 @@ jobs:
           tf_actions_subcommand: 'import'
           tf_actions_working_dir: ${{ env.terraform_working_dir }}
           tf_actions_comment: false
-          args: 'fastly_service_dictionary_items_v1.items "${{ env.fastly_service_id }}/2RYpb2YAbYtpjSjwok0VWc"'
+          args: 'fastly_service_dictionary_items_v1.toppops_config_items "${{ env.fastly_service_id }}/2RYpb2YAbYtpjSjwok0VWc"'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FASTLY_API_KEY: ${{ secrets.FASTLY_API_KEY }}
+      - name: 'Terraform Import Fastly Service Dictionary Compute At Edge Config Items'
+        if: steps.witness.outputs.cache-hit != 'true'
+        uses: hashicorp/terraform-github-actions@v0.8.0
+        with:
+          tf_actions_version: ${{ env.terraform_version }}
+          tf_actions_subcommand: 'import'
+          tf_actions_working_dir: ${{ env.terraform_working_dir }}
+          tf_actions_comment: false
+          args: 'fastly_service_dictionary_items_v1.compute_at_edge_config_items "${{ env.fastly_service_id }}/2IoLgAUsrJOW8pU8FOQuyg"'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FASTLY_API_KEY: ${{ secrets.FASTLY_API_KEY }}

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -59,14 +59,27 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         FASTLY_API_KEY: ${{ secrets.FASTLY_API_KEY_PROD }}
-    - name: 'Terraform Import Fastly Service Dictionary Items'
+    - name: 'Terraform Import Fastly Service Dictionary Top-pops Config Items'
+      if: steps.witness.outputs.cache-hit != 'true'
       uses: hashicorp/terraform-github-actions@v0.8.0
       with:
         tf_actions_version: ${{ env.terraform_version }}
         tf_actions_subcommand: 'import'
         tf_actions_working_dir: ${{ env.terraform_working_dir }}
         tf_actions_comment: true
-        args: 'fastly_service_dictionary_items_v1.items "${{ env.fastly_service_id }}/3t3bjgcYBnC8nfCHM60Hay"'
+        args: 'fastly_service_dictionary_items_v1.toppops_config_items "${{ env.fastly_service_id }}/3t3bjgcYBnC8nfCHM60Hay"'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        FASTLY_API_KEY: ${{ secrets.FASTLY_API_KEY_PROD }}
+    - name: 'Terraform Import Fastly Service Dictionary Compute At Edge Config Items'
+      if: steps.witness.outputs.cache-hit != 'true'
+      uses: hashicorp/terraform-github-actions@v0.8.0
+      with:
+        tf_actions_version: ${{ env.terraform_version }}
+        tf_actions_subcommand: 'import'
+        tf_actions_working_dir: ${{ env.terraform_working_dir }}
+        tf_actions_comment: true
+        args: 'fastly_service_dictionary_items_v1.compute_at_edge_config_items "${{ env.fastly_service_id }}/5E74ZKOhK81rU53qOP4X4U"'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         FASTLY_API_KEY: ${{ secrets.FASTLY_API_KEY_PROD }}
@@ -120,7 +133,7 @@ jobs:
           environment: prod
           slack-channels: "ft-changes,origami-deploys"
 
-  scale-up:    
+  scale-up:
     needs: [deploy-to-production]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deploy-to-staging-and-test.yml
+++ b/.github/workflows/deploy-to-staging-and-test.yml
@@ -57,14 +57,27 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         FASTLY_API_KEY: ${{ secrets.FASTLY_API_KEY_STAGING }}
-    - name: 'Terraform Import Fastly Service Dictionary Items'
+    - name: 'Terraform Import Fastly Service Dictionary Top-pops Config Items'
+      if: steps.witness.outputs.cache-hit != 'true'
       uses: hashicorp/terraform-github-actions@v0.8.0
       with:
         tf_actions_version: ${{ env.terraform_version }}
         tf_actions_subcommand: 'import'
         tf_actions_working_dir: ${{ env.terraform_working_dir }}
         tf_actions_comment: true
-        args: 'fastly_service_dictionary_items_v1.items "${{ env.fastly_service_id }}/4dfSlimwvlJELO6htcnGsi"'
+        args: 'fastly_service_dictionary_items_v1.toppops_config_items "${{ env.fastly_service_id }}/4dfSlimwvlJELO6htcnGsi"'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        FASTLY_API_KEY: ${{ secrets.FASTLY_API_KEY_STAGING }}
+    - name: 'Terraform Import Fastly Service Dictionary Compute At Edge Config Items'
+      if: steps.witness.outputs.cache-hit != 'true'
+      uses: hashicorp/terraform-github-actions@v0.8.0
+      with:
+        tf_actions_version: ${{ env.terraform_version }}
+        tf_actions_subcommand: 'import'
+        tf_actions_working_dir: ${{ env.terraform_working_dir }}
+        tf_actions_comment: true
+        args: 'fastly_service_dictionary_items_v1.compute_at_edge_config_items "${{ env.fastly_service_id }}/6J7j8CkzoO7BsnE8iNl4uG"'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         FASTLY_API_KEY: ${{ secrets.FASTLY_API_KEY_STAGING }}

--- a/fastly/terraform/dev_override.tf
+++ b/fastly/terraform/dev_override.tf
@@ -6,6 +6,29 @@ resource "fastly_service_v1" "app" {
   }
 
   backend {
+    name                  = "compute_at_edge"
+    address               = "polyfill-service.edgecompute.app"
+    port                  = 443
+    healthcheck           = "compute_at_edge_healthcheck"
+    ssl_cert_hostname     = "*.edgecompute.app"
+    auto_loadbalance      = false
+    connect_timeout       = 5000
+    first_byte_timeout    = 120000
+    between_bytes_timeout = 120000
+    error_threshold       = 0
+    override_host         = "polyfill-service.edgecompute.app"
+  }
+
+  healthcheck {
+    name      = "compute_at_edge_healthcheck"
+    host      = "polyfill-service.edgecompute.app"
+    path      = "/__gtg"
+    timeout   = 5000
+    threshold = 2
+    window    = 5
+  }
+
+  backend {
     name                  = "v3_eu"
     address               = "origami-polyfill-service-int.herokuapp.com"
     port                  = 443

--- a/fastly/terraform/main.tf
+++ b/fastly/terraform/main.tf
@@ -65,11 +65,27 @@ resource "fastly_service_v1" "app" {
   dictionary {
     name = "toppops_config"
   }
+
+  dictionary {
+    name = "compute_at_edge_config"
+  }
 }
 
-resource "fastly_service_dictionary_items_v1" "items" {
+resource "fastly_service_dictionary_items_v1" "toppops_config_items" {
   service_id    = fastly_service_v1.app.id
   dictionary_id = { for dictionary in fastly_service_v1.app.dictionary : dictionary.name => dictionary.dictionary_id }["toppops_config"]
+
+  items = {
+  }
+
+  lifecycle {
+    ignore_changes = [items, ]
+  }
+}
+
+resource "fastly_service_dictionary_items_v1" "compute_at_edge_config_items" {
+  service_id    = fastly_service_v1.app.id
+  dictionary_id = { for dictionary in fastly_service_v1.app.dictionary : dictionary.name => dictionary.dictionary_id }["compute_at_edge_config"]
 
   items = {
   }

--- a/fastly/terraform/production_override.tf
+++ b/fastly/terraform/production_override.tf
@@ -30,6 +30,29 @@ resource "fastly_service_v1" "app" {
   }
 
   backend {
+    name                  = "compute_at_edge"
+    address               = "polyfill-service.edgecompute.app"
+    port                  = 443
+    healthcheck           = "compute_at_edge_healthcheck"
+    ssl_cert_hostname     = "*.edgecompute.app"
+    auto_loadbalance      = false
+    connect_timeout       = 5000
+    first_byte_timeout    = 120000
+    between_bytes_timeout = 120000
+    error_threshold       = 0
+    override_host         = "polyfill-service.edgecompute.app"
+  }
+
+  healthcheck {
+    name      = "compute_at_edge_healthcheck"
+    host      = "polyfill-service.edgecompute.app"
+    path      = "/__gtg"
+    timeout   = 5000
+    threshold = 2
+    window    = 5
+  }
+
+  backend {
     name                  = "v3_eu"
     address               = "origami-polyfill-service-eu.herokuapp.com"
     port                  = 443

--- a/fastly/terraform/qa_override.tf
+++ b/fastly/terraform/qa_override.tf
@@ -6,6 +6,29 @@ resource "fastly_service_v1" "app" {
   }
 
   backend {
+    name                  = "compute_at_edge"
+    address               = "polyfill-service.edgecompute.app"
+    port                  = 443
+    healthcheck           = "compute_at_edge_healthcheck"
+    ssl_cert_hostname     = "*.edgecompute.app"
+    auto_loadbalance      = false
+    connect_timeout       = 5000
+    first_byte_timeout    = 120000
+    between_bytes_timeout = 120000
+    error_threshold       = 0
+    override_host         = "polyfill-service.edgecompute.app"
+  }
+
+  healthcheck {
+    name      = "compute_at_edge_healthcheck"
+    host      = "polyfill-service.edgecompute.app"
+    path      = "/__gtg"
+    timeout   = 5000
+    threshold = 2
+    window    = 5
+  }
+
+  backend {
     name                  = "v3_eu"
     address               = "origami-polyfill-service-qa-eu.herokuapp.com"
     port                  = 443

--- a/fastly/vcl/polyfill-service.vcl
+++ b/fastly/vcl/polyfill-service.vcl
@@ -82,6 +82,8 @@ sub vcl_recv {
 	}
 
 
+    # We use this edge dictionary item as a flag for whether to use compute-at-edge for any requests.
+    # If the item is not found, then we default to `"0"`, which we interpret to mean the flag is off.
 	declare local var.compute-at-edge-active BOOL;
 	if (std.atoi(table.lookup(compute_at_edge_config, "active", "0")) == 1) {
 		set var.compute-at-edge-active = true;
@@ -91,8 +93,8 @@ sub vcl_recv {
 	if (var.compute-at-edge-active) {
 		# if the querystring parameter `use-compute-at-edge-backend` is set to yes`
 		# then use the c@e backend.
-		# else if the `use-compute-at-edge-backend` is not set to `no` then make
-		# 1 in 1000 requests which come directly from a client use the c@e backend
+		# The querystring parameter is used within our tests, so that we can confirm 
+		# the compute-at-edge backend is working as we expect it to.
 		declare local var.use-compute-at-edge-backend STRING;
 		set var.use-compute-at-edge-backend = querystring.get(req.url, "use-compute-at-edge-backend");
 		if (var.use-compute-at-edge-backend == "yes" && (std.prefixof(req.url.path, "/v3/polyfill.js") || std.prefixof(req.url.path, "/v3/polyfill.min.js"))) {
@@ -101,9 +103,17 @@ sub vcl_recv {
 				# if using the c@e backend then do not use the cache at all
 				return(pass);
 			}
+        # requests can set the querystring parameter to `no` to avoid ever user compute-at-edge
+        # if the querystring parameter is not set to no, then we run some logic to decide whether
+        # to use compute-at-edge for this request or not.
 		} else if (var.use-compute-at-edge-backend != "no") {
 			declare local var.selected BOOL;
 			set var.selected = randombool(1, std.atoi(table.lookup(compute_at_edge_config, "sample", "1000")));
+			# this logic is saying, only use compute-at-edge for a request which has come from outside this Fastly
+			# service. I.E. The request has directly from a client.
+			# We also have logic which decides how many of those direct client requests use compute-at-edge.
+			# We default to 1 in 1000 requests using compute-at-edge, this can be configured by the edge dictionary
+			# named `compute_at_edge_config` and the item in the dictionary named `sample`
 			if (var.selected && fastly_info.edge.is_tls && !req.is_background_fetch && !req.is_purge && req.restarts == 0 && fastly.ff.visits_this_service == 0 && (std.prefixof(req.url.path, "/v3/polyfill.js") || std.prefixof(req.url.path, "/v3/polyfill.min.js"))) {
 				set req.backend = F_compute_at_edge;
 				if (req.backend.healthy) {

--- a/src/assets/v3/api.njk
+++ b/src/assets/v3/api.njk
@@ -85,6 +85,17 @@ layout: layouts/base.njk
 								E.G.
 								`always,gated`.
 							</dd>
+							<dt>
+								<code>
+									<var>use-compute-at-edge-backend</var>
+								</code>
+							</dt>
+							<dd>
+								Whether to opt-in or opt-out of the new compute-at-edge implemenation of the CDN. Setting this to `yes` will
+								make the request always use the compute-at-edge implementation. Setting this to `no` will make the request
+								never use the compute-at-edge implementation. If this is not set, then the polyfill.io service will decide
+								which implementation to use.
+							</dd>
 						</dl>
 					</td>
 				</tr>

--- a/test/integration/v3/generative.test.js
+++ b/test/integration/v3/generative.test.js
@@ -54,10 +54,12 @@ function arrayToObject(array) {
 	return object;
 }
 
-function createTest(polyfillBundleOptions, ua) {
+function createTest(polyfillBundleOptions, ua, useComputeAtEdgeBackend = false) {
+
 	const qs = querystring.stringify({
 		features: polyfillBundleOptions.join(","),
-		ua
+		ua,
+		'use-compute-at-edge-backend': useComputeAtEdgeBackend ? 'yes' : 'no'
 	});
 	const path = `/v3/polyfill.js?${qs}`;
 	context(host + path, function() {
@@ -110,13 +112,23 @@ async function createFeaturesSet() {
 async function tests() {
 	const features = await createFeaturesSet();
 
-	describe("test combinations of polyfills/aliases", function() {
+	describe("test combinations of polyfills/aliases - vcl service", function() {
 		this.timeout(30 * 1000);
 
 		// Create 1024 random sets of 10 features
 		for (const polyfillBundleOptions of take(1024, sample(10, repeat(Number.POSITIVE_INFINITY, features)))) {
 			const ua = _.sample(browsers);
-			createTest(polyfillBundleOptions.sort(), ua);
+			createTest(polyfillBundleOptions.sort(), ua, false);
+		}
+	});
+
+	describe("test combinations of polyfills/aliases - compute-at-edge service", function() {
+		this.timeout(30 * 1000);
+
+		// Create 1024 random sets of 10 features
+		for (const polyfillBundleOptions of take(1024, sample(10, repeat(Number.POSITIVE_INFINITY, features)))) {
+			const ua = _.sample(browsers);
+			createTest(polyfillBundleOptions.sort(), ua, true);
 		}
 	});
 

--- a/test/integration/v3/polyfill.test.js
+++ b/test/integration/v3/polyfill.test.js
@@ -8,176 +8,304 @@ const vm = require("vm");
 
 const host = require("../helpers").host;
 
-describe("OPTIONS /v3/polyfill.js", function() {
-	this.timeout(30000);
-	it("responds with a 200 status", () => {
-		return request(host)
-			.options("/v3/polyfill.js")
-			.expect(200)
-			.expect("Allow", "OPTIONS, GET, HEAD");
-	});
-});
-
-describe("POST /v3/polyfill.js", function() {
-	this.timeout(30000);
-	it("responds with a 405 status", () => {
-		return request(host)
-			.post("/v3/polyfill.js")
-			.expect(405);
-	});
-});
-
-describe("DELETE /v3/polyfill.js", function() {
-	this.timeout(30000);
-	it("responds with a 405 status", () => {
-		return request(host)
-			.delete("/v3/polyfill.js")
-			.expect(405);
-	});
-});
-
-describe("PURGE /v3/polyfill.js", function() {
-	this.timeout(30000);
-	it("responds with a 401 status", () => {
-		return request(host)
-			.purge("/v3/polyfill.js")
-			.expect(401);
-	});
-});
-
-describe("HEAD /v3/polyfill.js", function() {
-	this.timeout(30000);
-	it("responds with a 200 status", () => {
-		return request(host)
-			.head("/v3/polyfill.js")
-			.set("Fastly-Debug", "true")
-			.expect(200)
-			.expect("Content-Type", "text/javascript; charset=utf-8")
-			.expect("Access-Control-Allow-Origin", "*")
-			.expect("Access-Control-Allow-Methods", "GET,HEAD,OPTIONS")
-			.expect("cache-control", "public, s-maxage=31536000, max-age=604800, stale-while-revalidate=604800, stale-if-error=604800")
-			.expect("surrogate-key", /polyfill-service/);
-	});
-});
-
-describe("GET /v3/polyfill.js", function() {
-	this.timeout(30000);
-	it("responds with a 200 status", () => {
-		return request(host)
-			.get("/v3/polyfill.js")
-			.set("Fastly-Debug", "true")
-			.expect(200)
-			.expect("Content-Type", "text/javascript; charset=utf-8")
-			.expect("Access-Control-Allow-Origin", "*")
-			.expect("Access-Control-Allow-Methods", "GET,HEAD,OPTIONS")
-			.expect("cache-control", "public, s-maxage=31536000, max-age=604800, stale-while-revalidate=604800, stale-if-error=604800")
-			.expect("surrogate-key", /polyfill-service/)
-			.then(response => {
-				assert.isString(response.text);
-				assert.doesNotThrow(() => new vm.Script(response.text));
-				assert.notMatch(response.text, /\/\/#\ssourceMappingURL(.+)/);
-			});
-	});
-});
-
-describe("GET /v3/polyfill.js?features=carrot&strict", function() {
-	this.timeout(30000);
-	it("responds with a 200 status", () => {
-		return request(host)
-			.get("/v3/polyfill.js")
-			.set("Fastly-Debug", "true")
-			.expect(200)
-			.expect("Content-Type", "text/javascript; charset=utf-8")
-			.expect("cache-control", "public, s-maxage=31536000, max-age=604800, stale-while-revalidate=604800, stale-if-error=604800")
-			.expect("surrogate-key", /polyfill-service/)
-			.then(response => {
-				assert.isString(response.text);
-				assert.doesNotThrow(() => new vm.Script(response.text));
-				assert.notMatch(response.text, /\/\/#\ssourceMappingURL(.+)/);
-			});
-	});
-});
-
-describe("GET /v3/polyfill.js?callback=AAA&callback=BBB", function() {
-	this.timeout(30000);
-	it("responds with a 200 status", () => {
-		return request(host)
-			.get("/v3/polyfill.js?callback=AAA&callback=BBB")
-			.set("Fastly-Debug", "true")
-			.expect(200)
-			.expect("Content-Type", "text/javascript; charset=utf-8")
-			.expect("Access-Control-Allow-Origin", "*")
-			.expect("Access-Control-Allow-Methods", "GET,HEAD,OPTIONS")
-			.expect("cache-control", "public, s-maxage=31536000, max-age=604800, stale-while-revalidate=604800, stale-if-error=604800")
-			.expect("surrogate-key", /polyfill-service/)
-			.then(response => {
-				assert.isString(response.text);
-				assert.doesNotThrow(() => new vm.Script(response.text));
-				assert.notMatch(response.text, /\/\/#\ssourceMappingURL(.+)/);
-			});
-	});
-});
-
-describe("GET /v3/polyfill.js?version=hello-i-am-not-a-version", function() {
-	this.timeout(30000);
-	it("responds with a generic message", () => {
-		if (!host.includes('origami-polyfill-service-dev.in.ft.com') && !host.includes('qa.polyfill.io')) {
+describe('vcl service', function() {
+	describe("OPTIONS /v3/polyfill.js", function() {
+		this.timeout(30000);
+		it("responds with a 200 status", () => {
 			return request(host)
-				.get("/v3/polyfill.js?version=hello-i-am-not-a-version")
-				.expect("Content-Type", "text/html; charset=utf-8")
+				.options("/v3/polyfill.js")
+				.expect(200)
+				.expect("Allow", "OPTIONS, GET, HEAD");
+		});
+	});
+
+	describe("POST /v3/polyfill.js", function() {
+		this.timeout(30000);
+		it("responds with a 405 status", () => {
+			return request(host)
+				.post("/v3/polyfill.js")
+				.expect(405);
+		});
+	});
+
+	describe("DELETE /v3/polyfill.js", function() {
+		this.timeout(30000);
+		it("responds with a 405 status", () => {
+			return request(host)
+				.delete("/v3/polyfill.js")
+				.expect(405);
+		});
+	});
+
+	describe("PURGE /v3/polyfill.js", function() {
+		this.timeout(30000);
+		it("responds with a 401 status", () => {
+			return request(host)
+				.purge("/v3/polyfill.js")
+				.expect(401);
+		});
+	});
+
+	describe("HEAD /v3/polyfill.js", function() {
+		this.timeout(30000);
+		it("responds with a 200 status", () => {
+			return request(host)
+				.head("/v3/polyfill.js")
+				.set("Fastly-Debug", "true")
+				.expect(200)
+				.expect("Content-Type", "text/javascript; charset=utf-8")
+				.expect("Access-Control-Allow-Origin", "*")
+				.expect("Access-Control-Allow-Methods", "GET,HEAD,OPTIONS")
+				.expect("cache-control", "public, s-maxage=31536000, max-age=604800, stale-while-revalidate=604800, stale-if-error=604800")
+				.expect("surrogate-key", /polyfill-service/);
+		});
+	});
+
+	describe("GET /v3/polyfill.js", function() {
+		this.timeout(30000);
+		it("responds with a 200 status", () => {
+			return request(host)
+				.get("/v3/polyfill.js")
+				.set("Fastly-Debug", "true")
+				.expect(200)
+				.expect("Content-Type", "text/javascript; charset=utf-8")
+				.expect("Access-Control-Allow-Origin", "*")
+				.expect("Access-Control-Allow-Methods", "GET,HEAD,OPTIONS")
+				.expect("cache-control", "public, s-maxage=31536000, max-age=604800, stale-while-revalidate=604800, stale-if-error=604800")
+				.expect("surrogate-key", /polyfill-service/)
 				.then(response => {
-					assert.deepEqual(response.text, 'requested version does not exist')
+					assert.isString(response.text);
+					assert.doesNotThrow(() => new vm.Script(response.text));
+					assert.notMatch(response.text, /\/\/#\ssourceMappingURL(.+)/);
 				});
-		}
+		});
+	});
+
+	describe("GET /v3/polyfill.js?features=carrot&strict", function() {
+		this.timeout(30000);
+		it("responds with a 200 status", () => {
+			return request(host)
+				.get("/v3/polyfill.js?features=carrot&strict")
+				.set("Fastly-Debug", "true")
+				.expect(200)
+				.expect("Content-Type", "text/javascript; charset=utf-8")
+				.expect("cache-control", "public, s-maxage=31536000, max-age=604800, stale-while-revalidate=604800, stale-if-error=604800")
+				.expect("surrogate-key", /polyfill-service/)
+				.then(response => {
+					assert.isString(response.text);
+					assert.doesNotThrow(() => new vm.Script(response.text));
+					assert.notMatch(response.text, /\/\/#\ssourceMappingURL(.+)/);
+				});
+		});
+	});
+
+	describe("GET /v3/polyfill.js?callback=AAA&callback=BBB", function() {
+		this.timeout(30000);
+		it("responds with a 200 status", () => {
+			return request(host)
+				.get("/v3/polyfill.js?callback=AAA&callback=BBB")
+				.set("Fastly-Debug", "true")
+				.expect(200)
+				.expect("Content-Type", "text/javascript; charset=utf-8")
+				.expect("Access-Control-Allow-Origin", "*")
+				.expect("Access-Control-Allow-Methods", "GET,HEAD,OPTIONS")
+				.expect("cache-control", "public, s-maxage=31536000, max-age=604800, stale-while-revalidate=604800, stale-if-error=604800")
+				.expect("surrogate-key", /polyfill-service/)
+				.then(response => {
+					assert.isString(response.text);
+					assert.doesNotThrow(() => new vm.Script(response.text));
+					assert.notMatch(response.text, /\/\/#\ssourceMappingURL(.+)/);
+				});
+		});
+	});
+
+	describe("GET /v3/polyfill.js?version=hello-i-am-not-a-version", function() {
+		this.timeout(30000);
+		it("responds with a generic message", () => {
+			if (!host.includes('origami-polyfill-service-dev.in.ft.com') && !host.includes('qa.polyfill.io')) {
+				return request(host)
+					.get("/v3/polyfill.js?version=hello-i-am-not-a-version")
+					.expect("Content-Type", "text/html; charset=utf-8")
+					.then(response => {
+						assert.deepEqual(response.text, 'requested version does not exist')
+					});
+			}
+		});
+	});
+
+	describe("encoding", function() {
+		this.timeout(30000);
+		it("responds with no compression if client does not accept compressed responses", () => {
+			return request(host)
+				.get("/v3/polyfill.js")
+				.set("Fastly-Debug", "true")
+				.set("Accept-Encoding", "identity")
+				.expect("Vary", "User-Agent, Accept-Encoding")
+				.then(response => {
+					assert.equal(response.headers["content-encoding"], undefined);
+				});
+		});
+
+		it("responds with gzip compression if client accepts gzip compressed responses", () => {
+			return request(host)
+				.get("/v3/polyfill.js")
+				.set("Fastly-Debug", "true")
+				.set("Accept-Encoding", "gzip")
+				.expect("Vary", "User-Agent, Accept-Encoding")
+				.expect("Content-Encoding", "gzip");
+		});
+
+		it("responds with gzip compression if client accepts gzip and deflate compressed responses", () => {
+			return request(host)
+				.get("/v3/polyfill.js")
+				.set("Fastly-Debug", "true")
+				.set("Accept-Encoding", "gzip, deflate")
+				.expect("Vary", "User-Agent, Accept-Encoding")
+				.expect("Content-Encoding", "gzip");
+		});
+
+		it("responds with brotli compression if client accepts brotli compressed responses", () => {
+			return request(host)
+				.get("/v3/polyfill.js")
+				.set("Fastly-Debug", "true")
+				.set("Accept-Encoding", "br")
+				.expect("Vary", "User-Agent, Accept-Encoding")
+				.expect("Content-Encoding", "br");
+		});
+
+		it("responds with brotli compression if client accepts brotli and gzip compressed responses", () => {
+			return request(host)
+				.get("/v3/polyfill.js")
+				.set("Fastly-Debug", "true")
+				.set("Accept-Encoding", "br, gzip")
+				.expect("Vary", "User-Agent, Accept-Encoding")
+				.expect("Content-Encoding", "br");
+		});
 	});
 });
 
-describe("encoding", function() {
-	this.timeout(30000);
-	it("responds with no compression if client does not accept compressed responses", () => {
-		return request(host)
-			.get("/v3/polyfill.js")
-			.set("Fastly-Debug", "true")
-			.set("Accept-Encoding", "identity")
-			.expect("Vary", "User-Agent, Accept-Encoding")
-			.then(response => {
-				assert.equal(response.headers["content-encoding"], undefined);
-			});
+describe('compute-at-edge service', function() {
+	describe("OPTIONS /v3/polyfill.js?use-compute-at-edge-backend=yes", function() {
+		this.timeout(30000);
+		it("responds with a 200 status", () => {
+			return request(host)
+				.options(`/v3/polyfill.js?use-compute-at-edge-backend=yes`)
+				.expect(200)
+				.expect('allow', "OPTIONS, GET, HEAD");
+		});
 	});
 
-	it("responds with gzip compression if client accepts gzip compressed responses", () => {
-		return request(host)
-			.get("/v3/polyfill.js")
-			.set("Fastly-Debug", "true")
-			.set("Accept-Encoding", "gzip")
-			.expect("Vary", "User-Agent, Accept-Encoding")
-			.expect("Content-Encoding", "gzip");
+	describe("POST /v3/polyfill.js?use-compute-at-edge-backend=yes", function() {
+		this.timeout(30000);
+		it("responds with a 405 status", () => {
+			return request(host)
+				.post(`/v3/polyfill.js?use-compute-at-edge-backend=yes`)
+				.expect(405);
+		});
 	});
 
-	it("responds with gzip compression if client accepts gzip and deflate compressed responses", () => {
-		return request(host)
-			.get("/v3/polyfill.js")
-			.set("Fastly-Debug", "true")
-			.set("Accept-Encoding", "gzip, deflate")
-			.expect("Vary", "User-Agent, Accept-Encoding")
-			.expect("Content-Encoding", "gzip");
+	describe("DELETE /v3/polyfill.js?use-compute-at-edge-backend=yes", function() {
+		this.timeout(30000);
+		it("responds with a 405 status", () => {
+			return request(host)
+				.delete("/v3/polyfill.js?use-compute-at-edge-backend=yes")
+				.expect(405);
+		});
 	});
 
-	it("responds with brotli compression if client accepts brotli compressed responses", () => {
-		return request(host)
-			.get("/v3/polyfill.js")
-			.set("Fastly-Debug", "true")
-			.set("Accept-Encoding", "br")
-			.expect("Vary", "User-Agent, Accept-Encoding")
-			.expect("Content-Encoding", "br");
+	describe("PURGE /v3/polyfill.js?use-compute-at-edge-backend=yes", function() {
+		this.timeout(30000);
+		it("responds with a 401 status", () => {
+			return request(host)
+				.purge("/v3/polyfill.js?use-compute-at-edge-backend=yes")
+				.expect(401);
+		});
 	});
 
-	it("responds with brotli compression if client accepts brotli and gzip compressed responses", () => {
-		return request(host)
-			.get("/v3/polyfill.js")
-			.set("Fastly-Debug", "true")
-			.set("Accept-Encoding", "br, gzip")
-			.expect("Vary", "User-Agent, Accept-Encoding")
-			.expect("Content-Encoding", "br");
+	describe("HEAD /v3/polyfill.js?use-compute-at-edge-backend=yes", function() {
+		this.timeout(30000);
+		it("responds with a 200 status", () => {
+			return request(host)
+				.head("/v3/polyfill.js?use-compute-at-edge-backend=yes")
+				.set("Fastly-Debug", "true")
+				.expect(200)
+				.expect("Content-Type", "text/javascript; charset=utf-8")
+				.expect("Access-Control-Allow-Origin", "*")
+				.expect("Access-Control-Allow-Methods", "GET,HEAD,OPTIONS")
+				.expect("cache-control", "public, s-maxage=31536000, max-age=604800, stale-while-revalidate=604800, stale-if-error=604800")
+				.expect("surrogate-key", /polyfill-service/);
+		});
+	});
+
+	describe("GET /v3/polyfill.js?use-compute-at-edge-backend=yes", function() {
+		this.timeout(30000);
+		it("responds with a 200 status", () => {
+			return request(host)
+				.get("/v3/polyfill.js?use-compute-at-edge-backend=yes")
+				.set("Fastly-Debug", "true")
+				.expect(200)
+				.expect("Content-Type", "text/javascript; charset=utf-8")
+				.expect("Access-Control-Allow-Origin", "*")
+				.expect("Access-Control-Allow-Methods", "GET,HEAD,OPTIONS")
+				.expect("cache-control", "public, s-maxage=31536000, max-age=604800, stale-while-revalidate=604800, stale-if-error=604800")
+				.expect("surrogate-key", /polyfill-service/)
+				.then(response => {
+					assert.isString(response.text);
+					assert.doesNotThrow(() => new vm.Script(response.text));
+					assert.notMatch(response.text, /\/\/#\ssourceMappingURL(.+)/);
+				});
+		});
+	});
+
+	describe("GET /v3/polyfill.js?features=carrot&strict", function() {
+		this.timeout(30000);
+		it("responds with a 200 status", () => {
+			return request(host)
+				.get("/v3/polyfill.js?features=carrot&strict&use-compute-at-edge-backend=yes")
+				.set("Fastly-Debug", "true")
+				.expect(200)
+				.expect("Content-Type", "text/javascript; charset=utf-8")
+				.expect("cache-control", "public, s-maxage=31536000, max-age=604800, stale-while-revalidate=604800, stale-if-error=604800")
+				.expect("surrogate-key", /polyfill-service/)
+				.then(response => {
+					assert.isString(response.text);
+					assert.doesNotThrow(() => new vm.Script(response.text));
+					assert.notMatch(response.text, /\/\/#\ssourceMappingURL(.+)/);
+				});
+		});
+	});
+
+	describe("GET /v3/polyfill.js?callback=AAA&callback=BBB&use-compute-at-edge-backend=yes", function() {
+		this.timeout(30000);
+		it("responds with a 200 status", () => {
+			return request(host)
+				.get("/v3/polyfill.js?callback=AAA&callback=BBB&use-compute-at-edge-backend=yes")
+				.set("Fastly-Debug", "true")
+				.expect(200)
+				.expect("Content-Type", "text/javascript; charset=utf-8")
+				.expect("Access-Control-Allow-Origin", "*")
+				.expect("Access-Control-Allow-Methods", "GET,HEAD,OPTIONS")
+				.expect("cache-control", "public, s-maxage=31536000, max-age=604800, stale-while-revalidate=604800, stale-if-error=604800")
+				.expect("surrogate-key", /polyfill-service/)
+				.then(response => {
+					assert.isString(response.text);
+					assert.doesNotThrow(() => new vm.Script(response.text));
+					assert.notMatch(response.text, /\/\/#\ssourceMappingURL(.+)/);
+				});
+		});
+	});
+
+	describe("GET /v3/polyfill.js?version=hello-i-am-not-a-version&use-compute-at-edge-backend=yes", function() {
+		this.timeout(30000);
+		it("responds with a generic message", () => {
+			if (!host.includes('origami-polyfill-service-dev.in.ft.com') && !host.includes('qa.polyfill.io')) {
+				return request(host)
+					.get("/v3/polyfill.js?version=hello-i-am-not-a-version&use-compute-at-edge-backend=yes")
+					.expect("Content-Type", "text/html; charset=utf-8")
+					.then(response => {
+						assert.deepEqual(response.text, 'requested version does not exist')
+					});
+			}
+		});
 	});
 });


### PR DESCRIPTION
The code for the compute-at-edge implementation is at https://github.com/Financial-Times/polyfill-c-e

We have ported the VCL to JavaScript using Fastly's Compute@Edge
platform. The port currently only contains the logic for the /v3/polyfill
endpoint.

We are going to roll out this change to 1 in 1000 requests by default.

We stop all requests from using the compute-at-edge backend by updating
the item named `active` in the Edge Dictionary `compute_at_edge_config`
from `"1"` to `"0"`. This can be done without a deployment and so will have
effect within a few seconds.

Websites can opt-out from using the compute-at-edge implementation
by setting the querystring parameter `use-compute-at-edge-backend` to `no`.

Websites can opt-in to always using the compute-at-edge implementation
by setting the querystring parameter `use-compute-at-edge-backend` to `yes`.

When the compute-at-edge implementation is used, we will not cache the
response within the VCL cache because the compute-at-edge implementation
will handle it's own cache.

If the compute-at-edge implementation returns an error or is not
responding, the VCL implementation will automatically be used instead.