### PR TITLE
migrate to the latest version of the fastly terraform provider

### DIFF
--- a/.github/workflows/deploy-to-dev-and-test.yml
+++ b/.github/workflows/deploy-to-dev-and-test.yml
@@ -1,7 +1,7 @@
 name: Deploy to dev and test
 on: [pull_request]
 env:
-  terraform_version: '0.12.29'
+  terraform_version: '1.1.7'
   terraform_working_dir: 'fastly/terraform/'
   fastly_service_id: ${{ secrets.FASTLY_SERVICE_ID_DEV }}
   domain: origami-polyfill-service-dev.in.ft.com
@@ -80,7 +80,7 @@ jobs:
           tf_actions_subcommand: 'import'
           tf_actions_working_dir: ${{ env.terraform_working_dir }}
           tf_actions_comment: false
-          args: 'fastly_service_v1.app ${{ env.fastly_service_id }}'
+          args: 'fastly_service_vcl.app ${{ env.fastly_service_id }}'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FASTLY_API_KEY: ${{ secrets.FASTLY_API_KEY }}
@@ -92,7 +92,7 @@ jobs:
           tf_actions_subcommand: 'import'
           tf_actions_working_dir: ${{ env.terraform_working_dir }}
           tf_actions_comment: false
-          args: 'fastly_service_dictionary_items_v1.toppops_config_items "${{ env.fastly_service_id }}/2RYpb2YAbYtpjSjwok0VWc"'
+          args: 'fastly_service_dictionary_items.toppops_config_items "${{ env.fastly_service_id }}/2RYpb2YAbYtpjSjwok0VWc"'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FASTLY_API_KEY: ${{ secrets.FASTLY_API_KEY }}
@@ -104,7 +104,7 @@ jobs:
           tf_actions_subcommand: 'import'
           tf_actions_working_dir: ${{ env.terraform_working_dir }}
           tf_actions_comment: false
-          args: 'fastly_service_dictionary_items_v1.compute_at_edge_config_items "${{ env.fastly_service_id }}/2IoLgAUsrJOW8pU8FOQuyg"'
+          args: 'fastly_service_dictionary_items.compute_at_edge_config_items "${{ env.fastly_service_id }}/2IoLgAUsrJOW8pU8FOQuyg"'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FASTLY_API_KEY: ${{ secrets.FASTLY_API_KEY }}

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -5,7 +5,7 @@ on:
 env:
   eu_app: origami-polyfill-service-eu
   us_app: origami-polyfill-service-us
-  terraform_version: '0.12.29'
+  terraform_version: '1.1.7'
   terraform_working_dir: 'fastly/terraform/'
   fastly_service_id: ${{ secrets.FASTLY_SERVICE_ID_PROD }}
   domain: cdn.polyfill.io
@@ -55,7 +55,7 @@ jobs:
         tf_actions_subcommand: 'import'
         tf_actions_working_dir: ${{ env.terraform_working_dir }}
         tf_actions_comment: true
-        args: 'fastly_service_v1.app ${{ env.fastly_service_id }}'
+        args: 'fastly_service_vcl.app ${{ env.fastly_service_id }}'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         FASTLY_API_KEY: ${{ secrets.FASTLY_API_KEY_PROD }}
@@ -67,7 +67,7 @@ jobs:
         tf_actions_subcommand: 'import'
         tf_actions_working_dir: ${{ env.terraform_working_dir }}
         tf_actions_comment: true
-        args: 'fastly_service_dictionary_items_v1.toppops_config_items "${{ env.fastly_service_id }}/3t3bjgcYBnC8nfCHM60Hay"'
+        args: 'fastly_service_dictionary_items.toppops_config_items "${{ env.fastly_service_id }}/3t3bjgcYBnC8nfCHM60Hay"'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         FASTLY_API_KEY: ${{ secrets.FASTLY_API_KEY_PROD }}
@@ -79,7 +79,7 @@ jobs:
         tf_actions_subcommand: 'import'
         tf_actions_working_dir: ${{ env.terraform_working_dir }}
         tf_actions_comment: true
-        args: 'fastly_service_dictionary_items_v1.compute_at_edge_config_items "${{ env.fastly_service_id }}/5E74ZKOhK81rU53qOP4X4U"'
+        args: 'fastly_service_dictionary_items.compute_at_edge_config_items "${{ env.fastly_service_id }}/5E74ZKOhK81rU53qOP4X4U"'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         FASTLY_API_KEY: ${{ secrets.FASTLY_API_KEY_PROD }}

--- a/.github/workflows/deploy-to-staging-and-test.yml
+++ b/.github/workflows/deploy-to-staging-and-test.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches: [ master ]
 env:
-  terraform_version: '0.12.29'
+  terraform_version: '1.1.7'
   terraform_working_dir: 'fastly/terraform/'
   fastly_service_id: ${{ secrets.FASTLY_SERVICE_ID_STAGING }}
   domain: qa.polyfill.io
@@ -53,7 +53,7 @@ jobs:
         tf_actions_subcommand: 'import'
         tf_actions_working_dir: ${{ env.terraform_working_dir }}
         tf_actions_comment: true
-        args: 'fastly_service_v1.app ${{ env.fastly_service_id }}'
+        args: 'fastly_service_vcl.app ${{ env.fastly_service_id }}'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         FASTLY_API_KEY: ${{ secrets.FASTLY_API_KEY_STAGING }}
@@ -65,7 +65,7 @@ jobs:
         tf_actions_subcommand: 'import'
         tf_actions_working_dir: ${{ env.terraform_working_dir }}
         tf_actions_comment: true
-        args: 'fastly_service_dictionary_items_v1.toppops_config_items "${{ env.fastly_service_id }}/4dfSlimwvlJELO6htcnGsi"'
+        args: 'fastly_service_dictionary_items.toppops_config_items "${{ env.fastly_service_id }}/4dfSlimwvlJELO6htcnGsi"'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         FASTLY_API_KEY: ${{ secrets.FASTLY_API_KEY_STAGING }}
@@ -77,7 +77,7 @@ jobs:
         tf_actions_subcommand: 'import'
         tf_actions_working_dir: ${{ env.terraform_working_dir }}
         tf_actions_comment: true
-        args: 'fastly_service_dictionary_items_v1.compute_at_edge_config_items "${{ env.fastly_service_id }}/6J7j8CkzoO7BsnE8iNl4uG"'
+        args: 'fastly_service_dictionary_items.compute_at_edge_config_items "${{ env.fastly_service_id }}/6J7j8CkzoO7BsnE8iNl4uG"'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         FASTLY_API_KEY: ${{ secrets.FASTLY_API_KEY_STAGING }}

--- a/fastly/terraform/dev_override.tf
+++ b/fastly/terraform/dev_override.tf
@@ -1,4 +1,4 @@
-resource "fastly_service_v1" "app" {
+resource "fastly_service_vcl" "app" {
   name = "origami-polyfill-service-dev.in.ft.com"
 
   domain {

--- a/fastly/terraform/main.tf
+++ b/fastly/terraform/main.tf
@@ -1,12 +1,17 @@
-provider "fastly" {
-  version = "0.11.1"
+terraform {
+  required_providers {
+    fastly = {
+      source  = "fastly/fastly"
+      version = "1.1.2"
+    }
+  }
 }
 
 output "service_id" {
-  value = ["${fastly_service_v1.app.id}"]
+  value = ["${fastly_service_vcl.app.id}"]
 }
 
-resource "fastly_service_v1" "app" {
+resource "fastly_service_vcl" "app" {
   name = "placeholder"
 
   force_destroy = false
@@ -71,9 +76,9 @@ resource "fastly_service_v1" "app" {
   }
 }
 
-resource "fastly_service_dictionary_items_v1" "toppops_config_items" {
-  service_id    = fastly_service_v1.app.id
-  dictionary_id = { for dictionary in fastly_service_v1.app.dictionary : dictionary.name => dictionary.dictionary_id }["toppops_config"]
+resource "fastly_service_dictionary_items" "toppops_config_items" {
+  service_id    = fastly_service_vcl.app.id
+  dictionary_id = { for dictionary in fastly_service_vcl.app.dictionary : dictionary.name => dictionary.dictionary_id }["toppops_config"]
 
   items = {
   }
@@ -83,9 +88,9 @@ resource "fastly_service_dictionary_items_v1" "toppops_config_items" {
   }
 }
 
-resource "fastly_service_dictionary_items_v1" "compute_at_edge_config_items" {
-  service_id    = fastly_service_v1.app.id
-  dictionary_id = { for dictionary in fastly_service_v1.app.dictionary : dictionary.name => dictionary.dictionary_id }["compute_at_edge_config"]
+resource "fastly_service_dictionary_items" "compute_at_edge_config_items" {
+  service_id    = fastly_service_vcl.app.id
+  dictionary_id = { for dictionary in fastly_service_vcl.app.dictionary : dictionary.name => dictionary.dictionary_id }["compute_at_edge_config"]
 
   items = {
   }

--- a/fastly/terraform/production_override.tf
+++ b/fastly/terraform/production_override.tf
@@ -1,4 +1,4 @@
-resource "fastly_service_v1" "app" {
+resource "fastly_service_vcl" "app" {
   name = "cdn.polyfill.io"
 
   domain {

--- a/fastly/terraform/qa_override.tf
+++ b/fastly/terraform/qa_override.tf
@@ -1,4 +1,4 @@
-resource "fastly_service_v1" "app" {
+resource "fastly_service_vcl" "app" {
   name = "qa.polyfill.io"
 
   domain {


### PR DESCRIPTION
this was done by following the migration guide posted at https://registry.terraform.io/providers/fastly/fastly/latest/docs/guides/migration-guide-1.0.0