### PR TITLE
move to honojs instead of flight-path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,9 +30,9 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3.1.0
     - name: Set up Fastly CLI
-      uses: fastly/compute-actions/setup@main
+      uses: fastly/compute-actions/setup@v2
       with:
-        cli_version: '1.7.0'
+        token: ${{ secrets.GITHUB_TOKEN }}
     - run: npm i
     - run: npm run build
     - run: npm i

--- a/fastly/c-at-e/.eslintrc.cjs
+++ b/fastly/c-at-e/.eslintrc.cjs
@@ -1,14 +1,15 @@
 module.exports = {
 	"root": true,
-    "env": {
-        "es2022": true
-    },
-    "extends": "eslint:recommended",
-    "parserOptions": {
-        "ecmaVersion": 13,
-        "sourceType": "module"
-    },
-    "rules": {
-        "no-cond-assign": "off"
-    }
+	"env": {
+		"es2022": true,
+		"serviceworker": true
+	},
+	"extends": "eslint:recommended",
+	"parserOptions": {
+		"ecmaVersion": 13,
+		"sourceType": "module"
+	},
+	"rules": {
+		"no-cond-assign": "off"
+	}
 };

--- a/fastly/c-at-e/package-lock.json
+++ b/fastly/c-at-e/package-lock.json
@@ -8,9 +8,9 @@
 			"name": "polyfill-service",
 			"version": "1.0.0",
 			"dependencies": {
-				"@fastly/js-compute": "0.2.4",
+				"@fastly/js-compute": "^0.5.3",
 				"@financial-times/polyfill-useragent-normaliser": "^1.10.2",
-				"flight-path": "^1.0.11"
+				"hono": "^2.2.1"
 			},
 			"devDependencies": {
 				"axios": "^0.26.0",
@@ -45,11 +45,17 @@
 			}
 		},
 		"node_modules/@fastly/js-compute": {
-			"version": "0.2.4",
-			"resolved": "https://registry.npmjs.org/@fastly/js-compute/-/js-compute-0.2.4.tgz",
-			"integrity": "sha512-2e26D/2FiIF7W0eahvlp7NAoLwKTNdMi75W9vjaNbpUf2RPiYS0TkNvp5zJ4QlYF7h55ocKE4oM8iTTDYXfmZA==",
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/@fastly/js-compute/-/js-compute-0.5.3.tgz",
+			"integrity": "sha512-4ZZJzLX1/egi3307a80nnc8c+0O5YTQ0gljbMLSxjQPcSSMqpDAkVah9E42Ec0dvPIG7e9+vgGf7r50wMezAVw==",
+			"dependencies": {
+				"typedoc-loopingz-theme": "^1.1.3"
+			},
 			"bin": {
 				"js-compute-runtime": "js-compute-runtime-cli.js"
+			},
+			"engines": {
+				"node": "^16 || ^18"
 			}
 		},
 		"node_modules/@financial-times/polyfill-useragent-normaliser": {
@@ -244,8 +250,7 @@
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
 		},
 		"node_modules/binary-extensions": {
 			"version": "2.2.0",
@@ -266,7 +271,6 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dev": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -465,26 +469,7 @@
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-			"dev": true
-		},
-		"node_modules/cookie": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-			"integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/core-js": {
-			"version": "3.21.1",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.21.1.tgz",
-			"integrity": "sha512-FRq5b/VMrWlrmCzwRrpDYNxyHP9BcAZC+xHJaqTgIE5091ZV1NTmyh0sGOg5XqpnHvR0svdy0sv1gWA1zmhxig==",
-			"hasInstallScript": true,
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/core-js"
-			}
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.3",
@@ -1303,16 +1288,6 @@
 			"integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
 			"dev": true
 		},
-		"node_modules/flight-path": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/flight-path/-/flight-path-1.0.11.tgz",
-			"integrity": "sha512-ZbL50z5mhu01R+lLmY4+4V8dW84JcJBs6g/ttXkuESPVvoaYYhmD4xKMkIVnsXC+h4HEqQr3aOTnDqWIi1pe8w==",
-			"dependencies": {
-				"@fastly/js-compute": "^0.2.0",
-				"cookie": "^0.4.1",
-				"core-js": "^3.19.0"
-			}
-		},
 		"node_modules/follow-redirects": {
 			"version": "1.14.9",
 			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
@@ -1348,8 +1323,7 @@
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-			"dev": true
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"node_modules/fsevents": {
 			"version": "2.3.2",
@@ -1432,7 +1406,6 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
 			"integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-			"dev": true,
 			"dependencies": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -1488,6 +1461,26 @@
 			"dev": true,
 			"engines": {
 				"node": ">=4.x"
+			}
+		},
+		"node_modules/handlebars": {
+			"version": "4.7.7",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+			"integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+			"dependencies": {
+				"minimist": "^1.2.5",
+				"neo-async": "^2.6.0",
+				"source-map": "^0.6.1",
+				"wordwrap": "^1.0.0"
+			},
+			"bin": {
+				"handlebars": "bin/handlebars"
+			},
+			"engines": {
+				"node": ">=0.4.7"
+			},
+			"optionalDependencies": {
+				"uglify-js": "^3.1.4"
 			}
 		},
 		"node_modules/has": {
@@ -1556,6 +1549,14 @@
 				"he": "bin/he"
 			}
 		},
+		"node_modules/hono": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/hono/-/hono-2.2.1.tgz",
+			"integrity": "sha512-tlawHM4uOMt41jibUF0fRYxUs3vibKzO1Ihuk/MohpUrkRc4fQo1n9+jLRKIC/8d0lLLW/CPWR/iItcf2HUv3A==",
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
 		"node_modules/hosted-git-info": {
 			"version": "2.8.9",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
@@ -1615,7 +1616,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"dev": true,
 			"dependencies": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -1624,8 +1624,7 @@
 		"node_modules/inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
 		"node_modules/internal-slot": {
 			"version": "1.0.3",
@@ -1957,6 +1956,11 @@
 			"deprecated": "Please use the native JSON object instead of JSON 3",
 			"dev": true
 		},
+		"node_modules/jsonc-parser": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+			"integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
+		},
 		"node_modules/lazy-ass": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
@@ -2048,11 +2052,27 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/lunr": {
+			"version": "2.3.9",
+			"resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+			"integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow=="
+		},
 		"node_modules/map-stream": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
 			"integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
 			"dev": true
+		},
+		"node_modules/marked": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-4.1.0.tgz",
+			"integrity": "sha512-+Z6KDjSPa6/723PQYyc1axYZpYYpDnECDaU6hkaf5gqBieBkMKYReL5hteF2QizhlMbgbo8umXl/clZ67+GlsA==",
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 12"
+			}
 		},
 		"node_modules/memorystream": {
 			"version": "0.3.1",
@@ -2082,7 +2102,6 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
 			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dev": true,
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -2093,8 +2112,7 @@
 		"node_modules/minimist": {
 			"version": "1.2.6",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-			"dev": true
+			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
 		},
 		"node_modules/mocha": {
 			"version": "9.2.2",
@@ -2218,6 +2236,11 @@
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
 			"dev": true
+		},
+		"node_modules/neo-async": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
 		},
 		"node_modules/nice-try": {
 			"version": "1.0.5",
@@ -2476,7 +2499,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
 			"dependencies": {
 				"wrappy": "1"
 			}
@@ -2581,7 +2603,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -2681,6 +2702,14 @@
 			},
 			"engines": {
 				"node": ">=0.10"
+			}
+		},
+		"node_modules/progress": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+			"engines": {
+				"node": ">=0.4.0"
 			}
 		},
 		"node_modules/ps-tree": {
@@ -2883,6 +2912,16 @@
 			"integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
 			"dev": true
 		},
+		"node_modules/shiki": {
+			"version": "0.9.15",
+			"resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.15.tgz",
+			"integrity": "sha512-/Y0z9IzhJ8nD9nbceORCqu6NgT9X6I8Fk8c3SICHI5NbZRLdZYFaB233gwct9sU0vvSypyaL/qaKvzyQGJBZSw==",
+			"dependencies": {
+				"jsonc-parser": "^3.0.0",
+				"vscode-oniguruma": "^1.6.1",
+				"vscode-textmate": "5.2.0"
+			}
+		},
 		"node_modules/side-channel": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -2902,6 +2941,14 @@
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
 			"dev": true
+		},
+		"node_modules/source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
 		"node_modules/spdx-correct": {
 			"version": "3.1.1",
@@ -3173,6 +3220,75 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/typedoc": {
+			"version": "0.21.10",
+			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.21.10.tgz",
+			"integrity": "sha512-Y0wYIehkjkPfsp3pv86fp3WPHUcOf8pnQUDLwG1PqSccUSqdsv7Pz1Gd5WrTJvXQB2wO1mKlZ8qW8qMiopKyjA==",
+			"dependencies": {
+				"glob": "^7.1.7",
+				"handlebars": "^4.7.7",
+				"lunr": "^2.3.9",
+				"marked": "^4.0.10",
+				"minimatch": "^3.0.0",
+				"progress": "^2.0.3",
+				"shiki": "^0.9.8",
+				"typedoc-default-themes": "^0.12.10"
+			},
+			"bin": {
+				"typedoc": "bin/typedoc"
+			},
+			"engines": {
+				"node": ">= 12.10.0"
+			},
+			"peerDependencies": {
+				"typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x"
+			}
+		},
+		"node_modules/typedoc-default-themes": {
+			"version": "0.12.10",
+			"resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.12.10.tgz",
+			"integrity": "sha512-fIS001cAYHkyQPidWXmHuhs8usjP5XVJjWB8oZGqkTowZaz3v7g3KDZeeqE82FBrmkAnIBOY3jgy7lnPnqATbA==",
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/typedoc-loopingz-theme": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/typedoc-loopingz-theme/-/typedoc-loopingz-theme-1.1.3.tgz",
+			"integrity": "sha512-9aqk1D0TNQRXroqYhNpUndsARND2PeQ7l0WUWFZz+5DSq00jXib+lauF7hmrQOIRukJnoA1ssUsy6C4X0qEjxA==",
+			"dependencies": {
+				"lunr": "^2.3.8",
+				"typedoc": "~0.21.9"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/typescript": {
+			"version": "4.4.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+			"integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+			"peer": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=4.2.0"
+			}
+		},
+		"node_modules/uglify-js": {
+			"version": "3.17.1",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.1.tgz",
+			"integrity": "sha512-+juFBsLLw7AqMaqJ0GFvlsGZwdQfI2ooKQB39PSBgMnMakcFosi9O8jCwE+2/2nMNcc0z63r9mwjoDG8zr+q0Q==",
+			"optional": true,
+			"bin": {
+				"uglifyjs": "bin/uglifyjs"
+			},
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
 		"node_modules/unbox-primitive": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
@@ -3236,6 +3352,16 @@
 				"spdx-correct": "^3.0.0",
 				"spdx-expression-parse": "^3.0.0"
 			}
+		},
+		"node_modules/vscode-oniguruma": {
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
+			"integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA=="
+		},
+		"node_modules/vscode-textmate": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+			"integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ=="
 		},
 		"node_modules/wait-on": {
 			"version": "6.0.0",
@@ -3305,6 +3431,11 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/wordwrap": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+			"integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
+		},
 		"node_modules/workerpool": {
 			"version": "6.2.0",
 			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
@@ -3331,8 +3462,7 @@
 		"node_modules/wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"node_modules/y18n": {
 			"version": "5.0.8",
@@ -3422,9 +3552,12 @@
 			}
 		},
 		"@fastly/js-compute": {
-			"version": "0.2.4",
-			"resolved": "https://registry.npmjs.org/@fastly/js-compute/-/js-compute-0.2.4.tgz",
-			"integrity": "sha512-2e26D/2FiIF7W0eahvlp7NAoLwKTNdMi75W9vjaNbpUf2RPiYS0TkNvp5zJ4QlYF7h55ocKE4oM8iTTDYXfmZA=="
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/@fastly/js-compute/-/js-compute-0.5.3.tgz",
+			"integrity": "sha512-4ZZJzLX1/egi3307a80nnc8c+0O5YTQ0gljbMLSxjQPcSSMqpDAkVah9E42Ec0dvPIG7e9+vgGf7r50wMezAVw==",
+			"requires": {
+				"typedoc-loopingz-theme": "^1.1.3"
+			}
 		},
 		"@financial-times/polyfill-useragent-normaliser": {
 			"version": "1.10.2",
@@ -3585,8 +3718,7 @@
 		"balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
 		},
 		"binary-extensions": {
 			"version": "2.2.0",
@@ -3604,7 +3736,6 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -3738,18 +3869,7 @@
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-			"dev": true
-		},
-		"cookie": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-			"integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA=="
-		},
-		"core-js": {
-			"version": "3.21.1",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.21.1.tgz",
-			"integrity": "sha512-FRq5b/VMrWlrmCzwRrpDYNxyHP9BcAZC+xHJaqTgIE5091ZV1NTmyh0sGOg5XqpnHvR0svdy0sv1gWA1zmhxig=="
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"cross-spawn": {
 			"version": "7.0.3",
@@ -4270,16 +4390,6 @@
 			"integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
 			"dev": true
 		},
-		"flight-path": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/flight-path/-/flight-path-1.0.11.tgz",
-			"integrity": "sha512-ZbL50z5mhu01R+lLmY4+4V8dW84JcJBs6g/ttXkuESPVvoaYYhmD4xKMkIVnsXC+h4HEqQr3aOTnDqWIi1pe8w==",
-			"requires": {
-				"@fastly/js-compute": "^0.2.0",
-				"cookie": "^0.4.1",
-				"core-js": "^3.19.0"
-			}
-		},
 		"follow-redirects": {
 			"version": "1.14.9",
 			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
@@ -4301,8 +4411,7 @@
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-			"dev": true
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
 			"version": "2.3.2",
@@ -4360,7 +4469,6 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
 			"integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -4399,6 +4507,18 @@
 			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
 			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
 			"dev": true
+		},
+		"handlebars": {
+			"version": "4.7.7",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+			"integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+			"requires": {
+				"minimist": "^1.2.5",
+				"neo-async": "^2.6.0",
+				"source-map": "^0.6.1",
+				"uglify-js": "^3.1.4",
+				"wordwrap": "^1.0.0"
+			}
 		},
 		"has": {
 			"version": "1.0.3",
@@ -4441,6 +4561,11 @@
 			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
 			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
 			"dev": true
+		},
+		"hono": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/hono/-/hono-2.2.1.tgz",
+			"integrity": "sha512-tlawHM4uOMt41jibUF0fRYxUs3vibKzO1Ihuk/MohpUrkRc4fQo1n9+jLRKIC/8d0lLLW/CPWR/iItcf2HUv3A=="
 		},
 		"hosted-git-info": {
 			"version": "2.8.9",
@@ -4486,7 +4611,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"dev": true,
 			"requires": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -4495,8 +4619,7 @@
 		"inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
 		"internal-slot": {
 			"version": "1.0.3",
@@ -4731,6 +4854,11 @@
 			"integrity": "sha1-Dp5/bF0nC3WJKa9Nb+/chL1m4lk=",
 			"dev": true
 		},
+		"jsonc-parser": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+			"integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
+		},
 		"lazy-ass": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
@@ -4798,11 +4926,21 @@
 				"yallist": "^4.0.0"
 			}
 		},
+		"lunr": {
+			"version": "2.3.9",
+			"resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+			"integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow=="
+		},
 		"map-stream": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
 			"integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
 			"dev": true
+		},
+		"marked": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-4.1.0.tgz",
+			"integrity": "sha512-+Z6KDjSPa6/723PQYyc1axYZpYYpDnECDaU6hkaf5gqBieBkMKYReL5hteF2QizhlMbgbo8umXl/clZ67+GlsA=="
 		},
 		"memorystream": {
 			"version": "0.3.1",
@@ -4826,7 +4964,6 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
 			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
@@ -4834,8 +4971,7 @@
 		"minimist": {
 			"version": "1.2.6",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-			"dev": true
+			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
 		},
 		"mocha": {
 			"version": "9.2.2",
@@ -4929,6 +5065,11 @@
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
 			"dev": true
+		},
+		"neo-async": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
 		},
 		"nice-try": {
 			"version": "1.0.5",
@@ -5129,7 +5270,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
@@ -5203,8 +5343,7 @@
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"dev": true
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 		},
 		"path-key": {
 			"version": "3.1.1",
@@ -5274,6 +5413,11 @@
 			"requires": {
 				"util-inspect": "^0.1.8"
 			}
+		},
+		"progress": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
 		},
 		"ps-tree": {
 			"version": "1.2.0",
@@ -5410,6 +5554,16 @@
 			"integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
 			"dev": true
 		},
+		"shiki": {
+			"version": "0.9.15",
+			"resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.15.tgz",
+			"integrity": "sha512-/Y0z9IzhJ8nD9nbceORCqu6NgT9X6I8Fk8c3SICHI5NbZRLdZYFaB233gwct9sU0vvSypyaL/qaKvzyQGJBZSw==",
+			"requires": {
+				"jsonc-parser": "^3.0.0",
+				"vscode-oniguruma": "^1.6.1",
+				"vscode-textmate": "5.2.0"
+			}
+		},
 		"side-channel": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -5426,6 +5580,11 @@
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
 			"dev": true
+		},
+		"source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 		},
 		"spdx-correct": {
 			"version": "3.1.1",
@@ -5629,6 +5788,47 @@
 			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
 			"dev": true
 		},
+		"typedoc": {
+			"version": "0.21.10",
+			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.21.10.tgz",
+			"integrity": "sha512-Y0wYIehkjkPfsp3pv86fp3WPHUcOf8pnQUDLwG1PqSccUSqdsv7Pz1Gd5WrTJvXQB2wO1mKlZ8qW8qMiopKyjA==",
+			"requires": {
+				"glob": "^7.1.7",
+				"handlebars": "^4.7.7",
+				"lunr": "^2.3.9",
+				"marked": "^4.0.10",
+				"minimatch": "^3.0.0",
+				"progress": "^2.0.3",
+				"shiki": "^0.9.8",
+				"typedoc-default-themes": "^0.12.10"
+			}
+		},
+		"typedoc-default-themes": {
+			"version": "0.12.10",
+			"resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.12.10.tgz",
+			"integrity": "sha512-fIS001cAYHkyQPidWXmHuhs8usjP5XVJjWB8oZGqkTowZaz3v7g3KDZeeqE82FBrmkAnIBOY3jgy7lnPnqATbA=="
+		},
+		"typedoc-loopingz-theme": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/typedoc-loopingz-theme/-/typedoc-loopingz-theme-1.1.3.tgz",
+			"integrity": "sha512-9aqk1D0TNQRXroqYhNpUndsARND2PeQ7l0WUWFZz+5DSq00jXib+lauF7hmrQOIRukJnoA1ssUsy6C4X0qEjxA==",
+			"requires": {
+				"lunr": "^2.3.8",
+				"typedoc": "~0.21.9"
+			}
+		},
+		"typescript": {
+			"version": "4.4.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+			"integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+			"peer": true
+		},
+		"uglify-js": {
+			"version": "3.17.1",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.1.tgz",
+			"integrity": "sha512-+juFBsLLw7AqMaqJ0GFvlsGZwdQfI2ooKQB39PSBgMnMakcFosi9O8jCwE+2/2nMNcc0z63r9mwjoDG8zr+q0Q==",
+			"optional": true
+		},
 		"unbox-primitive": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
@@ -5689,6 +5889,16 @@
 				"spdx-expression-parse": "^3.0.0"
 			}
 		},
+		"vscode-oniguruma": {
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
+			"integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA=="
+		},
+		"vscode-textmate": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+			"integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ=="
+		},
 		"wait-on": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/wait-on/-/wait-on-6.0.0.tgz",
@@ -5741,6 +5951,11 @@
 			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
 			"dev": true
 		},
+		"wordwrap": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+			"integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
+		},
 		"workerpool": {
 			"version": "6.2.0",
 			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
@@ -5761,8 +5976,7 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"y18n": {
 			"version": "5.0.8",

--- a/fastly/c-at-e/package.json
+++ b/fastly/c-at-e/package.json
@@ -4,19 +4,19 @@
 	"version": "1.0.0",
 	"type": "module",
 	"scripts": {
-		"prebuild": "esbuild src/index.js --target=es2020 --platform=browser --bundle --minify --outfile=bin/index.js",
+		"prebuild": "esbuild src/index.js --target=es2020 --platform=browser --bundle --outfile=bin/index.js",
 		"build": "js-compute-runtime bin/index.js bin/main.wasm",
 		"dev": "npm run build && npm run start:c-at-e",
-    "start:c-at-e": "fastly compute serve",
-    "start:server": "npm --prefix ../../ run start",
+		"start:c-at-e": "fastly compute serve",
+		"start:server": "npm --prefix ../../ run start",
 		"lint": "eslint .",
-    "test": "NODE_ENV='production' start-test start:server 8080 start:c-at-e 7676 test:integration",
+		"test": "NODE_ENV='production' start-test start:server 8080 start:c-at-e 7676 test:integration",
 		"test:integration": "mocha test/integration/*.test.js test/integration/**/*.test.js --recursive --check-leaks --timeout 30000 --exit --bail"
 	},
 	"dependencies": {
-		"@fastly/js-compute": "0.2.4",
+		"@fastly/js-compute": "^0.5.3",
 		"@financial-times/polyfill-useragent-normaliser": "^1.10.2",
-		"flight-path": "^1.0.11"
+		"hono": "^2.2.1"
 	},
 	"devDependencies": {
 		"axios": "^0.26.0",

--- a/fastly/c-at-e/src/index.js
+++ b/fastly/c-at-e/src/index.js
@@ -1,115 +1,87 @@
 /// <reference types="@fastly/js-compute" />
-import { Router } from "flight-path";
 import UA from "@financial-times/polyfill-useragent-normaliser/lib/normalise-user-agent-c-at-e.js";
 import { normalise_querystring_parameters_for_polyfill_bundle } from "./normalise-query-parameters.js";
 import useragent_parser from "@financial-times/useragent_parser/lib/ua_parser-c-at-e.js";
 import fetchWithFailover from "./fetch-with-failover.js";
+import { Hono } from 'hono'
+import { logger } from 'hono/logger'
 
-const allowed_methods = new Set(["GET", "HEAD", "OPTIONS", "FASTLYPURGE", "PURGE"]);
+const app = new Hono()
+app.use('*', logger())
 
-const router = new Router();
-
-router.use(async function(request, response) {
-  response.setHeader("Server-Timing", fastly.env.get("FASTLY_HOSTNAME"));
-})
-router.get("/", async (_, response) => {
-  response.redirect("/v3/");
+app.get("/", (c) => c.redirect("/v3/", 301));
+app.get("/v3/normalizeUa", (c) => {
+  const useragent = UA.normalize(c.req.headers.get("User-Agent"));
+  c.res.headers.set("Normalized-User-Agent", useragent);
+  return c.text(useragent);
 });
-
-router.get("/v3/normalizeUa", async (request, response) => {
-  const useragent = UA.normalize(request.headers["user-agent"]);
-  response.setHeader("Content-Type", "text/plain; charset=utf-8");
-  response.setHeader("Normalized-User-Agent", useragent);
-  response.send(useragent);
-});
-
-router.get("/v3/parseUa", async (request, response) => {
+app.get("/v3/parseUa", (c) => {
   const {
     family,
     major = "0",
     minor = "0",
     patch = "0",
-  } = useragent_parser(request.headers["user-agent"]);
-  response.setHeader("content-type", "text/plain; charset=utf-8");
-  response.setHeader("useragent_parser_family", family);
-  response.setHeader("useragent_parser_major", major);
-  response.setHeader("useragent_parser_minor", minor);
-  response.setHeader("useragent_parser_patch", patch);
-  response.send(`${family}/${major}.${minor}.${patch}`);
+  } = useragent_parser(c.req.headers.get("User-Agent"));
+  c.res.headers.set("useragent_parser_family", family);
+  c.res.headers.set("useragent_parser_major", major);
+  c.res.headers.set("useragent_parser_minor", minor);
+  c.res.headers.set("useragent_parser_patch", patch);
+  return c.text(`${family}/${major}.${minor}.${patch}`);
 });
-router.get("/robots.txt", async (_, response) => {
-  response.setHeader("content-type", "text/plain; charset=utf-8");
-  response.send("User-agent: *\nDisallow:");
-});
-
-async function notFound(_, response) {
-  response.setHeader("content-type", "text/plain; charset=utf-8");
-  response.status = 404;
-  response.send("Not Found.");
-}
-router.get("/https://cdn.polyfill.io", notFound);
-router.get("/https://polyfill.io", notFound);
-router.get("/pages/fixedData", notFound);
-
-router.get("/v1", async (_, response) => {
-  return response.redirect("/v3/");
-});
-
-router.get("/v1/*", async (request, response) => {
-  request.url.searchParams.delete("libVersion");
-  request.url.searchParams.delete("gated");
+app.get("/robots.txt", (c) => c.text("User-agent: *\nDisallow:"));
+app.get("/https://cdn.polyfill.io", c => c.notFound());
+app.get("/https://polyfill.io", c => c.notFound());
+app.get("/pages/fixedData", c => c.notFound());
+app.get("/v1", (c) => c.redirect("/v3/", 301));
+app.get("/v1/*", (c) => {
+  const requestURL = new URL(c.req.url);
+  requestURL.searchParams.delete("libVersion");
+  requestURL.searchParams.delete("gated");
   //   res.body = "API version 1 has been decommissioned. Your request is being redirected to v2.  The `libVersion` and `gated` query string parameters are no longer supported and if present have been removed from your request.\n\nA deprecation period for v1 existed between August and December 2015, during which time v1 requests were honoured but a deprecation warning was added to output.";
-  return response.redirect(
-    request.url.pathname.replace("/v1", "/v2") + request.url.search
+  return c.redirect(
+    requestURL.pathname.replace("/v1", "/v2") + requestURL.search, 301
   );
 });
 
-router.route("OPTIONS", "*", async (_, response) => {
-  response.setHeader("allow", "OPTIONS, GET, HEAD");
-  response.send("");
+app.options("*", (c) => {
+  c.res.headers.set("allow", "OPTIONS, GET, HEAD");
+  return c.text("");
 });
 
-function configureV2Defaults(request) {
-  // # Override the v3 defaults with the defaults of v2
-  request.url.pathname = request.url.pathname.replace("/v2", "/v3");
-  request.url.searchParams.set("version", "3.25.1");
-  if (!request.url.searchParams.has("unknown")) {
-    request.url.searchParams.set("unknown", "ignore");
+function configureV2Defaults(url) {
+  url.pathname = url.pathname.replace("/v2", "/v3");
+  url.searchParams.set("version", "3.25.1");
+  if (!url.searchParams.has("unknown")) {
+    url.searchParams.set("unknown", "ignore");
   }
+  return url;
 }
 
-router.get(
+app.get(
   "/v3/normalise_querystring_parameters_for_polyfill_bundle",
-  async function (request, response) {
-    response.json(
+  function (c) {
+    return c.json(
       Object.fromEntries(Array.from(
         normalise_querystring_parameters_for_polyfill_bundle(
-          request,
-          request.url.searchParams
+          c.req,
+          new URL(c.req.url).searchParams
         ).entries())
       )
     );
   }
 );
 
-router.route("*", "*", async function (request, response) {
-	console.log(request.url)
-  if (!allowed_methods.has(request.method)) {
-    response.status = 405;
-    return response.send(`${request.method} METHOD NOT ALLOWED`);
-  }
-
-  if (request.method === "PURGE") {
-		request.headers['Fastly-Purge-Requires-Auth'] = "1";
-    let backendResponse = await fetchWithFailover(request.url.toString(), {
-      backend: "polyfill",
-      headers: request.headers,
-      method: request.method
-    });
-    return response.send(backendResponse);
-  }
-
-  const host = request.headers.host;
+app.get("*", handler);
+app.head("*", handler);
+app.options("*", handler);
+app.all("*", c => {
+  return c.text(`${c.req.method} METHOD NOT ALLOWED`, 405);
+})
+async function handler(c) {
+  console.log(`FASTLY_SERVICE_VERSION: ${fastly.env.get('FASTLY_SERVICE_VERSION')}`)
+  let requestURL = new URL(c.req.url);
+  console.log(requestURL.pathname)
+  const host = c.req.headers.get('host');
   // Canonicalize requests onto https://polyfill.io (and allow https://polyfills.io)
   switch (host) {
     //  We are no longer redirecting this domain and instead using it as an
@@ -119,54 +91,55 @@ router.route("*", "*", async function (request, response) {
     case "www.polyfills.io":
     case "www.polyfill.io": {
       // Do the canonicalise redirects before the HTTPS redirect to avoid a double redirect
-      return response.redirect(`https://polyfill.io${request.url.pathname}`);
+      return c.redirect(`https://polyfill.io${requestURL.pathname}`, 301);
     }
   }
   const fastlyHostname = fastly.env.get("FASTLY_HOSTNAME");
   const isRunningLocally = fastlyHostname === "localhost";
   // Fastly C@E Local Testing has a limitation where TLS information about the client connection is not available
   // https://developer.fastly.com/learning/compute/testing/#constraints-and-limitations-1
-  // if (!isRunningLocally && !request.headers['fastly-ssl']) {
-  if (!isRunningLocally && request.url.protocol != "https:") {
-    return response.redirect(`https://${host}${request.url.pathname}`);
+  // if (!isRunningLocally && !c.req.headers.get('fastly-ssl')) {
+  if (!isRunningLocally && requestURL.protocol != "https:") {
+    return c.redirect(`https://${host}${requestURL.pathname}`, 301);
   }
 
   // # Because the old service had a router which allowed any words between /v2/polyfill. and .js
-  if (/v2\/polyfill(\..*)?\.js/.test(request.url.pathname)) {
-    request.url.pathname = "/v2/polyfill.min.js";
-    configureV2Defaults(request);
+  if (/v2\/polyfill(\..*)?\.js/.test(requestURL.pathname)) {
+    requestURL.pathname = "/v2/polyfill.min.js";
+    requestURL = configureV2Defaults(requestURL);
   }
 
   if (
-    request.url.pathname.startsWith("/v2/") ||
-    request.url.pathname == "/v2"
+    requestURL.pathname.startsWith("/v2/") ||
+    requestURL.pathname == "/v2"
   ) {
-    let urlPath = request.url.pathname;
+    let urlPath = requestURL.pathname;
     if (!(urlPath.startsWith("/v2/polyfill.") && urlPath.endsWith("js"))) {
-      return response.redirect("/v3/");
+      return c.redirect("/v3/", 301);
     }
   }
 
-  const urlPath = request.url.pathname;
+  const urlPath = requestURL.pathname;
 
   if (urlPath === "/v3/polyfill.min.js" || urlPath === "/v3/polyfill.js") {
-		request.url.search = normalise_querystring_parameters_for_polyfill_bundle(
-			request,
-			request.url.searchParams
-		).toString();
-		// # Sort the querystring parameters alphabetically to improve chances of hitting a cached copy.
-		request.url.searchParams.sort();
+    requestURL.search = normalise_querystring_parameters_for_polyfill_bundle(
+      c.req,
+      requestURL.searchParams
+    ).toString();
+    // # Sort the querystring parameters alphabetically to improve chances of hitting a cached copy.
+    requestURL.searchParams.sort();
   } else {
     // # The request is to an endpoint which doesn't use query parameters, let's remove them to increase our cache-hit-ratio
-    request.url.search = "";
+    requestURL.search = "";
   }
 
-  let backendResponse = await fetchWithFailover(request.url.toString(), {
-    headers: request.headers,
-    method: request.method
+  let backendResponse = await fetchWithFailover(requestURL, {
+    method: c.req.method,
+    headers: c.req.headers,
   });
 
-	backendResponse.headers.set('useragent_normaliser', request.url.searchParams.get('ua'));
+
+  backendResponse.headers.set('useragent_normaliser', requestURL.searchParams.get('ua'));
 
   if (urlPath === "/v3/polyfill.min.js" || urlPath === "/v3/polyfill.js") {
     let vary = backendResponse.headers.get("vary");
@@ -188,7 +161,7 @@ router.route("*", "*", async function (request, response) {
     backendResponse.headers.set("vary", "Accept-Encoding");
   }
 
-  if (new Date(request.headers["if-modified-since"]) >= new Date(backendResponse.headers.get("last-modified"))) {
+  if (c.req.headers.has("if-modified-since") && backendResponse.headers.get("last-modified") && new Date(c.req.headers.get("if-modified-since")) >= new Date(backendResponse.headers.get("last-modified"))) {
     backendResponse.headers.set("age", "0")
     backendResponse = new Response(null, {
       status: 304,
@@ -200,7 +173,7 @@ router.route("*", "*", async function (request, response) {
     backendResponse.headers.set("Age", "0");
   }
 
-  response.send(backendResponse);
-});
+  return backendResponse;
+}
 
-router.listen();
+app.fire()

--- a/fastly/c-at-e/src/normalise-query-parameters.js
+++ b/fastly/c-at-e/src/normalise-query-parameters.js
@@ -121,7 +121,7 @@ export function normalise_querystring_parameters_for_polyfill_bundle(originalReq
         newQuerystring.set("ua", decodeURIComponent(ua));
     } else {
         // # If ua is not set, normalise the User-Agent header based upon the version of the polyfill-library that has been requested.
-        const useragent = originalRequest.headers["user-agent"];
+        const useragent = originalRequest.headers.get("User-Agent");
         let normalisedUserAgent;
 		normalisedUserAgent = version === "3.25.1" ? oldUserAgentNormaliser.UA(useragent) : latestUserAgentNormaliser.normalize(useragent);
 		newQuerystring.set("ua", normalisedUserAgent);
@@ -141,8 +141,8 @@ export function normalise_querystring_parameters_for_polyfill_bundle(originalReq
 	} else {
         // # If compression is not set, use the best compression that the user-agent supports.
 		// # Before SP2, IE/6 doesn't always read and cache gzipped content correctly.
-        let acceptEncoding = originalRequest.headers['fastly-orig-accept-encoding'] || originalRequest.headers['accept-encoding']
-        let isIE6 = Boolean(originalRequest.headers['user-agent'] && originalRequest.headers['user-agent'].includes("MSIE 6"))
+        let acceptEncoding = originalRequest.headers.get('fastly-orig-accept-encoding') || originalRequest.headers.get('accept-encoding')
+        let isIE6 = Boolean(originalRequest.headers.get('user-agent') && originalRequest.headers.get('user-agent').includes("MSIE 6"))
 		if (acceptEncoding && !isIE6) {
 			if (acceptEncoding.includes("br")) {
 				newQuerystring.set("compression", "br");

--- a/fastly/c-at-e/test/integration/robots.test.js
+++ b/fastly/c-at-e/test/integration/robots.test.js
@@ -10,7 +10,7 @@ describe("GET /robots.txt", function() {
 		const response = await axios.get(`/robots.txt?use-compute-at-edge-backend=yes`)
 
 		assert.equal(response.status, 200)
-		assert.equal(response.headers["content-type"], "text/plain; charset=utf-8")
+		assert.equal(response.headers["content-type"].toLowerCase(), "text/plain; charset=utf-8")
 		assert.equal(response.data, "User-agent: *\nDisallow:");
 	});
 });


### PR DESCRIPTION
[honojs](https://honojs.dev/) is a small and very fast web-server library built primarily for edge-compute platforms such as Fastly and Cloudflare Workers.

I have a lot more experience using honojs now than I do flight-path and thought I'd take a moment to migrate polyfill.io over to it as the migration is rather low effort due to flight-path having a similar API ☺️ 