### PR TITLE
Revert `polyfill-library` references from `main` to `master`

### DIFF
--- a/src/assets/js/index.js
+++ b/src/assets/js/index.js
@@ -165,7 +165,7 @@ const renderFeatureList = ({ polyfillAliases, polyfills }) => {
 							${item.license ? `<li class='license'><a title='This polyfill has a specific licence' href='https://choosealicense.com/licenses/${item.licenseLowerCase}'>License: ${item.license}</a></li>` : ""}
 							${item.spec ? `<li><a href='${item.spec}'>Specification</a></li>` : ""}
 							${item.docs ? `<li><a href='${item.docs}'>Documentation</a></li>` : ""}
-							${item.baseDir ? `<li><a href='https://github.com/Financial-Times/polyfill-library/tree/main/polyfills/${item.baseDir}'>Polyfill source</a></li>` : ""}
+							${item.baseDir ? `<li><a href='https://github.com/Financial-Times/polyfill-library/tree/master/polyfills/${item.baseDir}'>Polyfill source</a></li>` : ""}
 						</ul>
 					</div>
 				</div>

--- a/src/assets/v3/url-builder.njk
+++ b/src/assets/v3/url-builder.njk
@@ -125,7 +125,7 @@ oLayoutStyle: "o-layout--query"
 							{% if item.license %}<li class='license'><a title='This polyfill has a specific licence' href='https://choosealicense.com/licenses/{{item.licenseLowerCase}}'>License: {{item.license}}</a></li>{% endif %}
 							{% if item.spec %}<li><a href='{{item.spec}}'>Specification</a></li>{% endif %}
 							{% if item.docs %}<li><a href='{{item.docs}}'>Documentation</a></li>{% endif %}
-							{% if item.baseDir %}<li><a href='https://github.com/Financial-Times/polyfill-library/tree/main/polyfills/{{item.baseDir}}'>Polyfill source</a></li>{% endif %}
+							{% if item.baseDir %}<li><a href='https://github.com/Financial-Times/polyfill-library/tree/master/polyfills/{{item.baseDir}}'>Polyfill source</a></li>{% endif %}
 						</ul>
 					</div>
 				</div>


### PR DESCRIPTION
This PR fixes references to the `polyfill-library` repository, which were incorrectly updated from `master` to `main` in https://github.com/Financial-Times/polyfill-service/commit/510781a6.

Resolves https://github.com/Financial-Times/polyfill-service/issues/2723.